### PR TITLE
Add command for copying ISO images

### DIFF
--- a/shared/utils/pod.go
+++ b/shared/utils/pod.go
@@ -12,6 +12,7 @@ var VOLUMES = map[string]string{
 	"srv-www-pub":         "/srv/www/htdocs/pub",
 	"srv-www-cobbler":     "/srv/www/cobbler",
 	"srv-www-osimages":    "/srv/www/os-images",
+	"srv-www-distributions": "/srv/www/distributions",
 	"srv-tftpboot":        "/srv/tftpboot",
 	"srv-formulametadata": "/srv/formula_metadata",
 	"srv-pillar":          "/srv/pillar",

--- a/uyunictl/cmd/cmd.go
+++ b/uyunictl/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/uyunictl/cmd/cp"
 	"github.com/uyuni-project/uyuni-tools/uyunictl/cmd/exec"
+	"github.com/uyuni-project/uyuni-tools/uyunictl/cmd/distcp"
 )
 
 // NewCommand returns a new cobra.Command implementing the root command for kinder
@@ -23,6 +24,7 @@ func NewUyunictlCommand() *cobra.Command {
 
 	rootCmd.AddCommand(exec.NewCommand(globalFlags))
 	rootCmd.AddCommand(cp.NewCommand(globalFlags))
+	rootCmd.AddCommand(distcp.NewCommand(globalFlags))
 
 	return rootCmd
 }

--- a/uyunictl/cmd/distcp/distcp.go
+++ b/uyunictl/cmd/distcp/distcp.go
@@ -1,0 +1,41 @@
+package distcp
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type flagpole struct {
+	User  string
+	Group string
+}
+
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	flags := &flagpole{}
+
+	cpCmd := &cobra.Command{
+		Use:   "distcp [path/to/mounted/iso] [distribution name]",
+		Short: "copy distribution files from monted iso to container",
+		Long: `distcp takes a path to mounted iso and copies it into the container.
+	Distribution name specifies the destination diretory under /srv/www/distributions.`,
+		Args: cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			run(globalFlags, flags, cmd, args)
+		},
+	}
+
+	cpCmd.Flags().StringVar(&flags.User, "user", "", "User or UID to set on the destination files")
+	cpCmd.Flags().StringVar(&flags.Group, "group", "", "Group or GID to set on the destination files")
+	return cpCmd
+}
+
+func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, args []string) {
+	dstpath := "/srv/www/distributions/" + args[1]
+	if utils.TestExistence(dstpath) {
+		log.Fatalf("Distribution already exists: %s\n", dstpath)
+	}
+	utils.Copy(globalFlags, args[0], "server:" + dstpath, flags.User, flags.Group)
+}


### PR DESCRIPTION
This PR adds `/srv/www/distributions` volume and adds uyunictl command to copy an iso.

Usage is the same as documented here:
https://www.uyuni-project.org/uyuni-docs/en/uyuni/client-configuration/autoinst-distributions.html#based-on-iso-image

just replace 
`cp -a /mnt /srv/www/distributions/<image_name>`  
with
`uyunictl distcp /mnt <image_name>`
