### PR TITLE
fix migration: new container should have same hostname and ssh passwordless fix

### DIFF
--- a/uyuniadm/cmd/migrate/migrate.go
+++ b/uyuniadm/cmd/migrate/migrate.go
@@ -22,6 +22,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 This migration command assumes a few things:
   * the SSH configuration for the source server is complete, including user and
     all needed options to connect to the machine,
+  * the SSH configuration should stored in $HOME/.ssh, including the keys
   * an SSH agent is started and the key to use to connect to the server is added to it,
   * podman or kubectl is installed locally
   * if kubectl is installed, a working kubeconfig should be set to connect to the cluster to deploy to

--- a/uyuniadm/cmd/migrate/podman.go
+++ b/uyuniadm/cmd/migrate/podman.go
@@ -19,15 +19,15 @@ import (
 func migrateToPodman(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, args []string) {
 	sshAuthSocket := getSshAuthSocket()
 
+	sourceFqdn := args[0]
+
 	// Find ssh config to mount it in the container
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatal("Failed to find home directory to look for SSH config")
 	}
-	sshConfigPath := filepath.Join(homedir, ".ssh", "config")
-	sshKnownhostsPath := filepath.Join(homedir, ".ssh", "known_hosts")
-
-	scriptDir := generateMigrationScript(args[0], false)
+	sshPath := filepath.Join(homedir, ".ssh")
+	scriptDir := generateMigrationScript(sourceFqdn, false)
 	defer os.RemoveAll(scriptDir)
 
 	extraArgs := []string{
@@ -36,13 +36,9 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra
 		"-v", scriptDir + ":/var/lib/uyuni-tools/",
 	}
 
-	if _, err = os.Stat(sshConfigPath); err == nil {
-		extraArgs = append(extraArgs, "-v", sshConfigPath+":/root/.ssh/config")
+	if _, err = os.Stat(sshPath); err == nil {
+		extraArgs = append(extraArgs, "-v", sshPath+":/root/.ssh")
 
-	}
-
-	if _, err = os.Stat(sshKnownhostsPath); err == nil {
-		extraArgs = append(extraArgs, "-v", sshKnownhostsPath+":/root/.ssh/known_hosts")
 	}
 
 	log.Println("Migrating server")
@@ -60,7 +56,10 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra
 
 	image := fmt.Sprintf("%s:%s", flags.Image, flags.ImageTag)
 
-	podman.GenerateSystemdService(tz, image, viper.GetStringSlice("podman.arg"), globalFlags.Verbose)
+	podmanMigrateArgs := viper.GetStringSlice("podman.arg")
+	podmanMigrateArgs = append(podmanMigrateArgs, "--hostname="+sourceFqdn)
+
+	podman.GenerateSystemdService(tz, image, podmanMigrateArgs, globalFlags.Verbose)
 
 	// Start the service
 	if err = exec.Command("systemctl", "enable", "--now", "uyuni-server").Run(); err != nil {

--- a/uyuniadm/cmd/migrate/utils.go
+++ b/uyuniadm/cmd/migrate/utils.go
@@ -27,7 +27,7 @@ func generateMigrationScript(sourceFqdn string, kubernetes bool) string {
 set -e
 for folder in {{range .Volumes}}{{.}} {{end}};
 do
-  rsync -e "ssh -A " --rsync-path='sudo rsync' -avz {{.SourceFqdn}}:$folder/ $folder;
+  rsync -e "ssh -A -o StrictHostKeyChecking=no" --rsync-path='sudo rsync' -avz {{.SourceFqdn}}:$folder/ $folder;
 done;
 rm -f /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT;
 ln -s /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT;
@@ -38,6 +38,9 @@ ssh {{ .SourceFqdn }} timedatectl show -p Timezone >/var/lib/uyuni-tools/data
 echo 'server.no_ssl = 1' >> /etc/rhn/rhn.conf;
 sed 's/address=[^:]*:/address=uyuni:/' -i /etc/rhn/taskomatic.conf;
 sed 's/address=[^:]*:/address=uyuni:/' -i /etc/sysconfig/tomcat;
+{{ else }}
+sed 's/address=[^:]*:/address={{ .SourceFqdn }}:/' -i /etc/rhn/taskomatic.conf;
+sed 's/address=[^:]*:/address={{ .SourceFqdn }}:/' -i /etc/sysconfig/tomcat;
 {{ end }}
 echo "DONE"`
 


### PR DESCRIPTION
- the agent for working requires also the ssh key, so it may be better to mount the entire `.ssh` folder
- improve help
- add  `-o StrictHostKeyChecking=no` to rsync, to prevent any interaction
- migrate container should have same fqdn