### PR TITLE
Fix podman network setup to detect disabled ipv6

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -69,7 +69,6 @@ func WaitForServer() {
 		args = append(args, "systemctl", "is-active", "-q", "multi-user.target")
 		testCmd := exec.Command(cmd, args...)
 		testCmd.Run()
-		log.Printf("Ran %s %s: %d\n", cmd, strings.Join(args, " "), testCmd.ProcessState.ExitCode())
 		if testCmd.ProcessState.ExitCode() == 0 {
 			return
 		}


### PR DESCRIPTION
If IPv6 is disabled on the host, creating a podman network with IPv6 enabled will lead to the bridge interface failing to go up.

Try hard to detect if IPv6 is disabled on the host before enabling it.

To help updating the configuration after enabling IPv6 on the host, also remove any existing `uyuni` network that doesn't have IPv6 and recreate if needed.