### PR TITLE
add remote debugging command

### DIFF
--- a/uyuniadm/cmd/cmd.go
+++ b/uyuniadm/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/uyuniadm/cmd/debug"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/cmd/install"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/cmd/migrate"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/cmd/uninstall"
@@ -36,6 +37,7 @@ func NewUyuniadmCommand() *cobra.Command {
 	rootCmd.AddCommand(installCmd)
 
 	rootCmd.AddCommand(uninstall.NewCommand(globalFlags))
+	rootCmd.AddCommand(debug.NewCommand(globalFlags))
 
 	return rootCmd
 }

--- a/uyuniadm/cmd/debug/debug.go
+++ b/uyuniadm/cmd/debug/debug.go
@@ -1,0 +1,54 @@
+package debug
+
+import (
+	"log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type flagpole struct {
+	Enable     bool
+	Restart		bool
+}
+
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	flags := &flagpole{}
+
+	debugCmd := &cobra.Command{
+		Use:   "debug ",
+		Short: "Enable/Disable remote debugging",
+		Long: `Enable or Disable remote debugging. 
+Remote debugging is available using:
+- port 8000, for rhn
+- port 8001, for taskomatic
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			run(globalFlags, flags, cmd, args)
+		},
+	}
+
+	debugCmd.Flags().BoolVar(&flags.Enable, "enable", true, "Enable or disable remote debugging")
+	debugCmd.Flags().BoolVar(&flags.Restart, "restart", false, "Apply changes restarting spacewalk-service")
+
+	return debugCmd
+}
+
+func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, args []string) {
+	if flags.Enable {
+		log.Printf("Enabling remote debug")
+		utils.Exec(globalFlags, "", false, false, []string{}, "grep -q 'JAVA_OPTS=\" \\$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=\\*:8000,server=y,suspend=n\"' /etc/tomcat/conf.d/remote_debug.conf || echo 'JAVA_OPTS=\" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n\" ' >> /etc/tomcat/conf.d/remote_debug.conf")
+		utils.Exec(globalFlags, "", false, false, []string{}, "grep -q 'JAVA_OPTS=\" \\$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=\\*:8001,server=y,suspend=n\"' /etc/rhn/taskomatic.conf || echo 'JAVA_OPTS=\" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:8001,server=y,suspend=n\" ' >> /etc/rhn/taskomatic.conf")
+	} else {
+		log.Printf("Disabling remote debug")
+		utils.Exec(globalFlags, "", false, false, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' /etc/tomcat/conf.d/remote_debug.conf")
+		utils.Exec(globalFlags, "", false, false, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' /etc/rhn/taskomatic.conf")
+	}
+	
+	if flags.Restart {
+		log.Printf("Running spacewalk-service restart")
+		utils.Exec(globalFlags, "", false, false, []string{}, "spacewalk-service restart")
+	} else {
+		log.Printf("Changes applied. Please restart spacewalk-service to apply them")
+	}
+}

--- a/uyuniadm/cmd/debug/debug.go
+++ b/uyuniadm/cmd/debug/debug.go
@@ -8,8 +8,8 @@ import (
 )
 
 type flagpole struct {
-	Enable     bool
-	Restart		bool
+	Enable			bool
+	Restart			bool
 }
 
 func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {

--- a/uyuniadm/cmd/debug/debug.go
+++ b/uyuniadm/cmd/debug/debug.go
@@ -46,9 +46,9 @@ func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, ar
 	}
 	
 	if flags.Restart {
-		log.Printf("Running spacewalk-service restart")
+		log.Printf("Running spacewalk-service restart. Changes will be applied after restart ")
 		utils.Exec(globalFlags, "", false, false, []string{}, "spacewalk-service restart")
 	} else {
-		log.Printf("Changes applied. Please restart spacewalk-service to apply them")
+		log.Printf("Configuration files changes but not applied. Please restart spacewalk-service to apply them")
 	}
 }

--- a/uyuniadm/cmd/debug/debug.go
+++ b/uyuniadm/cmd/debug/debug.go
@@ -1,15 +1,17 @@
 package debug
 
 import (
+	"fmt"
 	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 type flagpole struct {
-	Enable			bool
-	Restart			bool
+	Enable  bool
+	Restart bool
 }
 
 func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
@@ -35,19 +37,25 @@ Remote debugging is available using:
 }
 
 func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, args []string) {
+	const tomcatFile = "/etc/tomcat/conf.d/remote_debug.conf"
+	const taskoFile = "/etc/rhn/taskomatic.conf"
+
 	if flags.Enable {
+		enableTemplate := "grep -q 'JAVA_OPTS=\" \\$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=\\*:%d,server=y,suspend=n\"' %s ||" +
+			" echo 'JAVA_OPTS=\" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:%d,server=y,suspend=n\" ' >> %s"
+
 		log.Printf("Enabling remote debug")
-		utils.Exec(globalFlags, "", false, false, []string{}, "grep -q 'JAVA_OPTS=\" \\$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=\\*:8000,server=y,suspend=n\"' /etc/tomcat/conf.d/remote_debug.conf || echo 'JAVA_OPTS=\" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n\" ' >> /etc/tomcat/conf.d/remote_debug.conf")
-		utils.Exec(globalFlags, "", false, false, []string{}, "grep -q 'JAVA_OPTS=\" \\$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=\\*:8001,server=y,suspend=n\"' /etc/rhn/taskomatic.conf || echo 'JAVA_OPTS=\" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:8001,server=y,suspend=n\" ' >> /etc/rhn/taskomatic.conf")
+		utils.Exec(globalFlags, "", false, false, true, []string{}, fmt.Sprintf(enableTemplate, 8000, tomcatFile, 8000, tomcatFile))
+		utils.Exec(globalFlags, "", false, false, true, []string{}, fmt.Sprintf(enableTemplate, 8001, taskoFile, 8001, taskoFile))
 	} else {
 		log.Printf("Disabling remote debug")
-		utils.Exec(globalFlags, "", false, false, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' /etc/tomcat/conf.d/remote_debug.conf")
-		utils.Exec(globalFlags, "", false, false, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' /etc/rhn/taskomatic.conf")
+		utils.Exec(globalFlags, "", false, false, true, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' "+tomcatFile)
+		utils.Exec(globalFlags, "", false, false, true, []string{}, "sed -i '/-Xdebug -Xrunjdwp:transport=dt_socket,address=/d' "+taskoFile)
 	}
-	
+
 	if flags.Restart {
 		log.Printf("Running spacewalk-service restart. Changes will be applied after restart ")
-		utils.Exec(globalFlags, "", false, false, []string{}, "spacewalk-service restart")
+		utils.Exec(globalFlags, "", false, false, true, []string{}, "spacewalk-service restart")
 	} else {
 		log.Printf("Configuration files changed but not applied. Please restart spacewalk-service to apply them")
 	}

--- a/uyuniadm/cmd/debug/debug.go
+++ b/uyuniadm/cmd/debug/debug.go
@@ -49,6 +49,6 @@ func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, ar
 		log.Printf("Running spacewalk-service restart. Changes will be applied after restart ")
 		utils.Exec(globalFlags, "", false, false, []string{}, "spacewalk-service restart")
 	} else {
-		log.Printf("Configuration files changes but not applied. Please restart spacewalk-service to apply them")
+		log.Printf("Configuration files changed but not applied. Please restart spacewalk-service to apply them")
 	}
 }


### PR DESCRIPTION
add remote debugging command

```
uyuniadm debug --help
Enable or Disable remote debugging. 
Remote debugging is available using:
- port 8000, for rhn
- port 8001, for taskomatic

Usage:
  uyuniadm debug  [flags]

Flags:
      --enable    Enable or disable remote debugging (default true)
  -h, --help      help for debug
      --restart   Apply changes restarting spacewalk-service
```