### PR TITLE
Enable podman socket for remote use with uyunictl

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Available Commands:
   * **exec**: execute commands inside the uyuni containers using 'sh -c'
   * **help**: Help about any command
 
+Using `uyunictl` to access a remote cluster requires `kubectl` to be configured to connect to it before hand.
+
+In order to connect to a remote `podman`, ensure the `podman.socket` systemd unit is active on the server by running `systemctl enable --now podman.socket`.
+Then configure the Podman connection on the client machine:
+
+```
+podman system connection add <name> ssh://root@<host.fqdn>
+```
+
+Then export `CONTAINER_CONNECTION=<name>` before running `uyunictl`.
+Note that passing `--identity <file>` may be needed to tell SSH which key to use to connect to the podman host.
+
+
 ### Uyunictl cp
 
 Takes a source and destination parameters. One of them can be prefixed with 'server:' to indicate the path is within the server pod.

--- a/uyuniadm/cmd/install/podman.go
+++ b/uyuniadm/cmd/install/podman.go
@@ -61,4 +61,6 @@ func installForPodman(globalFlags *types.GlobalFlags, flags *InstallFlags, cmd *
 	}
 
 	runSetup(globalFlags, flags, args[0], env)
+
+	podman.EnablePodmanSocket(globalFlags.Verbose)
 }

--- a/uyuniadm/cmd/migrate/podman.go
+++ b/uyuniadm/cmd/migrate/podman.go
@@ -68,6 +68,8 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *MigrateFlags, cmd *c
 	}
 
 	log.Println("Server migrated")
+
+	podman.EnablePodmanSocket(globalFlags.Verbose)
 }
 
 func runContainer(name string, image string, tag string, extraArgs []string, cmd []string, env []string, verbose bool) {

--- a/uyuniadm/shared/podman/podman.go
+++ b/uyuniadm/shared/podman/podman.go
@@ -104,3 +104,7 @@ func getFileBoolean(file string) bool {
 	}
 	return string(out[:]) != "0"
 }
+
+func EnablePodmanSocket(verbose bool) {
+	utils.RunCmd("systemctl", []string{"enable", "--now", "podman.socket"}, "Failed to enable podman.socket unit", verbose)
+}


### PR DESCRIPTION
Enable the `podman.socket` unit from `uyuniadm install` and `uyuniadm migrate`.