### PR TITLE
Fix mirrors handling in uyuniadm install

### DIFF
--- a/uyuniadm/cmd/install/kubernetes.go
+++ b/uyuniadm/cmd/install/kubernetes.go
@@ -186,6 +186,11 @@ func uyuniInstall(globalFlags *types.GlobalFlags, flags *InstallFlags, kubeconfi
 		"--set", "timezone="+flags.TZ,
 		"--set", "fqdn="+fqdn)
 
+	if flags.MirrorPath != "" {
+		// TODO Handle claims for multi-node clusters
+		helmParams = append(helmParams, "--set", "mirror.hostPath="+flags.MirrorPath)
+	}
+
 	namespace := flags.Helm.Uyuni.Namespace
 	chart := flags.Helm.Uyuni.Chart
 	version := flags.Helm.Uyuni.Version

--- a/uyuniadm/cmd/install/podman.go
+++ b/uyuniadm/cmd/install/podman.go
@@ -16,7 +16,13 @@ import (
 func waitForSystemStart(globalFlags *types.GlobalFlags, flags *InstallFlags) {
 	// Setup the systemd service configuration options
 	image := fmt.Sprintf("%s:%s", flags.Image.Name, flags.Image.Tag)
-	podman.GenerateSystemdService(flags.TZ, image, flags.Podman.Args, globalFlags.Verbose)
+
+	podmanArgs := flags.Podman.Args
+	if flags.MirrorPath != "" {
+		podmanArgs = append(podmanArgs, "-v", flags.MirrorPath+":/mirror")
+	}
+
+	podman.GenerateSystemdService(flags.TZ, image, podmanArgs, globalFlags.Verbose)
 
 	log.Println("Waiting for the server to start...")
 	// Start the service

--- a/uyuniadm/cmd/install/shared.go
+++ b/uyuniadm/cmd/install/shared.go
@@ -67,10 +67,12 @@ func generateSetupScript(flags *InstallFlags, fqdn string, extraEnv map[string]s
 		"EXTERNALDB_ADMIN_PASS": flags.Db.Admin.Password,
 		"EXTERNALDB_PROVIDER":   flags.Db.Provider,
 		"ISS_PARENT":            flags.IssParent,
-		"MIRROR_PATH":           flags.MirrorPath,
 		"ACTIVATE_SLP":          "N", // Deprecated, will be removed soon
 		"SCC_USER":              flags.Scc.User,
 		"SCC_PASS":              flags.Scc.Password,
+	}
+	if flags.MirrorPath != "" {
+		env["MIRROR_PATH"] = "/mirror"
 	}
 
 	// Add the extra environment variables


### PR DESCRIPTION
The mirror path is always `/mirror` in the container and the mirror.hostPath value needs to be set on the helm chart.