### PR TITLE
force remove container before run a new one

### DIFF
--- a/uyuniadm/shared/podman/podman.go
+++ b/uyuniadm/shared/podman/podman.go
@@ -12,7 +12,7 @@ import (
 )
 
 const UYUNI_NETWORK = "uyuni"
-const commonArgs = "--name %s --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw"
+const commonArgs = "--rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw"
 
 func GetCommonParams(containerName string) []string {
 	return strings.Split(fmt.Sprintf(commonArgs, containerName), " ")
@@ -29,12 +29,13 @@ func GenerateSystemdService(tz string, image string, podmanArgs []string, verbos
 	setupNetwork(verbose)
 
 	data := templates.PodmanServiceTemplateData{
-		Volumes:  utils.VOLUMES,
-		Args:     fmt.Sprintf(commonArgs, "uyuni-server") + " " + strings.Join(podmanArgs, " "),
-		Ports:    GetExposedPorts(),
-		Timezone: tz,
-		Image:    image,
-		Network:  UYUNI_NETWORK,
+		Volumes:    utils.VOLUMES,
+		NamePrefix: "uyuni",
+		Args:       commonArgs + " " + strings.Join(podmanArgs, " "),
+		Ports:      GetExposedPorts(),
+		Timezone:   tz,
+		Image:      image,
+		Network:    UYUNI_NETWORK,
 	}
 	if err := utils.WriteTemplateToFile(data, ServicePath, 0555, false); err != nil {
 		log.Fatalf("Failed to generate systemd service unit file: %s\n", err)

--- a/uyuniadm/shared/templates/serviceTemplate.go
+++ b/uyuniadm/shared/templates/serviceTemplate.go
@@ -20,12 +20,14 @@ Environment=UYUNI_IMAGE={{ .Image }}
 Environment=TZ={{ .Timezone }}
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-server.pid %t/%n.ctr-id
+ExecStartPre=/usr/bin/podman rm --ignore --force {{ NamePrefix }}-server
 ExecStart=/usr/bin/podman run \
 	--conmon-pidfile %t/uyuni-server.pid \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
 	--sdnotify=conmon \
 	-d \
+	--name {{ NamePrefix }}-server
 	{{ .Args }} \
 	{{- range .Ports }}
 	-p {{ . }}:{{ . }} \
@@ -54,12 +56,13 @@ WantedBy=multi-user.target default.target
 `
 
 type PodmanServiceTemplateData struct {
-	Volumes  map[string]string
-	Args     string
-	Ports    []string
-	Timezone string
-	Image    string
-	Network  string
+	Volumes    map[string]string
+	NamePrefix string
+	Args       string
+	Ports      []string
+	Timezone   string
+	Image      string
+	Network    string
 }
 
 func (data PodmanServiceTemplateData) Render(wr io.Writer) error {


### PR DESCRIPTION
If the host OS is stop, without stopping the systemd service, the container stays around. Since the systemd configuration call the podmand command "run" if a container with the same name exists it is unable to start, returning an error.

This PR removes the container in case it exists, which will then allow the systemd unit to start