### PR TITLE
install podman service in etc instead of usr

### DIFF
--- a/uyuniadm/shared/podman/podman.go
+++ b/uyuniadm/shared/podman/podman.go
@@ -22,7 +22,7 @@ func GetExposedPorts() []string {
 	return []string{"443", "80", "4505", "4506", "69", "25151", "5432", "9100", "9187", "9800"}
 }
 
-const ServicePath = "/usr/lib/systemd/system/uyuni-server.service"
+const ServicePath = "/etc/systemd/system/uyuni-server.service"
 
 func GenerateSystemdService(tz string, image string, podmanArgs []string, verbose bool) {
 


### PR DESCRIPTION
Installing on the folder "/usr/lib" was causing problems when installing on a transactional system (sles-micro) since this is part of the transactional file system.
Moving this to "/etc/" solves this issue and still allows us to install the service the same way.