### PR TITLE
only print log caller in debug or lower level

### DIFF
--- a/shared/utils/logUtils.go
+++ b/shared/utils/logUtils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -12,13 +11,13 @@ import (
 
 func LogInit(appName string) {
 	zerolog.CallerMarshalFunc = logCallerMarshalFunction
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	consoleWritter := zerolog.NewConsoleWriter()
-	consoleWritter.TimeFormat = time.RFC3339
 
-	multi := zerolog.MultiLevelWriter(consoleWritter, getFileWriter())
-
-	log.Logger = zerolog.New(multi).With().Timestamp().Caller().Logger()
+	fileWritter := getFileWriter()
+	multi := zerolog.MultiLevelWriter(consoleWritter, fileWritter)
+	log.Logger = zerolog.New(multi).With().Timestamp().Logger()
 	log.Info().Msgf("welcome to %s", appName)
 }
 
@@ -37,6 +36,9 @@ func SetLogLevel(logLevel string) {
 	level, err := zerolog.ParseLevel(logLevel)
 	if err != nil {
 		level = zerolog.InfoLevel
+	}
+	if level <= zerolog.DebugLevel {
+		log.Logger = log.Logger.With().Caller().Logger()
 	}
 	zerolog.SetGlobalLevel(level)
 }


### PR DESCRIPTION
Improve logs for console log. 

at the console we only put the time: 
![image](https://github.com/uyuni-project/uyuni-tools/assets/2996004/bb5ea7de-8ad5-4dbf-b229-976a6b6a54b5)

The file log will contain full date/time:
![image](https://github.com/uyuni-project/uyuni-tools/assets/2996004/9a82f7b7-13bf-46cc-97bc-8181dc8d4216)

The caller method will only be printed if the log level is debug or lower, and will be printed to the console and log file:
![image](https://github.com/uyuni-project/uyuni-tools/assets/2996004/77b31469-4846-4f9a-a09c-6e81e3b7756a)

![image](https://github.com/uyuni-project/uyuni-tools/assets/2996004/17e68fbb-b8d8-4f52-a6ea-180f2df6a3c5)

