### PR TITLE
Add log level differenciation between console and file

### DIFF
--- a/uyuniadm/cmd/cmd.go
+++ b/uyuniadm/cmd/cmd.go
@@ -28,7 +28,7 @@ func NewUyuniadmCommand() *cobra.Command {
 
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.ConfigPath, "config", "c", "", "configuration file path")
-	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "logLevel", "info", "application log level (trace|debug|info|warn|error|fatal|panic)")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "logLevel", "", "application log level (trace|debug|info|warn|error|fatal|panic)")
 
 	migrateCmd := migrate.NewCommand(globalFlags)
 	rootCmd.AddCommand(migrateCmd)

--- a/uyunictl/cmd/cmd.go
+++ b/uyunictl/cmd/cmd.go
@@ -22,7 +22,7 @@ func NewUyunictlCommand() *cobra.Command {
 
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.ConfigPath, "config", "c", "", "configuration file path")
-	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "logLevel", "info", "application log level (trace|debug|info|warn|error|fatal|panic)")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "logLevel", "", "application log level (trace|debug|info|warn|error|fatal|panic)")
 
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		utils.SetLogLevel(globalFlags.LogLevel)


### PR DESCRIPTION
uyunictl exec needs only the output of the executed command by default but we may want to log some things to the file. By default the console logger is set to warn level and the file to info.