### PR TITLE
refactoring the EXEC to split between ctl and adm

### DIFF
--- a/shared/utils/cp.go
+++ b/shared/utils/cp.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
@@ -29,7 +30,7 @@ func Copy(globalFlags *types.GlobalFlags, backend string, src string, dst string
 		log.Fatal().Msgf("Unknown container kind: %s", command)
 	}
 
-	RunRawCmd(command, commandArgs, true)
+	RunCmdStdMapping(command, commandArgs...)
 
 	if user != "" && strings.HasPrefix(dst, "server:") {
 		execArgs := []string{"exec", podName}
@@ -39,7 +40,7 @@ func Copy(globalFlags *types.GlobalFlags, backend string, src string, dst string
 			owner = user + ":" + group
 		}
 		execArgs = append(execArgs, "chown", owner, strings.Replace(dst, "server:", "", 1))
-		RunRawCmd(command, execArgs, true)
+		RunCmdStdMapping(command, execArgs...)
 	}
 }
 
@@ -56,7 +57,7 @@ func TestExistenceInPod(globalFlags *types.GlobalFlags, backend string, dstpath 
 		log.Fatal().Msgf("Unknown container kind: %s\n", command)
 	}
 
-	if _, err := RunCmdOutput(command, commandArgs...); err != nil {
+	if _, err := RunCmdOutput(zerolog.DebugLevel, command, commandArgs...); err != nil {
 		return false
 	}
 	return true

--- a/shared/utils/exec.go
+++ b/shared/utils/exec.go
@@ -1,130 +1,54 @@
 package utils
 
 import (
-	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-type outputLogWriter struct {
-	logger zerolog.Logger
+type OutputLogWriter struct {
+	Logger   zerolog.Logger
+	LogLevel zerolog.Level
 }
 
-func (l outputLogWriter) Write(p []byte) (n int, err error) {
+func (l OutputLogWriter) Write(p []byte) (n int, err error) {
 	n = len(p)
 	if n > 0 && p[n-1] == '\n' {
 		// Trim CR added by stdlog.
 		p = p[0 : n-1]
 	}
-	l.logger.Debug().CallerSkipFrame(1).Msg(string(p))
+	l.Logger.WithLevel(l.LogLevel).CallerSkipFrame(1).Msg(string(p))
 	return
 }
 
-func Exec(globalFlags *types.GlobalFlags, backend string, interactive bool, tty bool, 
-	outputToLog bool, env []string, args ...string) error{
-	command, podName := GetPodName(globalFlags, backend, true)
+func RunCmd(command string, args ...string) error {
+	log.Debug().Msgf("Running: %s %s", command, strings.Join(args, " "))
 
-	commandArgs := []string{"exec"}
-	if interactive {
-		commandArgs = append(commandArgs, "-i")
-	}
-	if tty {
-		commandArgs = append(commandArgs, "-t")
-	}
-	commandArgs = append(commandArgs, podName)
-
-	if command == "kubectl" {
-		commandArgs = append(commandArgs, "-c", "uyuni", "--")
-	}
-
-	newEnv := []string{}
-	for _, envValue := range env {
-		if !strings.Contains(envValue, "=") {
-			if value, set := os.LookupEnv(envValue); set {
-				newEnv = append(newEnv, fmt.Sprintf("%s=%s", envValue, value))
-			}
-		} else {
-			newEnv = append(newEnv, envValue)
-		}
-	}
-	if len(newEnv) > 0 {
-		commandArgs = append(commandArgs, "env")
-		commandArgs = append(commandArgs, newEnv...)
-	}
-	commandArgs = append(commandArgs, "sh", "-c", strings.Join(args, " "))
-
-	return RunRawCmd(command, commandArgs, outputToLog)
-	
+	return exec.Command(command, args...).Run()
 }
 
-func RunRawCmd(command string, args []string, outputToLog bool) error {
-
-	log.Debug().Msgf(" Running: %s %s", command, strings.Join(args, " "))
+func RunCmdStdMapping(command string, args ...string) error {
+	log.Debug().Msgf("Running: %s %s", command, strings.Join(args, " "))
 
 	runCmd := exec.Command(command, args...)
-	runCmd.Stdin = os.Stdin
-	if outputToLog {
-		runCmd.Stdout = outputLogWriter{log.Logger}
-	} else {
-		runCmd.Stdout = os.Stdout
-	}
-
-	// Filter out kubectl line about terminated exit code
-	stderr, err := runCmd.StderrPipe()
-	if err != nil {
-		log.Debug().Err(err).Msg("error starting stderr processor for command")
-		return err
-	}
-	defer stderr.Close()
-
-	if err = runCmd.Start(); err != nil {
-		log.Debug().Err(err).Msg("error starting command")
-		return err
-	}
-
-	scanner := bufio.NewScanner(stderr)
-	for scanner.Scan() {
-		line := scanner.Text()
-		// needed because of kubernetes installation, to ignore the stderr
-		if !strings.HasPrefix(line, "command terminated with exit code") {
-			if outputToLog {
-				log.Debug().Msg(line)
-			} else {
-				fmt.Fprintln(os.Stderr, line)
-			}
-		}
-	}
-
-	if scanner.Err() != nil {
-		log.Debug().Msg("error scanning stderr")
-		return scanner.Err()
-	}
-	if err = runCmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); !ok {
-			log.Debug().Err(exitErr).Msgf("error on command exit code")
-			return exitErr
-		}
-		log.Debug().Err(err).Msg("error on wait command")
-		return err
-	}
-	return nil
+	runCmd.Stdout = os.Stdout
+	runCmd.Stderr = os.Stderr
+	return runCmd.Run()
 }
 
-func RunCmdOutput(command string, args ...string) ([]byte, error) {
+func RunCmdOutput(logLevel zerolog.Level, command string, args ...string) ([]byte, error) {
+	logger := log.Logger.WithLevel(logLevel)
 
-	log.Debug().Msgf(" Running: %s %s", command, strings.Join(args, " "))
+	log.Debug().Msgf("Running: %s %s", command, strings.Join(args, " "))
 
 	output, err := exec.Command(command, args...).Output()
 	if err != nil {
-		log.Debug().Err(err).Msgf("Command returned Error: %s", output)
+		logger.Err(err).Msgf("Command returned Error: %s", output)
 	} else if len(output) > 0 {
-		log.Debug().Msgf("Command output: %s", output)
+		logger.Msgf("Command output: %s", output)
 	}
 	return output, err
 }

--- a/shared/utils/logUtils.go
+++ b/shared/utils/logUtils.go
@@ -12,7 +12,7 @@ import (
 
 var consoleFiteredWriter FilteredLevelWriter
 
-func LogInit(appName string) {
+func LogInit() {
 	zerolog.CallerMarshalFunc = logCallerMarshalFunction
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
@@ -25,7 +25,6 @@ func LogInit(appName string) {
 	fileWritter := getFileWriter()
 	multi := zerolog.MultiLevelWriter(&consoleFiteredWriter, fileWritter)
 	log.Logger = zerolog.New(multi).With().Timestamp().Stack().Logger()
-	log.Info().Msgf("welcome to %s", appName)
 }
 
 func getFileWriter() *lumberjack.Logger {

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"golang.org/x/term"
@@ -30,7 +31,7 @@ func GetCommand(backend string) string {
 		// Check kubectl with a timeout in case the configured cluster is not responding
 		_, err := exec.LookPath("kubectl")
 		if err == nil {
-			if _, err = RunCmdOutput("kubectl", "--request-timeout=30s", "get", "pod"); err != nil {
+			if _, err = RunCmdOutput(zerolog.DebugLevel, "kubectl", "--request-timeout=30s", "get", "pod"); err != nil {
 				log.Info().Msg("kubectl not configured to connect to a cluster, ignoring")
 			} else {
 				return "kubectl"
@@ -61,13 +62,13 @@ func GetPodName(globalFlags *types.GlobalFlags, backend string, fail bool) (stri
 		fallthrough
 	case "podman":
 
-		if out, _ := RunCmdOutput(command, "ps", "-q", "-f", "name="+pod); len(out) == 0 {
+		if out, _ := RunCmdOutput(zerolog.DebugLevel, command, "ps", "-q", "-f", "name="+pod); len(out) == 0 {
 			if fail {
 				log.Fatal().Msgf("Container %s is not running on podman", pod)
 			}
 		}
 	case "kubectl":
-		podName, err := RunCmdOutput("kubectl", "get", "pod", "-lapp=uyuni", "-o=jsonpath={.items[0].metadata.name}")
+		podName, err := RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "pod", "-lapp=uyuni", "-o=jsonpath={.items[0].metadata.name}")
 		if err == nil {
 			pod = string(podName[:])
 		}
@@ -125,7 +126,7 @@ func AskIfMissing(value *string, prompt string) {
 // Get the timezone set on the machine running the tool
 func GetLocalTimezone() string {
 
-	out, err := RunCmdOutput("timedatectl", "show", "--value", "-p", "Timezone")
+	out, err := RunCmdOutput(zerolog.DebugLevel, "timedatectl", "show", "--value", "-p", "Timezone")
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to run timedatectl show --value -p Timezone")
 	}

--- a/uyuniadm/cmd/cmd.go
+++ b/uyuniadm/cmd/cmd.go
@@ -12,7 +12,7 @@ import (
 
 // NewCommand returns a new cobra.Command implementing the root command for kinder
 func NewUyuniadmCommand() *cobra.Command {
-	utils.LogInit("uyuniadm")
+	utils.LogInit()
 	globalFlags := &types.GlobalFlags{}
 	rootCmd := &cobra.Command{
 		Use:     "uyuniadm",

--- a/uyuniadm/cmd/install/kubernetes.go
+++ b/uyuniadm/cmd/install/kubernetes.go
@@ -1,11 +1,12 @@
 package install
 
 import (
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
-	"github.com/uyuni-project/uyuni-tools/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/shared/kubernetes"
+	adm_utils "github.com/uyuni-project/uyuni-tools/uyuniadm/shared/utils"
 )
 
 func installForKubernetes(globalFlags *types.GlobalFlags, flags *InstallFlags, cmd *cobra.Command, args []string) {
@@ -36,7 +37,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags, flags *InstallFlags, c
 	runSetup(globalFlags, flags, args[0], envs)
 
 	// The CA needs to be added to the database for Kickstart use.
-	err := utils.Exec(globalFlags, "kubectl", false, false, true, []string{},
+	err := adm_utils.ExecCommand(zerolog.DebugLevel, globalFlags, "kubectl",
 		"/usr/bin/rhn-ssl-dbstore", "--ca-cert=/etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error storing the SSL CA certificate in database")

--- a/uyuniadm/cmd/install/podman.go
+++ b/uyuniadm/cmd/install/podman.go
@@ -25,7 +25,7 @@ func waitForSystemStart(globalFlags *types.GlobalFlags, flags *InstallFlags) {
 	log.Info().Msg("Waiting for the server to start...")
 	// Start the service
 
-	if err := utils.RunRawCmd("systemctl", []string{"enable", "--now", "uyuni-server"}, true); err != nil {
+	if err := utils.RunCmd("systemctl", "enable", "--now", "uyuni-server"); err != nil {
 		log.Fatal().Err(err).Msg("Failed to enable uyuni-server systemd service")
 	}
 
@@ -36,7 +36,7 @@ func pullImage(flags *InstallFlags) {
 	image := fmt.Sprintf("%s:%s", flags.Image.Name, flags.Image.Tag)
 	log.Info().Msgf("Running podman pull %s", image)
 
-	err := utils.RunRawCmd("podman", []string{"pull", image}, false)
+	err := utils.RunCmdStdMapping("podman", "pull", image)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to pull image")
 	}

--- a/uyuniadm/cmd/install/shared.go
+++ b/uyuniadm/cmd/install/shared.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/shared/templates"
+	adm_utils "github.com/uyuni-project/uyuni-tools/uyuniadm/shared/utils"
 )
 
 const SETUP_NAME = "setup.sh"
@@ -19,7 +21,7 @@ func runSetup(globalFlags *types.GlobalFlags, flags *InstallFlags, fqdn string, 
 
 	utils.Copy(globalFlags, "", filepath.Join(tmpFolder, SETUP_NAME), "server:/tmp/setup.sh", "root", "root")
 
-	err := utils.Exec(globalFlags, "", false, false, true, []string{}, "/tmp/setup.sh")
+	err := adm_utils.ExecCommand(zerolog.InfoLevel, globalFlags, "", "/tmp/setup.sh")
 	if err != nil {
 		log.Fatal().Err(err).Msg("error running the setup script")
 	}

--- a/uyuniadm/cmd/migrate/podman.go
+++ b/uyuniadm/cmd/migrate/podman.go
@@ -47,7 +47,7 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *MigrateFlags, cmd *c
 
 	// Start the service
 
-	if err := utils.RunRawCmd("systemctl", []string{"enable", "--now", "uyuni-server"}, true); err != nil {
+	if err := utils.RunCmd("systemctl", "enable", "--now", "uyuni-server"); err != nil {
 		log.Fatal().Err(err).Msgf("Failed to enable uyuni-server systemd service")
 	}
 
@@ -68,7 +68,7 @@ func runContainer(name string, image string, tag string, extraArgs []string, cmd
 	podmanArgs = append(podmanArgs, image+":"+tag)
 	podmanArgs = append(podmanArgs, cmd...)
 
-	err := utils.RunRawCmd("podman", podmanArgs, false)
+	err := utils.RunCmd("podman", podmanArgs...)
 
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to run %s container", name)

--- a/uyuniadm/cmd/uninstall/kubernetes.go
+++ b/uyuniadm/cmd/uninstall/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
@@ -24,13 +25,13 @@ func uninstallForKubernetes(globalFlags *types.GlobalFlags, dryRun bool) {
 			log.Info().Msgf("Would run kubectl delete -n %s secret uyuni-ca uyuni-cert", namespace)
 		} else {
 			log.Info().Msgf("Running kubectl delete -n %s configmap uyuni-ca", namespace)
-			if err := utils.RunRawCmd("kubectl", []string{"delete", "-n", namespace, "configmap", "uyuni-ca"}, false); err != nil {
+			if err := utils.RunCmd("kubectl", "delete", "-n", namespace, "configmap", "uyuni-ca"); err != nil {
 				log.Info().Err(err).Msgf("Failed deleting config map")
 			}
 
 			log.Info().Msgf("Running kubectl delete -n %s secret uyuni-ca uyuni-cert", namespace)
 
-			err := utils.RunRawCmd("kubectl", []string{"delete", "-n", namespace, "secret", "uyuni-ca", "uyuni-cert"}, false)
+			err := utils.RunCmd("kubectl", "delete", "-n", namespace, "secret", "uyuni-ca", "uyuni-cert")
 			if err != nil {
 				log.Info().Err(err).Msgf("Failed deleting config map")
 			}
@@ -58,7 +59,7 @@ func helmUninstall(kubeconfig string, deployment string, filter string, dryRun b
 		args = append(args, filter)
 	}
 
-	out, err := utils.RunCmdOutput("kubectl", args...)
+	out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", args...)
 	if err != nil {
 		log.Info().Err(err).Msgf("Failed to find %s's namespace, skipping removal", deployment)
 	}
@@ -75,7 +76,7 @@ func helmUninstall(kubeconfig string, deployment string, filter string, dryRun b
 		} else {
 			log.Info().Msgf("Uninstalling %s", deployment)
 			message := "Failed to run helm " + strings.Join(helmArgs, " ")
-			err := utils.RunRawCmd("helm", helmArgs, true)
+			err := utils.RunCmd("helm", helmArgs...)
 			if err != nil {
 				log.Fatal().Err(err).Msg(message)
 			}

--- a/uyuniadm/shared/kubernetes/helm.go
+++ b/uyuniadm/shared/kubernetes/helm.go
@@ -44,7 +44,7 @@ func helmUpgrade(globalFlags *types.GlobalFlags, kubeconfig string, namespace st
 		command = "install"
 	}
 	errorMessage := fmt.Sprintf("Failed to %s helm chart %s in namespace %s", command, chart, namespace)
-	err := utils.RunRawCmd("helm", helmArgs, true)
+	err := utils.RunCmd("helm", helmArgs...)
 	if err != nil {
 		log.Fatal().Err(err).Msg(errorMessage)
 	}

--- a/uyuniadm/shared/kubernetes/k3s.go
+++ b/uyuniadm/shared/kubernetes/k3s.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/shared/templates"
@@ -24,7 +25,7 @@ func InstallK3sTraefikConfig() {
 	// Wait for traefik to be back
 	log.Info().Msg("Waiting for Traefik to be reloaded")
 	for i := 0; i < 60; i++ {
-		out, err := utils.RunCmdOutput("kubectl", "get", "job", "-A",
+		out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "job", "-A",
 			"-o", "jsonpath={.status.completionTime}", "helm-install-traefik")
 		if err == nil {
 			completionTime, err := time.Parse(time.RFC3339, string(out))

--- a/uyuniadm/shared/kubernetes/kubernetes.go
+++ b/uyuniadm/shared/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -43,7 +44,7 @@ func CheckCluster() ClusterInfos {
 		log.Fatal().Err(err).Msgf("Failed to get node hostname")
 	}
 
-	out, err := utils.RunCmdOutput("kubectl", "get", "node",
+	out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "node",
 		"-o", "jsonpath={.status.nodeInfo.kubeletVersion}", hostname)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to get kubelet version for node %s", hostname)
@@ -60,13 +61,13 @@ func guessIngress() string {
 	var ingress string
 
 	// Check for a traefik resource
-	err := utils.RunRawCmd("kubectl", []string{"explain", "ingressroutetcp"}, false)
+	err := utils.RunCmd("kubectl", "explain", "ingressroutetcp")
 	if err == nil {
 		ingress = "traefik"
 	}
 
 	// Look for a pod running the nginx-ingress-controller: there is no other common way to find out
-	out, err := utils.RunCmdOutput("kubectl", "get", "pod", "-A",
+	out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "pod", "-A",
 		"-o", "jsonpath={range .items[*]}{.spec.containers[*].args[0]}{.spec.containers[*].command}{end}")
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to get get pod commands to look for nginx controller")

--- a/uyuniadm/shared/kubernetes/rke2.go
+++ b/uyuniadm/shared/kubernetes/rke2.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"strconv"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/uyuniadm/shared/templates"
@@ -25,7 +26,7 @@ func InstallRke2NginxConfig(namespace string) {
 	// Wait for the nginx controller to be back
 	log.Info().Msg("Waiting for Nginx controller to be reloaded")
 	for i := 0; i < 60; i++ {
-		out, err := utils.RunCmdOutput("kubectl", "get", "daemonset", "-A",
+		out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "daemonset", "-A",
 			"-o", "jsonpath={.status.numberReady}", "rke2-ingress-nginx-controller")
 		if err == nil {
 			if count, err := strconv.Atoi(string(out)); err == nil && count > 0 {

--- a/uyuniadm/shared/kubernetes/utils.go
+++ b/uyuniadm/shared/kubernetes/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -22,7 +23,7 @@ func waitForDeployment(namespace string, name string, appName string) {
 	cmdArgs = addNamespace(cmdArgs, namespace)
 
 	for i := 0; i < 60; i++ {
-		out, err := utils.RunCmdOutput("kubectl", cmdArgs...)
+		out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", cmdArgs...)
 		if err == nil {
 			podName = string(out)
 			break
@@ -59,7 +60,7 @@ func waitForPulledImage(namespace string, podName string) {
 	failedArgs = addNamespace(failedArgs, namespace)
 	for {
 		// Look for events indicating an image pull issue
-		out, err := utils.RunCmdOutput("kubectl", failedArgs...)
+		out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", failedArgs...)
 		if err != nil {
 			log.Fatal().Err(err).Msgf("Failed to get failed events for pod %s", podName)
 		}
@@ -71,7 +72,7 @@ func waitForPulledImage(namespace string, podName string) {
 		}
 
 		// Has the image pull finished?
-		out, err = utils.RunCmdOutput("kubectl", pulledArgs...)
+		out, err = utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", pulledArgs...)
 		if err != nil {
 			log.Fatal().Err(err).Msgf("Failed to get events for pod %s", podName)
 		}
@@ -90,7 +91,7 @@ func isDeploymentReady(namespace string, name string) bool {
 	args := []string{"get", "-o", jsonpath, "deploy"}
 	args = addNamespace(args, namespace)
 
-	out, err := utils.RunCmdOutput("kubectl", args...)
+	out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", args...)
 	// kubectl errors out if the deployment or namespace doesn't exist
 	if err == nil {
 		if replicas, _ := strconv.Atoi(string(out)); replicas > 0 {

--- a/uyuniadm/shared/utils/exec.go
+++ b/uyuniadm/shared/utils/exec.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func ExecCommand(logLevel zerolog.Level, globalFlags *types.GlobalFlags, backend string, args ...string) error {
+	command, podName := utils.GetPodName(globalFlags, backend, true)
+
+	commandArgs := []string{"exec", podName}
+
+	if command == "kubectl" {
+		commandArgs = append(commandArgs, "-c", "uyuni", "--")
+	}
+
+	commandArgs = append(commandArgs, "sh", "-c", strings.Join(args, " "))
+
+	runCmd := exec.Command(command, commandArgs...)
+	logger := utils.OutputLogWriter{Logger: log.Logger, LogLevel: logLevel}
+	runCmd.Stdout = logger
+	runCmd.Stderr = logger
+	return runCmd.Run()
+}

--- a/uyunictl/cmd/cmd.go
+++ b/uyunictl/cmd/cmd.go
@@ -12,7 +12,7 @@ import (
 
 // NewCommand returns a new cobra.Command implementing the root command for kinder
 func NewUyunictlCommand() *cobra.Command {
-	utils.LogInit("uyunictl")
+	utils.LogInit()
 	globalFlags := &types.GlobalFlags{}
 	rootCmd := &cobra.Command{
 		Use:     "uyunictl",

--- a/uyunictl/cmd/distro/cp.go
+++ b/uyunictl/cmd/distro/cp.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
@@ -16,7 +17,7 @@ func umountAndRemove(mountpoint string) {
 		mountpoint,
 	}
 
-	if err := utils.RunRawCmd("/usr/bin/sudo", umount_cmd, true); err != nil {
+	if err := utils.RunCmd("/usr/bin/sudo", umount_cmd...); err != nil {
 		log.Fatal().Err(err).Msgf("Unable to unmount iso file, leaving %s intact", mountpoint)
 	}
 
@@ -50,7 +51,7 @@ func distCp(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command,
 			source,
 			srcdir,
 		}
-		if out, err := utils.RunCmdOutput("/usr/bin/sudo", mount_cmd...); err != nil {
+		if out, err := utils.RunCmdOutput(zerolog.DebugLevel, "/usr/bin/sudo", mount_cmd...); err != nil {
 			log.Debug().Msgf("output %s", out)
 			log.Error().Err(err).Msg("Unable to mount iso file. Mount manually and try again")
 			return


### PR DESCRIPTION
Refactoring the cmd execute commands to make them simpler to use and log information.
At the same time split the cmd exec for uyunictl and uyuniadm, since they have different requirements