### PR TITLE
hide debug flag, since is for developer only

### DIFF
--- a/uyuniadm/cmd/install/install.go
+++ b/uyuniadm/cmd/install/install.go
@@ -113,6 +113,7 @@ NOTE: for now installing on a remote cluster or podman is not supported!
 	installCmd.Flags().String("scc-password", "", "SUSE Customer Center password")
 
 	installCmd.Flags().Bool("debug", false, "Enable debugging features")
+	installCmd.Flags().MarkHidden("debug")
 
 	cmd_utils.AddImageFlag(installCmd)
 	cmd_utils.AddPodmanInstallFlag(installCmd)


### PR DESCRIPTION
Hide debug flag, since it should not be presented for end users, it should be used for developers only.