### PR TITLE
common function without conatiner name

### DIFF
--- a/uyuniadm/cmd/migrate/podman/utils.go
+++ b/uyuniadm/cmd/migrate/podman/utils.go
@@ -59,7 +59,7 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 
 func runContainer(name string, image string, tag string, extraArgs []string, cmd []string) {
 
-	podmanArgs := append([]string{"run"}, podman.GetCommonParams(name)...)
+	podmanArgs := append([]string{"run", "--name", name}, podman.GetCommonParams()...)
 	podmanArgs = append(podmanArgs, extraArgs...)
 
 	for volumeName, containerPath := range utils.VOLUMES {
@@ -69,7 +69,7 @@ func runContainer(name string, image string, tag string, extraArgs []string, cmd
 	podmanArgs = append(podmanArgs, image+":"+tag)
 	podmanArgs = append(podmanArgs, cmd...)
 
-	err := utils.RunCmd("podman", podmanArgs...)
+	err := utils.RunCmdStdMapping("podman", podmanArgs...)
 
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to run %s container", name)

--- a/uyuniadm/shared/podman/podman.go
+++ b/uyuniadm/shared/podman/podman.go
@@ -15,8 +15,8 @@ import (
 const UYUNI_NETWORK = "uyuni"
 const commonArgs = "--rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw"
 
-func GetCommonParams(containerName string) []string {
-	return strings.Split(fmt.Sprintf(commonArgs, containerName), " ")
+func GetCommonParams() []string {
+	return strings.Split(commonArgs, " ")
 }
 
 func GetExposedPorts(debug bool) []utils.PortMap {


### PR DESCRIPTION
The podman migrate command was failing because of refactoring in the common flag which does receive the name anymore.
This pr solves it by assigning the name outside the command arguments.