### PR TITLE
push-2-obs: tell git our mounted directory is safe

### DIFF
--- a/push-2-obs
+++ b/push-2-obs
@@ -82,6 +82,7 @@ cp ${PKG_NAME}.spec \$PUSH_DIR/${OBS_PROJ}/${PKG_NAME}
 cp ${PKG_NAME}.changes \$PUSH_DIR/${OBS_PROJ}/${PKG_NAME}
 
 mkdir -p \${BUILD_DIR}/${OBS_PROJ}/${PKG_NAME}
+git config --global --add safe.directory /src
 git archive --prefix ${PKG_NAME}-\${LAST_TAG}/ -o \${BUILD_DIR}/${OBS_PROJ}/${PKG_NAME}/${PKG_NAME}-\${LAST_TAG}.tar.gz HEAD && echo "tarball created"
 PUSH_TARBALL="\${PUSH_DIR}/${OBS_PROJ}/${PKG_NAME}/${PKG_NAME}-\${LAST_TAG}.tar.gz"
 BUILD_TARBALL="\${BUILD_DIR}/${OBS_PROJ}/${PKG_NAME}/${PKG_NAME}-\${LAST_TAG}.tar.gz"


### PR DESCRIPTION
This is required to get rid of the following error message when running `git archive`, however I have no idea why this didn't happen before

    fatal: detected dubious ownership in repository at '/src'