### PR TITLE
spec: handle go bin located outside of the PATH

### DIFF
--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -93,7 +93,12 @@ chart=%{chart}
   chart='%{_default_chart}'
 %endif
 
-go build \
+go_path=
+%if "%{?_go_bin}" != ""
+  go_path='%{_go_bin}/'
+%endif
+
+${go_path}go build \
     -ldflags "-X ${ADM_PATH}.DefaultImage=${image} -X ${ADM_PATH}.DefaultTag=${tag} -X ${ADM_PATH}.DefaultChart=${chart}" \
     -o ./bin ./...
 


### PR DESCRIPTION
Some distros like Ubuntu 20.04 have go 1.18+ installed but not in the PATH. Allow setting a `%_go_bin` variable to change where to find go to build the package.