### PR TITLE
Polishing the spec file for removing macros from prjconf

### DIFF
--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -20,6 +20,7 @@
 %global org             uyuni-project
 %global project         uyuni-tools
 %global provider_prefix %{provider}.%{provider_tld}/%{org}/%{project}
+%global productname     Uyuni
 
 %global image           registry.opensuse.org/uyuni/server
 %global chart           oci://registry.opensuse.org/uyuni/server
@@ -34,7 +35,7 @@
 Name:           %{project}
 Version:        0.0.1
 Release:        0
-Summary:        Tools for managing uyuni container
+Summary:        Tools for managing %{productname} container
 License:        Apache-2.0
 Group:          System/Management
 URL:            https://%{provider_prefix}
@@ -61,19 +62,19 @@ Tools for managing uyuni container.
 
 %if %{adm_build}
 %package -n uyuniadm
-Summary:      Command line tool to install and update Uyuni
+Summary:      Command line tool to install and update %{productname}
 
 %description -n uyuniadm
-uyuniadm is a convenient tool to install and update Uyuni components as containers running
-either on podman or a kubernetes cluster.
+uyuniadm is a convenient tool to install and update %{productname} components as containers running
+either on Podman or a Kubernetes cluster.
 %endif
 
 %package -n uyunictl
-Summary:      Command line tool to perform day-to-day operations on Uyuni
+Summary:      Command line tool to perform day-to-day operations on %{productname}
 
 %description -n uyunictl
-uyunictl is a tool helping with dayly tasks on Uyuni components running as containers
-either on podman or a kubernetes cluster.
+uyunictl is a tool helping with dayly tasks on %{productname} components running as containers
+either on Podman or a Kubernetes cluster.
 
 
 %prep

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -24,7 +24,7 @@
 %global image           registry.opensuse.org/uyuni/server
 %global chart           oci://registry.opensuse.org/uyuni/server
 
-%if 0%{?sle_version} >= 150400 || 0%{?rhel} >= 8 || 0%{?fedora} >= 37 || 0%{?debian} >= 12 || 0%{?ubuntu} >= 2204
+%if 0%{?sle_version} >= 150400 || 0%{?rhel} >= 8 || 0%{?fedora} >= 37 || 0%{?debian} >= 12 || 0%{?ubuntu} >= 2004
 %define adm_build    1
 %else
 %define adm_build    0
@@ -41,16 +41,20 @@ URL:            https://%{provider_prefix}
 Source0:        %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
 BuildRequires:  coreutils
+# Get the proper Go version on different distros
 %if 0%{?suse_version}
 BuildRequires:  golang(API) >= 1.20
-%else
+%endif
 %if 0%{?ubuntu}
-BuildRequires:  golang >= golang-1.18
-%else
-BuildRequires:  golang >= 1.18
+%define go_version      1.20
+BuildRequires:  golang-%{go_version}
 %endif
+%if 0%{?debian}
+BuildRequires:  golang >= 1.20
 %endif
-
+%if 0%{?fedora} || 0%{?rhel}
+BuildRequires:  golang >= 1.19
+%endif
 
 %description
 Tools for managing uyuni container.
@@ -98,8 +102,12 @@ chart=%{chart}
 %endif
 
 go_path=
-%if "%{?_go_bin}" != ""
-  go_path='%{_go_bin}/'
+%if 0%{?ubuntu}
+  go_path=/usr/lib/go-%{go_version}/bin/
+%else
+  %if "%{?_go_bin}" != ""
+    go_path='%{_go_bin}/'
+  %endif
 %endif
 
 ${go_path}go build \


### PR DESCRIPTION
* Buildrequires different Go versions according to the used distro
* Use a variable for defining the product name and fix podman and kubernetes spelling

Note: Given that this is still the first release, no need to pollute the .changes with the details of all the attempts to polish the spec file.

For info, this is the current **prjconf** of my testing branch on OBS
~~~
%if "%_repository" == "Debian_12" || "%_repository" == "Ubuntu_22.04" || "%_repository" == "Ubuntu_20.04"
Type: spec
BinaryType: deb
BuildEngine: debbuild
Support: debbuild pax
Keep: debbuild
%define vendor debbuild
%define _vendor debbuild
Macros:
%vendor debbuild
%_vendor debbuild
%_deb_maintainer Uyuni packagers <devel@lists.uyuni-project.org>
%_buildshell /bin/bash
:Macros
%endif

Macros:
%_default_image registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server
%_default_chart oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server
:Macros
~~~

For the **meta**, my project is now aligned with the main one but something to consider is if we want to reduce the architectures we support per repos:
~~~
  <build>
    <disable repository="Debian_10"/>
    <disable repository="Debian_11"/>
  </build>
  <debuginfo>
    <enable/>
    <disable arch="x86_64" repository="AlmaLinux_8"/>
    <disable arch="x86_64" repository="Fedora_38"/>
  </debuginfo>
  <repository name="openSUSE_Leap_15.5">
    <path project="openSUSE:Leap:15.5:Update" repository="standard"/>
    <arch>aarch64</arch>
    <arch>ppc64le</arch>
    <arch>s390x</arch>
    <arch>x86_64</arch>
  </repository>
  <repository name="Ubuntu_22.04">
    <path project="systemsmanagement:Uyuni:Master:Ubuntu2204-Uyuni-Client-Tools:Build-Dependencies" repository="xUbuntu_22.04"/>
    <path project="openSUSE:Tools" repository="xUbuntu_22.04"/>
    <path project="Ubuntu:22.04" repository="universe-update"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="Ubuntu_20.04">
    <path project="systemsmanagement:Uyuni:Master:Ubuntu2004-Uyuni-Client-Tools:Build-Dependencies" repository="xUbuntu_20.04"/>
    <path project="openSUSE:Tools" repository="xUbuntu_20.04"/>
    <path project="Ubuntu:20.04" repository="universe-update"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="SLE_15">
    <path project="systemsmanagement:Uyuni:Master:SLE15-Uyuni-Client-Tools:Build-Dependencies" repository="SLE_15"/>
    <arch>x86_64</arch>
    <arch>s390x</arch>
    <arch>aarch64</arch>
    <arch>ppc64le</arch>
  </repository>
  <repository name="SLE_12">
    <path project="systemsmanagement:Uyuni:Master:SLE12-Uyuni-Client-Tools:Build-Dependencies" repository="SLE_12"/>
    <arch>x86_64</arch>
    <arch>s390x</arch>
    <arch>aarch64</arch>
    <arch>ppc64le</arch>
  </repository>
  <repository name="Fedora_38">
    <path project="Fedora:38" repository="standard"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="EL_9">
    <path project="systemsmanagement:Uyuni:Master:Other:EL" repository="AlmaLinux_8"/>
    <path project="Fedora:EPEL:9" repository="standard"/>
    <path project="systemsmanagement:Uyuni:Master:Other" repository="EL_9"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="Debian_12">
    <path project="systemsmanagement:Uyuni:Master:Debian12-Uyuni-Client-Tools:Build-Dependencies" repository="Debian_12"/>
    <path project="Debian:12" repository="update"/>
    <path project="Debian:12" repository="standard"/>
    <arch>x86_64</arch>
    <arch>aarch64</arch>
    <arch>armv7l</arch>
    <arch>i586</arch>
    <arch>ppc64le</arch>
    <arch>s390x</arch>
  </repository>
  <repository name="AlmaLinux_8">
    <path project="systemsmanagement:Uyuni:Master:Other:EL" repository="AlmaLinux_8"/>
    <path project="Fedora:EPEL:8" repository="modular"/>
    <path project="systemsmanagement:Uyuni:Master:Other" repository="AlmaLinux_8"/>
    <arch>x86_64</arch>
  </repository>
~~~
