### PR TITLE
Enable systemd colorized output

### DIFF
--- a/uyuniadm/shared/templates/serviceTemplate.go
+++ b/uyuniadm/shared/templates/serviceTemplate.go
@@ -20,6 +20,7 @@ RequiresMountsFor=%t/containers
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=UYUNI_IMAGE={{ .Image }}
 Environment=TZ={{ .Timezone }}
+Environment=SYSTEMD_COLORS=1
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-server.pid %t/%n.ctr-id
 ExecStartPre=/usr/bin/podman rm --ignore --force -t 10 {{ .NamePrefix }}-server


### PR DESCRIPTION
I noticed that the commands inside our server container don't output with colors by default, so we need to enforce them manually. 

<details>
<summary>
Example:
</summary>

NO COLORS:
![image](https://github.com/SUSE/spacewalk/assets/2827771/cceab143-1211-4f83-9f5c-19dcce67bc5b)
COLORS:
![image](https://github.com/SUSE/spacewalk/assets/2827771/13905582-6f76-4cf2-b40b-0d16aa69de02)
</details>