### PR TITLE
Build uyuniadm also for Tumbleweed and ALP

### DIFF
--- a/uyuni-tools.changes
+++ b/uyuni-tools.changes
@@ -1,3 +1,5 @@
+- Build uyuniadm also for Tumbleweed and ALP
+
 -------------------------------------------------------------------
 Tue Oct 24 13:24:46 UTC 2023 - Michele Bussolotto <michele.bussolotto@suse.com>
 

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -25,7 +25,7 @@
 %global image           registry.opensuse.org/uyuni/server
 %global chart           oci://registry.opensuse.org/uyuni/server
 
-%if 0%{?sle_version} >= 150400 || 0%{?rhel} >= 8 || 0%{?fedora} >= 37 || 0%{?debian} >= 12 || 0%{?ubuntu} >= 2004
+%if 0%{?suse_version} >= 1600 || 0%{?sle_version} >= 150400 || 0%{?rhel} >= 8 || 0%{?fedora} >= 37 || 0%{?debian} >= 12 || 0%{?ubuntu} >= 2004
 %define adm_build    1
 %else
 %define adm_build    0


### PR DESCRIPTION
Build uyuniadm also for Tumbleweed and ALP. Description about which flag match OS version can be found here: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto