### PR TITLE
Add migration of autoinstallable distributions

### DIFF
--- a/uyuni-tools.changes.nadvornik.distro_migration
+++ b/uyuni-tools.changes.nadvornik.distro_migration
@@ -1,0 +1,1 @@
+- Add migration of autoinstallable distributions


### PR DESCRIPTION
This PR implements copying of autoinstallable distributions to standard location `/srv/www/distributions`

Then the database must be updated with:
```
UPDATE rhnKickstartableTree SET base_path = CONCAT('/srv/www/distributions/', CASE WHEN org_id = 1 THEN label ELSE CONCAT(org_id, '-', label) END);
```
This is not part of the PR.