### PR TITLE
Use the SSH variable instead of ssh command in migrate script

### DIFF
--- a/uyuniadm/shared/templates/migrateScriptTemplate.go
+++ b/uyuniadm/shared/templates/migrateScriptTemplate.go
@@ -15,7 +15,7 @@ SSH="ssh -A $SSH_CONFIG "
 SCP="scp -A $SSH_CONFIG "
 for folder in {{ range .Volumes }}{{ . }} {{ end }};
 do
-  if ssh -A {{ .SourceFqdn }} test -e $folder; then
+  if $SSH {{ .SourceFqdn }} test -e $folder; then
     echo "Copying $folder..."
     rsync -e "$SSH" --rsync-path='sudo rsync' -avz {{ .SourceFqdn }}:$folder/ $folder;
   else


### PR DESCRIPTION
In order to load the ssh_config file, we want to use `$SSH` instead of `ssh`