### PR TITLE
Migration script: Altering configuration for domain resolution

### DIFF
--- a/uyuniadm/shared/templates/migrateScriptTemplate.go
+++ b/uyuniadm/shared/templates/migrateScriptTemplate.go
@@ -32,6 +32,11 @@ ln -s /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT /srv/www/htdocs/pub/
 echo "Extracting time zone..."
 $SSH {{ .SourceFqdn }} timedatectl show -p Timezone >/var/lib/uyuni-tools/data
 
+echo "Altering configuration for domain resolution..."
+sed 's/report_db_host = {{ .SourceFqdn }}/report_db_host = localhost/' -i /etc/rhn/rhn.conf;
+sed 's/server\.jabber_server/java\.hostname/' -i /etc/rhn/rhn.conf;
+sed 's/client_use_localhost: false/client_use_localhost: true/' -i /etc/cobbler/settings.yaml;
+
 {{ if .Kubernetes }}
 echo "Altering configuration for kubernetes..."
 echo 'server.no_ssl = 1' >> /etc/rhn/rhn.conf;


### PR DESCRIPTION
**Context:**
Once we migrate from one server to another, we have a problem with domain resolution, as we have all the configurations using the FQDN from the previous machine.

**Manual step after migration:**
Ideally, we expect our users to re-use the same FQDN in the new machine once the migration script has finished.

**Proposal:**

Here we replace some of the FQDN matches in our etc config files, routing them to `localhost`, the changed values must stay for the correct usage on containers.
**But** we will still have some configuration files using the FQDN of the source server, therefore we still require that the user manually replace the FQDN of the new server and re-use the FQDN of the source server.