### PR TITLE
Fix environment variables handling in mgrctl exec

### DIFF
--- a/mgrctl/cmd/exec/exec.go
+++ b/mgrctl/cmd/exec/exec.go
@@ -61,6 +61,7 @@ func run(flags *flagpole, cmd *cobra.Command, args []string) {
 
 	commandArgs := []string{"exec"}
 	envs := []string{}
+	envs = append(envs, flags.Envs...)
 	if flags.Interactive {
 		commandArgs = append(commandArgs, "-i")
 	}


### PR DESCRIPTION
Commit 85d09cd introduced a regression by forgetting to add the passed environment variables to the command.