### PR TITLE
Add migration of config files

### DIFF
--- a/uyuni-tools.changes.nadvornik.migration-config
+++ b/uyuni-tools.changes.nadvornik.migration-config
@@ -1,0 +1,1 @@
+- Add migration of config files


### PR DESCRIPTION
With this PR the migration command copies from the old machine only files marked config(noreplace) in rpm.
Additionally, it completely excludes db migration and makes sure that the migrated files points to /usr/share/susemanager.

Fixes https://github.com/SUSE/spacewalk/issues/23259
