### PR TITLE
Remove custom SELinux policy, instead use label:disable for podman migration

### DIFF
--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -28,6 +28,7 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 	defer os.RemoveAll(scriptDir)
 
 	extraArgs := []string{
+		"--security-opt", "label:disable",
 		"-e", "SSH_AUTH_SOCK",
 		"-v", filepath.Dir(sshAuthSocket) + ":" + filepath.Dir(sshAuthSocket),
 		"-v", scriptDir + ":/var/lib/uyuni-tools/",
@@ -39,15 +40,6 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 
 	if sshKnownhostsPath != "" {
 		extraArgs = append(extraArgs, "-v", sshKnownhostsPath+":/etc/ssh/ssh_known_hosts")
-	}
-
-	if utils.GetSELinuxMode() == "Enforcing" {
-		customSELinuxPolicyPodmanLabel, customSELinuxPolicyPath := shared.GetCustomSELinuxPolicyDetails("uyuni")
-		shared.InstallCustomSELinuxPolicy(customSELinuxPolicyPath)
-		if customSELinuxPolicyPath != "" {
-			log.Debug().Msgf("customSELinuxPolicyPodmanLabel: %s", customSELinuxPolicyPodmanLabel)
-			extraArgs = append(extraArgs, "--security-opt", customSELinuxPolicyPodmanLabel)
-		}
 	}
 
 	serverImage, err := utils.ComputeImage(flags.Image.Name, flags.Image.Tag)

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -91,20 +90,6 @@ func ReadFile(file string) []byte {
 		log.Fatal().Err(err).Msgf("Failed to read file %s", file)
 	}
 	return out
-}
-
-// Get SELinux mode
-func GetSELinuxMode() string {
-	_, err := exec.LookPath("getenforce")
-	if err == nil {
-		output, _ := RunCmdOutput(zerolog.Disabled, "getenforce")
-		mode := strings.TrimSpace(string(output))
-		log.Debug().Msgf("SELinux mode: %s", mode)
-		return mode
-	} else {
-		log.Debug().Msg("SELinux is not present")
-		return ""
-	}
 }
 
 // Get the value of a file containing a boolean.

--- a/uyuni-tools.changes.oholecek.selinux-podman-label-disable
+++ b/uyuni-tools.changes.oholecek.selinux-podman-label-disable
@@ -1,0 +1,2 @@
+- Disable selinux relabeling by podman for migration container.
+  Fixes SELinux access problems for SSH agent socket.


### PR DESCRIPTION
Fixes SELinux access problems for SSH agent socket by disabling selinux relabeling for migration container.

This does not affect container host, side effect is that for migration container there is no separation in selinux labels, weakening a security by little. However migration container is short lived one and once migration is complete, normal server container with separate selinux labels for container is used as before.

I did not test Kubernetes yet, but I expect it to have similar problem with accessing SSH agent and will need similar solution by using something like:

```yaml
apiVersion: v1
kind: Pod
spec:
  containers:
    securityContext:
        seLinuxOptions:
            type: spc_t

```

Fixes https://github.com/SUSE/spacewalk/issues/23125