### PR TITLE
Add push script to tweak spec file for IBS

### DIFF
--- a/.tito/custom/custom.py
+++ b/.tito/custom/custom.py
@@ -9,7 +9,7 @@ Code for building packages in SUSE that need generated code not tracked in git.
 import os
 
 from tito.builder import Builder
-from tito.common import  info_out, run_command
+from tito.common import  info_out, run_command, debug
 
 class SuseGitExtraGenerationBuilder(Builder):
 
@@ -28,3 +28,13 @@ class SuseGitExtraGenerationBuilder(Builder):
             run_command("cp %s %s/" % (os.path.join(setup_file_dir, filename), self.rpmbuild_sourcedir), True)
             self.sources.append(os.path.join(self.rpmbuild_sourcedir, filename))
 
+        source_push = os.path.join(setup_file_dir, "push.sh")
+        if os.path.exists(source_push):
+            push_path = os.path.join(self.rpmbuild_sourcedir, "push.sh")
+            run_command("cp %s %s/" % (source_push, self.rpmbuild_sourcedir), True)
+            self.sources.append(push_path)
+
+            run_command(f"sed '/^URL: .*$/aSource10000: push.sh' -i {self.spec_file}")
+            cleanup = f"\nsed '/^Source10000: push.sh/d' -i $SRPM_PKG_DIR/{self.spec_file_name}"
+            with open(push_path, "a") as fd:
+                fd.write(cleanup)

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2024 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is called by push-packages-to-obs
+
+OSCAPI=$1
+GIT_DIR=$2
+PKG_NAME=$3
+
+SRPM_PKG_DIR=$(dirname "$0")
+
+if [ "${OSCAPI}" == "https://api.suse.de" ]; then
+  sed 's/^tag=%{!?_default_tag:latest}/tag=5.0.0-alpha1/' -i ${SRPM_PKG_DIR}/uyuni-tools.spec
+fi


### PR DESCRIPTION
There are some build differences between the tools for Uyuni and those for SUSE Manager. Add a push.sh script to apply those changes when pushing to IBS for SUSE Manager.

Requires PR https://github.com/uyuni-project/uyuni-releng-tools/pull/9 to be merged and deployed before pushing.