### PR TITLE
Verify if podman, kubectl or helm are installed before using them

### DIFF
--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -7,6 +7,8 @@
 package kubernetes
 
 import (
+	"os/exec"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -24,6 +26,12 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	cmd *cobra.Command,
 	args []string,
 ) error {
+	for _, binary := range []string{"kubectl", "helm"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			log.Fatal().Err(err).Msgf("install %s before running this command", binary)
+		}
+	}
+
 	flags.CheckParameters(cmd, "kubectl")
 	cnx := shared.NewConnection("kubectl", "", shared_kubernetes.ServerFilter)
 

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -6,6 +6,7 @@ package podman
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -43,6 +44,10 @@ func installForPodman(
 	args []string,
 ) error {
 	flags.CheckParameters(cmd, "podman")
+	if _, err := exec.LookPath("podman"); err != nil {
+		log.Fatal().Err(err).Msg("install podman before running this command")
+	}
+
 	fqdn := getFqdn(args)
 	log.Info().Msgf("setting up server with the FQDN '%s'", fqdn)
 

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 
 	"github.com/rs/zerolog"
@@ -31,6 +32,11 @@ func migrateToKubernetes(
 	cmd *cobra.Command,
 	args []string,
 ) error {
+	for _, binary := range []string{"kubectl", "helm"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			log.Fatal().Err(err).Msgf("install %s before running this command", binary)
+		}
+	}
 	cnx := shared.NewConnection("kubectl", "", shared_kubernetes.ServerFilter)
 	fqdn := args[0]
 

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -7,6 +7,7 @@ package podman
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
@@ -20,6 +21,10 @@ import (
 )
 
 func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, cmd *cobra.Command, args []string) error {
+	if _, err := exec.LookPath("podman"); err != nil {
+		log.Fatal().Err(err).Msg("install podman before running this command")
+	}
+
 	// Find the SSH Socket and paths for the migration
 	sshAuthSocket := shared.GetSshAuthSocket()
 	sshConfigPath, sshKnownhostsPath := shared.GetSshPaths()

--- a/mgrpxy/cmd/install/kubernetes/utils.go
+++ b/mgrpxy/cmd/install/kubernetes/utils.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"os"
+	"os/exec"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -19,6 +20,12 @@ import (
 func installForKubernetes(globalFlags *types.GlobalFlags,
 	flags *kubernetesProxyInstallFlags, cmd *cobra.Command, args []string,
 ) error {
+	for _, binary := range []string{"kubectl", "helm"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			log.Fatal().Err(err).Msgf("install %s before running this command", binary)
+		}
+	}
+
 	// Unpack the tarball
 	configPath := utils.GetConfigPath(args)
 

--- a/mgrpxy/cmd/install/podman/utils.go
+++ b/mgrpxy/cmd/install/podman/utils.go
@@ -6,6 +6,7 @@ package podman
 
 import (
 	"os"
+	"os/exec"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -27,6 +28,10 @@ func startPod() {
 }
 
 func installForPodman(globalFlags *types.GlobalFlags, flags *podmanProxyInstallFlags, cmd *cobra.Command, args []string) error {
+	if _, err := exec.LookPath("podman"); err != nil {
+		log.Fatal().Err(err).Msgf("install podman before running this command")
+	}
+
 	configPath := utils.GetConfigPath(args)
 	if err := unpackConfig(configPath); err != nil {
 		log.Fatal().Err(err).Msgf("Failed to extract proxy config from %s file", configPath)

--- a/uyuni-tools.changes.cbosdonnat.tools-checks
+++ b/uyuni-tools.changes.cbosdonnat.tools-checks
@@ -1,0 +1,1 @@
+- Verify if podman, kubectl or helm are installed before using them


### PR DESCRIPTION
Check those tools to be available ahead of time helps providing more meaningful messages to the user in case of error.