### PR TITLE
Add a warning message for interactive shells

### DIFF
--- a/mgrctl/cmd/exec/exec.go
+++ b/mgrctl/cmd/exec/exec.go
@@ -63,6 +63,7 @@ func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, ar
 	envs = append(envs, flags.Envs...)
 	if flags.Interactive {
 		commandArgs = append(commandArgs, "-i")
+		envs = append(envs, "ENV=/etc/sh.shrc.local")
 	}
 	if flags.Tty {
 		commandArgs = append(commandArgs, "-t")

--- a/uyuni-tools.changes.cbosdonnat.motd
+++ b/uyuni-tools.changes.cbosdonnat.motd
@@ -1,0 +1,1 @@
+- Add a warning message for interactive shell


### PR DESCRIPTION
`sh` requires an `ENV` variable pointint to a script to run. Others shell can live with `/etc/sh.shrc.local`.