### PR TITLE
Use a TestMain func for utils tests setup/teardown

### DIFF
--- a/shared/utils/tar_test.go
+++ b/shared/utils/tar_test.go
@@ -11,111 +11,58 @@ import (
 	"testing"
 )
 
-const dataDir = "data"
-const outDir = "out"
-
-const file1_content = "file1 content"
-
-var filesData = map[string]string{
-	"file1":     file1_content,
-	"sub/file2": "file2 content",
-}
-
-// Prepare test files to include in the tarball.
-func setup(t *testing.T) (string, func(t *testing.T)) {
-	dir, err := os.MkdirTemp("", "uyuni-tools-test-")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory for test: %s", err)
-	}
-
-	// Create sub directories for the data and the test
-	for _, dirPath := range []string{dataDir, outDir} {
-		subDir := path.Join(dir, dirPath)
-		if err := os.Mkdir(subDir, 0700); err != nil {
-			t.Fatalf("failed to create %s directory: %s", dirPath, err)
-		}
-	}
-
-	// Add some content to the data directory
-	for name, content := range filesData {
-		filePath := path.Dir(name)
-		if filePath != "." {
-			absDir := path.Join(dir, dataDir, filePath)
-			if err := os.MkdirAll(absDir, 0700); err != nil {
-				t.Fatalf("failed to create subdirectory %s for test: %s", absDir, err)
-			}
-		}
-		if err := os.WriteFile(path.Join(dir, dataDir, name), []byte(content), 0700); err != nil {
-			t.Fatalf("failed to write test data file %s: %s", name, err)
-		}
-	}
-
-	// Returns the teardown function.
-	return dir, func(t *testing.T) {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("failed to clean test directory: %s", err)
-		}
-	}
-}
-
 func TestWriteTarGz(t *testing.T) {
-	tmpDir, teardown := setup(t)
-	defer teardown(t)
-
 	// Create the tarball
-	tarballPath := path.Join(tmpDir, "test.tar.gz")
+	tarballPath := path.Join(testDir, "test.tar.gz")
 	tarball, err := NewTarGz(tarballPath)
 	if err != nil {
 		t.Fatalf("failed to create tarball: %s", err)
 	}
-	if err := tarball.AddFile(path.Join(tmpDir, dataDir, "file1"), "otherfile1"); err != nil {
-		t.Fatalf("failed to add file1 to tarball: %s", err)
+	if err := tarball.AddFile(path.Join(testDir, dataDir, "tar_file1"), "tar_otherfile1"); err != nil {
+		t.Fatalf("failed to add tar_file1 to tarball: %s", err)
 	}
-	if err := tarball.AddFile(path.Join(tmpDir, dataDir, "sub/file2"), "sub/file2"); err != nil {
-		t.Fatalf("failed to add sub/file2 to tarball: %s", err)
+	if err := tarball.AddFile(path.Join(testDir, dataDir, "sub/tar_file2"), "sub/tar_file2"); err != nil {
+		t.Fatalf("failed to add sub/tar_file2 to tarball: %s", err)
 	}
 	tarball.Close()
 
 	// Check the tarball using the tar utility
-	testDir := path.Join(tmpDir, outDir)
+	testDir := path.Join(testDir, outDir)
 	if out, err := exec.Command("tar", "xzf", tarballPath, "-C", testDir).CombinedOutput(); err != nil {
 		t.Fatalf("failed to extract generated tarball: %s", string(out))
 	}
 
 	// Ensure we have all expected files
-	for _, file := range []string{"otherfile1", "sub/file2"} {
+	for _, file := range []string{"tar_otherfile1", "sub/tar_file2"} {
 		if !FileExists(path.Join(testDir, file)) {
 			t.Errorf("Missing %s in archive", file)
 		}
 	}
 
 	// Check the content of a file
-	if out, err := os.ReadFile(path.Join(testDir, "otherfile1")); err != nil {
-		t.Errorf("failed to read otherfile1: %s", err)
-	} else if string(out) != file1_content {
-		t.Errorf("expected otherfile1 content %s, but got %s", file1_content, string(out))
+	if out, err := os.ReadFile(path.Join(testDir, "tar_otherfile1")); err != nil {
+		t.Errorf("failed to read tar_otherfile1: %s", err)
+	} else if string(out) != tarFile1Content {
+		t.Errorf("expected tar_otherfile1 content %s, but got %s", tarFile1Content, string(out))
 	}
 }
 
 func TestExtractTarGz(t *testing.T) {
-	tmpDir, teardown := setup(t)
-	defer teardown(t)
-
 	// Create an archive using the tar tool
-	tarballPath := path.Join(tmpDir, "test.tar.gz")
-	dataPath := path.Join(tmpDir, dataDir)
+	tarballPath := path.Join(testDir, "test.tar.gz")
+	dataPath := path.Join(testDir, dataDir)
 	if out, err := exec.Command("tar", "czf", tarballPath, "-C", dataPath, ".").CombinedOutput(); err != nil {
 		t.Fatalf("failed to create test tar.gz: %s", string(out))
 	}
 
 	// Extract the tarball
-	testDir := path.Join(tmpDir, outDir)
+	testDir := path.Join(testDir, outDir)
 	if err := ExtractTarGz(tarballPath, testDir); err != nil {
 		t.Errorf("Failed to extract tar.gz: %s", err)
 	}
 
 	// Check the extracted content
-	for name, content := range filesData {
+	for name, content := range tarFilesData {
 		if out, err := os.ReadFile(path.Join(testDir, name)); err != nil {
 			t.Errorf("failed to read %s: %s", name, err)
 		} else if string(out) != content {

--- a/shared/utils/utils_main_test.go
+++ b/shared/utils/utils_main_test.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"testing"
+)
+
+// will hold the path to the testing directory for the utils package
+var testDir string
+
+const tmpDirPattern = "uyuni-tools-utils-test-"
+const dataDir = "data"
+const outDir = "out"
+
+const tarFile1Content = "file1 content"
+
+var tarFilesData = map[string]string{
+	"tar_file1":     tarFile1Content,
+	"sub/tar_file2": "file2 content",
+}
+
+func TestMain(m *testing.M) {
+	teardown := setup()
+	exitCode := m.Run()
+	teardown()
+	os.Exit(exitCode)
+}
+
+// Prepare test files and directories
+func setup() func() {
+	tmpDir, err := os.MkdirTemp("", tmpDirPattern)
+	if err != nil {
+		log.Fatalf("failed to create temporary directory for test: %s", err)
+	}
+	testDir = tmpDir
+
+	// Create sub directories for the data and the test
+	for _, dirPath := range []string{dataDir, outDir} {
+		subDir := path.Join(testDir, dirPath)
+		if err := os.Mkdir(subDir, 0700); err != nil {
+			log.Fatalf("failed to create %s directory: %s", dirPath, err)
+		}
+	}
+
+	if err := tarTestSetup(testDir); err != nil {
+		log.Fatalf("failed to setup tar test: %s", err)
+	}
+	// more setups if needed be
+
+	// return the teardown func
+	return func() {
+		if err := os.RemoveAll(testDir); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func tarTestSetup(dir string) error {
+	// Add some content to the data directory
+	for name, content := range tarFilesData {
+		filePath := path.Dir(name)
+		if filePath != "." {
+			absDir := path.Join(dir, dataDir, filePath)
+			if err := os.MkdirAll(absDir, 0700); err != nil {
+				return fmt.Errorf("failed to create subdirectory %s for tar test: %s", absDir, err)
+			}
+		}
+		if err := os.WriteFile(path.Join(dir, dataDir, name), []byte(content), 0700); err != nil {
+			return fmt.Errorf("failed to write tar test data file %s: %s", name, err)
+		}
+	}
+	return nil
+}

--- a/shared/utils/utils_main_test.go
+++ b/shared/utils/utils_main_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (


### PR DESCRIPTION
This PR is a proposal (and example of) aimed at moving the setup/teardown functions needed by the utils package tests to a dedicated file.
Using`testing.M` it will be possible to have a single setup function, running before  the package's tests, and a single teardown function , running after them.

This should make the setup/teardown of temporary directories and files needed by the tests in that package less prone to repetition as the testsuite grows.