### PR TITLE
FQDN optional in command install for podman

### DIFF
--- a/mgradm/cmd/install/podman/podman.go
+++ b/mgradm/cmd/install/podman/podman.go
@@ -28,7 +28,7 @@ The install podman command assumes podman is installed locally
 
 NOTE: for now installing on a remote podman is not supported!
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags podmanInstallFlags
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, installForPodman)

--- a/uyuni-tools.changes
+++ b/uyuni-tools.changes
@@ -1,3 +1,5 @@
+* FQDN optional in command install for podman
+
 -------------------------------------------------------------------
 Mon Jan 15 11:08:45 CET 2024 - marina.latini@suse.com
 


### PR DESCRIPTION
FQDN in podman install can be optional since we get the name from the hostname directly