### PR TITLE
force system list refresh on migrate

### DIFF
--- a/mgradm/shared/templates/pgsqlPostMigrationScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlPostMigrationScriptTemplate.go
@@ -38,6 +38,17 @@ UPDATE rhnKickstartableTree SET base_path = CONCAT('/srv/www/distributions/', ta
 DROP TABLE dist_map;
 EOT
 {{ end }}
+
+echo "Schedule a system list update task..."
+spacewalk-sql --select-mode - <<EOT
+insert into rhnTaskQueue (id, org_id, task_name, task_data)
+SELECT nextval('rhn_task_queue_id_seq'), 1, 'update_system_overview', s.id
+from rhnserver s
+where not exists (select 1 from rhntaskorun r join rhntaskotemplate t on r.template_id = t.id
+join rhntaskobunch b on t.bunch_id = b.id where b.name='update-system-overview-bunch' limit 1);
+EOT
+
+
 echo "Stopping Postgresql..."
 su -s /bin/bash - postgres -c "/usr/share/postgresql/postgresql-script stop"
 echo "DONE"

--- a/uyuni-tools.changes.rmateus.update_system_list
+++ b/uyuni-tools.changes.rmateus.update_system_list
@@ -1,0 +1,1 @@
+- Schedule a system list refresh after migrate if not runned before


### PR DESCRIPTION
Insert directly in the queue to update all the systems in the system list view in case we don't have run of the overall update task.
I have tested it locally in a migration from 4.3.10 to HEAD running in podman.