### PR TITLE
CI: Add Dependabot GitHub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:


### PR DESCRIPTION
## What does this PR change?

This will add checks from Dependabot to keep the [GitHub Actions](https://github.com/uyuni-project/uyuni-tools/tree/main/.github/workflows) up to date.

For example, Node 16 will be deprecated soon, so the used actions should be updated at some point.



## Links

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions
- https://github.com/uyuni-project/uyuni/blob/master/.github/dependabot.yml
- https://github.com/uyuni-project/sumaform/blob/master/.github/dependabot.yml
- https://github.com/SUSE/susemanager-ci/blob/master/.github/dependabot.yml
