### PR TITLE
ignore error on optional flag

### DIFF
--- a/mgrctl/cmd/cmd.go
+++ b/mgrctl/cmd/cmd.go
@@ -51,19 +51,14 @@ func NewUyunictlCommand() (*cobra.Command, error) {
 		}
 	}
 
-	apiCmd, err := api.NewCommand(globalFlags)
-	if err != nil {
-		//FIXME this should return err, but with it the code stop compiling
-		return rootCmd, nil
-	}
+	//FIXME this is currently return an err
+	apiCmd, _ := api.NewCommand(globalFlags)
 	rootCmd.AddCommand(apiCmd)
 	rootCmd.AddCommand(exec.NewCommand(globalFlags))
 	rootCmd.AddCommand(cp.NewCommand(globalFlags))
 	rootCmd.AddCommand(completion.NewCommand(globalFlags))
-	orgCmd, err := org.NewCommand(globalFlags)
-	if err != nil {
-		return rootCmd, err
-	}
+	//FIXME this is currently return an err
+	orgCmd, _ := org.NewCommand(globalFlags)
 	rootCmd.AddCommand(orgCmd)
 
 	return rootCmd, nil

--- a/uyuni-tools.changes.mbussolotto.mgrctl
+++ b/uyuni-tools.changes.mbussolotto.mgrctl
@@ -1,0 +1,1 @@
+- ignore error on optional flag


### PR DESCRIPTION
ignore error on optional flag. This should allow to continue compile `mgrctl`