### PR TITLE
Improve error handling when exec.Command is used

### DIFF
--- a/shared/connection.go
+++ b/shared/connection.go
@@ -178,16 +178,15 @@ func (c *Connection) WaitForServer() error {
 			args = append(args, "--")
 		}
 		args = append(args, "systemctl", "is-active", "-q", "multi-user.target")
-		testCmd := exec.Command(command, args...)
-		if err := testCmd.Run(); err != nil {
-			return fmt.Errorf("cannot wait for server: %s", err)
-		}
-		if testCmd.ProcessState.ExitCode() == 0 {
+		output := utils.RunCmd(command, args...)
+		isActive := output == nil
+
+		if isActive {
 			return nil
 		}
 		time.Sleep(1 * time.Second)
 	}
-	return errors.New("server didn't start within 60s")
+	return errors.New("server didn't start within 60s. Check for the service status")
 }
 
 // Copy transfers a file to or from the container.

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -73,11 +73,11 @@ func DeleteContainer(name string, dryRun bool) {
 // DeleteVolume deletes a podman volume based on its name.
 // If dryRun is set to true, nothing will be done, only messages logged to explain what would happen.
 func DeleteVolume(name string, dryRun bool) error {
-	cmd := exec.Command("podman", "volume", "exists", name)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cannot run delete volume: %s", err)
+	exists, err := isVolumePresent(name)
+	if exists && err != nil {
+		return fmt.Errorf("cannot check if volume %s already exists", name)
 	}
-	if cmd.ProcessState.ExitCode() == 0 {
+	if exists {
 		if dryRun {
 			log.Info().Msgf("Would run podman volume rm %s", name)
 		} else {
@@ -89,4 +89,12 @@ func DeleteVolume(name string, dryRun bool) error {
 		}
 	}
 	return nil
+}
+
+func isVolumePresent(volume string) (bool, error) {
+	cmd := exec.Command("podman", "volume", "exists", volume)
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+	return cmd.ProcessState.ExitCode() == 0, nil
 }

--- a/uyuni-tools.changes.mbussolotto.fix_network
+++ b/uyuni-tools.changes.mbussolotto.fix_network
@@ -1,0 +1,1 @@
+- Improve error handling when exec.Command is used


### PR DESCRIPTION
We run several bash command that does not provide any output but just a return code. In this case:
- we raise an error only if bash command exit status == 0
- we cannot distinguish between bash or golang error, so we cannot directly handle the error