### PR TITLE
Force installation of aardvark-dns if netavark is installed

### DIFF
--- a/uyuni-tools.changes.cbosdonnat.aardvark-dns
+++ b/uyuni-tools.changes.cbosdonnat.aardvark-dns
@@ -1,0 +1,1 @@
+- Install aardvark-dns if netavark is installed (bsc#1220371)

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -80,6 +80,9 @@ Tools for managing uyuni container.
 
 %package -n %{name_adm}
 Summary:        Command line tool to install and update %{productname}
+%if 0%{?suse_version}
+Requires:       (aardvark-dns if netavark)
+%endif
 
 %description -n %{name_adm}
 %{name_adm} is a convenient tool to install and update %{productname} components as containers running
@@ -87,6 +90,9 @@ either on Podman or a Kubernetes cluster.
 
 %package -n %{name_pxy}
 Summary:        Command line tool to install and update %{productname} proxy
+%if 0%{?suse_version}
+Requires:       (aardvark-dns if netavark)
+%endif
 
 %description -n %{name_pxy}
 %{name_pxy} is a convenient tool to install and update %{productname} proxy components as containers


### PR DESCRIPTION
## What does this PR change?

On SLE Micro 5.5, sometimes we have the netavark package installed but not the aardvark-dns one as it's only a recommends. Without it the server will have issues so force it.

## Test coverage
- No tests: RPM requires

- [X] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1220371

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

