### PR TITLE
Add data checks to user input

### DIFF
--- a/mgradm/cmd/install/shared/flags_test.go
+++ b/mgradm/cmd/install/shared/flags_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import "testing"
+
+func TestIdChecker(t *testing.T) {
+	data := map[string]bool{
+		"foo":       true,
+		"foo bar":   false,
+		"\u798f":    false,
+		"foo123._-": true,
+		"foo+":      false,
+		"foo&":      false,
+		"foo'":      false,
+		"foo\"":     false,
+		"foo`":      false,
+		"foo=":      false,
+		"foo#":      false,
+	}
+	for value, expected := range data {
+		actual := idChecker(value)
+		if actual != expected {
+			t.Errorf("%s: expected %v got %v", value, expected, actual)
+		}
+	}
+}
+
+func TestEmailChecker(t *testing.T) {
+	data := map[string]bool{
+		"root@localhost":           true,
+		"joe.hacker@foo.bar.com":   true,
+		"<joe.hacker@foo.bar.com>": false,
+		"fooo":                     false,
+	}
+	for value, expected := range data {
+		actual := emailChecker(value)
+		if actual != expected {
+			t.Errorf("%s: expected %v got %v", value, expected, actual)
+		}
+	}
+}

--- a/mgradm/shared/ssl/ssl.go
+++ b/mgradm/shared/ssl/ssl.go
@@ -253,7 +253,7 @@ func optionalFile(file string) {
 func GetRsaKey(keyPath string, password string) []byte {
 	// Kubernetes only handles RSA private TLS keys, convert and strip password
 	caPassword := password
-	utils.AskIfMissing(&caPassword, "Source server SSL CA private key password")
+	utils.AskPasswordIfMissing(&caPassword, "Source server SSL CA private key password", 0, 0)
 
 	// Convert the key file to RSA format for kubectl to handle it
 	cmd := exec.Command("openssl", "rsa", "-in", keyPath, "-passin", "env:pass")

--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -160,7 +160,7 @@ func Init(conn *ConnectionDetails) (*HTTPClient, error) {
 
 	if len(conn.User) > 0 {
 		if len(conn.Password) == 0 {
-			utils.AskPasswordIfMissing(&conn.Password, "API server password")
+			utils.AskPasswordIfMissing(&conn.Password, "API server password", 0, 0)
 		}
 		err = client.login(conn)
 	}


### PR DESCRIPTION
## What does this PR change?

Add length and content check to user input. Constraints extracted from https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd#L25

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23337

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

