### PR TITLE
Port 80 should be published to the port 80 of the containers

### DIFF
--- a/shared/utils/ports.go
+++ b/shared/utils/ports.go
@@ -55,5 +55,5 @@ var PROXY_TCP_PORTS = []types.PortMap{
 // PROXY_PODMAN_PORTS are the http/s ports required by the proxy.
 var PROXY_PODMAN_PORTS = []types.PortMap{
 	NewPortMap("https", 443, 443),
-	NewPortMap("http", 80, 8080),
+	NewPortMap("http", 80, 80),
 }

--- a/uyuni-tools.changes.oholecek.fix_http_portpublish
+++ b/uyuni-tools.changes.oholecek.fix_http_portpublish
@@ -1,0 +1,1 @@
+- Port 80 should be published to the port 80 of the containers. 8080 is squid


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Port 80 should be published to the port 80 of the containers. 8080 is squid and accessing it directly will return error.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

