### PR TITLE
Add command to register Peripheral server to Hub

### DIFF
--- a/mgradm/cmd/cmd.go
+++ b/mgradm/cmd/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/distro"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/hub"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/inspect"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/install"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/migrate"
@@ -73,6 +74,7 @@ func NewUyuniadmCommand() (*cobra.Command, error) {
 	rootCmd.AddCommand(completion.NewCommand(globalFlags))
 	rootCmd.AddCommand(support.NewCommand(globalFlags))
 	rootCmd.AddCommand(start.NewCommand(globalFlags))
+	rootCmd.AddCommand(hub.NewCommand(globalFlags))
 	rootCmd.AddCommand(restart.NewCommand(globalFlags))
 	rootCmd.AddCommand(stop.NewCommand(globalFlags))
 	rootCmd.AddCommand(inspect.NewCommand(globalFlags))

--- a/mgradm/cmd/hub/hub.go
+++ b/mgradm/cmd/hub/hub.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hub
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/hub/register"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+// NewCommand command for Hub management.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	hubCmd := &cobra.Command{
+		Use:     "hub",
+		Short:   "Hub management",
+		Long:    "Tools and utilities for Hub management",
+		Aliases: []string{"hub"},
+	}
+
+	hubCmd.SetUsageTemplate(hubCmd.UsageTemplate())
+	hubCmd.AddCommand(register.NewCommand(globalFlags))
+	return hubCmd
+}

--- a/mgradm/cmd/hub/register/register.go
+++ b/mgradm/cmd/hub/register/register.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package register
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type configFlags struct {
+	Backend           string
+	ConnectionDetails api.ConnectionDetails `mapstructure:"api"`
+}
+
+// NewCommand command for registering peripheral server to hub.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "register",
+		Long:  "Register this peripheral server to Hub API",
+		Args:  cobra.MaximumNArgs(0),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags configFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, register)
+		},
+	}
+	registerCmd.SetUsageTemplate(registerCmd.UsageTemplate())
+
+	if utils.KubernetesBuilt {
+		utils.AddBackendFlag(registerCmd)
+	}
+
+	if err := api.AddAPIFlags(registerCmd, false); err != nil {
+		return nil
+	}
+
+	return registerCmd
+}
+
+func register(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Command, args []string) error {
+	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
+	config, err := getRhnConfig(cnx)
+	if err != nil {
+		return err
+	}
+	err = registerToHub(config, &flags.ConnectionDetails)
+	return err
+}
+
+func getRhnConfig(cnx *shared.Connection) (map[string]string, error) {
+	out, err := cnx.Exec("/bin/cat", "/etc/rhn/rhn.conf")
+	if err != nil {
+		return nil, err
+	}
+	config := make(map[string]string)
+
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		log.Trace().Msgf("Config: %s", line)
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid line format: %s", line)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		config[key] = value
+	}
+
+	return config, nil
+}
+
+func registerToHub(config map[string]string, cnxDetails *api.ConnectionDetails) error {
+	for _, key := range []string{"java.hostname", "report_db_name", "report_db_port", "report_db_user", "report_db_password"} {
+		if _, ok := config[key]; !ok {
+			return fmt.Errorf("mandatory entry missing in config: %s", key)
+		}
+	}
+	log.Info().Msgf("Hub API server: %s", cnxDetails.Server)
+	client, err := api.Init(cnxDetails)
+	if err != nil {
+		return fmt.Errorf("failed to connect to the Hub server: %s", err)
+	}
+	data := map[string]interface{}{
+		"fqdn": config["java.hostname"],
+	}
+
+	ret, err := api.Post[int](client, "system/registerPeripheralServer", data)
+	if err != nil {
+		return fmt.Errorf("failed to register this peripheral server: %s", err)
+	}
+	if !ret.Success {
+		return fmt.Errorf("failed to register this peripheral server: %s", ret.Message)
+	}
+	id := ret.Result
+
+	data = map[string]interface{}{
+		"sid":              id,
+		"reportDbName":     config["report_db_name"],
+		"reportDbHost":     config["java.hostname"],
+		"reportDbPort":     config["report_db_port"],
+		"reportDbUser":     config["report_db_user"],
+		"reportDbPassword": config["report_db_password"],
+	}
+	ret, err = api.Post[int](client, "system/updatePeripheralServerInfo", data)
+	if err != nil {
+		return fmt.Errorf("failed to update peripheral server info: %s", err)
+	}
+
+	if !ret.Success {
+		return fmt.Errorf("failed to update peripheral server info: %s", ret.Message)
+	}
+	log.Info().Msgf("Registered peripheral server: %s, ID: %d", config["java.hostname"], id)
+	return nil
+}

--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -107,6 +107,7 @@ func (c *HTTPClient) sendRequest(req *http.Request) (*http.Response, error) {
 
 	res, err := c.Client.Do(req)
 	if err != nil {
+		log.Trace().Msgf("Request failed: %s", err)
 		return nil, err
 	}
 
@@ -224,6 +225,8 @@ func (c *HTTPClient) Post(path string, data map[string]interface{}) (*http.Respo
 		log.Error().Err(err).Msg("Unable to JSONify data")
 		return nil, err
 	}
+
+	log.Trace().Msg(string(jsonData))
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/uyuni-tools.changes.nadvornik.register
+++ b/uyuni-tools.changes.nadvornik.register
@@ -1,0 +1,1 @@
+- Add command to register Peripheral server to Hub


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR adds "register" command to mgradm. This commands registers this peripheral server to hub.
FQDN and report db  credentials are taken from rhn.conf.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/22498

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

