### PR TITLE
Remove shm size constraint on the server on podman

### DIFF
--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -30,6 +30,8 @@ ExecStart=/usr/bin/podman run \
 	--conmon-pidfile %t/uyuni-server.pid \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
+	--shm-size=0 \
+	--shm-size-systemd=0 \
 	--sdnotify=conmon \
 	-d \
 	--name {{ .NamePrefix }}-server \

--- a/uyuni-tools.changes.cbosdo.shm-size
+++ b/uyuni-tools.changes.cbosdo.shm-size
@@ -1,0 +1,1 @@
+- Remove shm size constraints on the server


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

podman limits the shm devices to 64MB by default. This sometimes leads to errors like the following:

```
org.postgresql.util.PSQLException: ERROR: could not resize shared memory segment "/PostgreSQL.3622072882" to 16777216 bytes: No space left on device
```

## Test coverage
- No tests: systemd generated files are not tested for now

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

