### PR TITLE
Don't assume any hostname for the cluster nodes

### DIFF
--- a/shared/kubernetes/kubernetes.go
+++ b/shared/kubernetes/kubernetes.go
@@ -47,15 +47,10 @@ func (infos ClusterInfos) GetKubeconfig() string {
 // CheckCluster return cluster information.
 func CheckCluster() (*ClusterInfos, error) {
 	// Get the kubelet version
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node hostname: %s", err)
-	}
-
 	out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "node",
-		"-o", "jsonpath={.status.nodeInfo.kubeletVersion}", hostname)
+		"-o", "jsonpath={.items[0].status.nodeInfo.kubeletVersion}")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubelet version for node %s: %s", hostname, err)
+		return nil, fmt.Errorf("failed to get kubelet version: %s", err)
 	}
 
 	var infos ClusterInfos

--- a/uyuni-tools.changes.cbosdo.kubelet-fix
+++ b/uyuni-tools.changes.cbosdo.kubelet-fix
@@ -1,0 +1,2 @@
+- Don't assume the current host is a cluster node when getting 
+  kubelet version


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When checking the kubelet version the tool should not rely on the executing host to be part of the cluster. Just use the kubelet of the first node in the cluster.

## Test coverage
- No tests: no clear way to mock functions to run for now

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

