### PR TITLE
Add monitoring ports

### DIFF
--- a/shared/utils/ports.go
+++ b/shared/utils/ports.go
@@ -25,6 +25,9 @@ var TCP_PORTS = []types.PortMap{
 	NewPortMap("psql-mtrx", 9187, 9187),
 	NewPortMap("tasko-jmx-mtrx", 5556, 5556),
 	NewPortMap("tomcat-jmx-mtrx", 5557, 5557),
+	// TODO: Replace Node exporter with cAdvisor
+	NewPortMap("node-exporter", 9100, 9100),
+	NewPortMap("tasko-mtrx", 9800, 9800),
 }
 
 // DEBUG_PORTS are the port used by dev for debugging applications.

--- a/uyuni-tools.changes.witek.monitoring_ports
+++ b/uyuni-tools.changes.witek.monitoring_ports
@@ -1,0 +1,2 @@
+- Add Node exporter (9100) and Taskomatic (9800) ports to the list
+  of open TCP ports


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Added ports for Node exporter (9100) and Taskomatic (9800) for exposing metrics.
Note: Node exporter should eventually get replaced by cAdvisor.


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] SUSE/spacewalk#23951

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

