### PR TITLE
Attach proxy pod to our podman network

### DIFF
--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -37,6 +37,7 @@ func GenerateSystemdService(httpdImage string, saltBrokerImage string, squidImag
 		Ports:         ports,
 		HttpProxyFile: httpProxyConfig,
 		Args:          strings.Join(podmanArgs, " "),
+		Network:       podman.UyuniNetwork,
 	}
 	if err := generateSystemdFile(dataPod, "pod"); err != nil {
 		return err
@@ -99,7 +100,7 @@ func generateSystemdFile(template utils.Template, service string) error {
 	const systemdPath = "/etc/systemd/system"
 	path := path.Join(systemdPath, name)
 	if err := utils.WriteTemplateToFile(template, path, 0644, true); err != nil {
-		return fmt.Errorf(L("failed to generate systemd file: %s"), path)
+		return fmt.Errorf(L("failed to generate systemd file %s: %s"), path, err)
 	}
 	return nil
 }

--- a/mgrpxy/shared/templates/pod.go
+++ b/mgrpxy/shared/templates/pod.go
@@ -30,6 +30,7 @@ ExecStartPre=/bin/rm -f %t/uyuni-proxy-pod.pid %t/uyuni-proxy-pod.pod-id
 
 ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid \
 		--pod-id-file %t/uyuni-proxy-pod.pod-id --name uyuni-proxy-pod \
+		--network {{ .Network }} \
         {{- range .Ports }}
         -p {{ .Exposed }}:{{ .Port }}{{ if .Protocol }}/{{ .Protocol }}{{ end }} \
         {{- end }}
@@ -52,6 +53,7 @@ type PodTemplateData struct {
 	Ports         []types.PortMap
 	HttpProxyFile string
 	Args          string
+	Network       string
 }
 
 // Render will create the systemd configuration file.

--- a/uyuni-tools.changes.oholecek.setup_proxy_pod_correct_net
+++ b/uyuni-tools.changes.oholecek.setup_proxy_pod_correct_net
@@ -1,0 +1,1 @@
+- Attach proxy pod to our podman network


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

We create our own podman network for proxy pods, but we were not attaching to it. This PR fixes it + some small improvements for error reporting and removing another Fatal encounters.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

