### PR TITLE
Fix: Minimal length of the admin password

### DIFF
--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -108,7 +108,7 @@ func (flags *InstallFlags) CheckParameters(cmd *cobra.Command, command string) {
 	utils.AskIfMissing(&flags.EmailFrom, cmd.Flag("emailfrom").Usage, 0, 0, emailChecker)
 
 	utils.AskIfMissing(&flags.Admin.Login, cmd.Flag("admin-login").Usage, 1, 64, idChecker)
-	utils.AskPasswordIfMissing(&flags.Admin.Password, cmd.Flag("admin-password").Usage, 1, 48)
+	utils.AskPasswordIfMissing(&flags.Admin.Password, cmd.Flag("admin-password").Usage, 5, 48)
 	utils.AskIfMissing(&flags.Admin.Email, cmd.Flag("admin-email").Usage, 1, 128, emailChecker)
 	utils.AskIfMissing(&flags.Organization, cmd.Flag("organization").Usage, 3, 128, nil)
 }

--- a/uyuni-tools.changes.nodeg.mgradm
+++ b/uyuni-tools.changes.nodeg.mgradm
@@ -1,0 +1,1 @@
+- Fix minimal administrator password length


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The administrator password must be at least 5 characters long.

```bash
localhost:~ # mgradm install podman
2:59PM INF Welcome to mgradm
2:59PM INF Executing command: podman
(...)
3:02PM INF Shutting down spacewalk services...
3:02PM INF Done.
3:03PM INF Starting spacewalk services...
3:03PM INF   Checking DB schema and running DB schema upgrade if needed. This may take a while.
  Call the following command to see progress: journalctl -f -u uyuni-check-database.service
3:03PM INF Done.
Error: Passwords must be at least 5 characters.
```

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

