### PR TITLE
Fixed migration of multiple autoinstallable distributions

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -61,8 +61,9 @@ sed -i -e 's|appBase="webapps"|appBase="/usr/share/susemanager/www/tomcat/webapp
 sed -i -e 's|DocumentRoot\s*"/srv/www/htdocs"|DocumentRoot "/usr/share/susemanager/www/htdocs"|' /etc/apache2/vhosts.d/vhost-ssl.conf
 
 echo "Migrating auto-installable distributions..."
+
 while IFS="," read -r target path ; do
-  if $SSH -A {{ .SourceFqdn }} test -e $path; then
+  if $SSH -n {{ .SourceFqdn }} test -e $path ; then
     echo "Copying distribution $target from $path"
     mkdir -p "/srv/www/distributions/$target"
     rsync -e "$SSH" --rsync-path='sudo rsync' -avz "{{ .SourceFqdn }}:$path/" "/srv/www/distributions/$target"

--- a/uyuni-tools.changes.nadvornik.distro-fix
+++ b/uyuni-tools.changes.nadvornik.distro-fix
@@ -1,0 +1,1 @@
+- Fixed migration of multiple autoinstallable distributions


### PR DESCRIPTION
## What does this PR change?

Parsing of  autoinstallable distributions list was broken because ssh read from stdin and consumed part of the list.
This PR calls ssh with `-n` to use /dev/null as stdin.
(the `-A` in the original code was redundant)

## Test coverage
- No tests: manual testing

## Links


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

