### PR TITLE
Enable SSSD authentication by default in containers: uyuni-tools changes

### DIFF
--- a/mgradm/shared/templates/postUpgradeScriptTemplate.go
+++ b/mgradm/shared/templates/postUpgradeScriptTemplate.go
@@ -19,6 +19,14 @@ else
 	sed 's/uyuni_authentication_endpoint.*/spacewalk_authentication_endpoint: http:\/\/localhost/' -i /etc/cobbler/settings.yaml;
 fi
 {{ end }}
+
+grep pam_auth_service /etc/rhn/rhn.conf
+if [ $? -eq 1 ]; then
+	echo 'pam_auth_service = susemanager' >> /etc/rhn/rhn.conf
+else
+	sed 's/pam_auth_service.*/pam_auth_service = susemanager/' -i /etc/rhn/rhn.conf;
+fi
+{{ end }}
 `
 
 // PostUpgradeTemplateData represents information used to create post upgrade.

--- a/shared/utils/volumes.go
+++ b/shared/utils/volumes.go
@@ -40,7 +40,7 @@ var EtcServerVolumeMounts = []types.VolumeMount{
 	{MountPath: "/etc/cobbler", Name: "etc-cobbler"},
 	{MountPath: "/etc/sysconfig", Name: "etc-sysconfig"},
 	{MountPath: "/etc/postfix", Name: "etc-postfix"},
-	{MountPath: "/etc/pam.d", Name: "etc-pam"},
+	{MountPath: "/etc/sssd", Name: "etc-sssd"},
 }
 
 // EtcServerVolumes represents volumes used for configuration.
@@ -54,7 +54,7 @@ var EtcServerVolumes = []types.Volume{
 	{Name: "etc-sysconfig", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-sysconfig"}},
 	{Name: "etc-postfix", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-postfix"}},
 	{Name: "etc-rhn", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-rhn"}},
-	{Name: "etc-pam", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-pam"}},
+	{Name: "etc-sssd", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-sssd"}},
 }
 
 var etcAndPgsqlVolumeMounts = append(PgsqlRequiredVolumeMounts, EtcServerVolumeMounts[:]...)

--- a/shared/utils/volumes.go
+++ b/shared/utils/volumes.go
@@ -40,9 +40,10 @@ var EtcServerVolumeMounts = []types.VolumeMount{
 	{MountPath: "/etc/cobbler", Name: "etc-cobbler"},
 	{MountPath: "/etc/sysconfig", Name: "etc-sysconfig"},
 	{MountPath: "/etc/postfix", Name: "etc-postfix"},
+	{MountPath: "/etc/pam.d", Name: "etc-pam"},
 }
 
-// EtcServerVolumeMounts represents volumes used for configuration.
+// EtcServerVolumes represents volumes used for configuration.
 var EtcServerVolumes = []types.Volume{
 	{Name: "etc-apache2", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-apache2"}},
 	{Name: "etc-systemd-multi", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-systemd-multi"}},
@@ -53,6 +54,7 @@ var EtcServerVolumes = []types.Volume{
 	{Name: "etc-sysconfig", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-sysconfig"}},
 	{Name: "etc-postfix", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-postfix"}},
 	{Name: "etc-rhn", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-rhn"}},
+	{Name: "etc-pam", PersistentVolumeClaim: &types.PersistentVolumeClaim{ClaimName: "etc-pam"}},
 }
 
 var etcAndPgsqlVolumeMounts = append(PgsqlRequiredVolumeMounts, EtcServerVolumeMounts[:]...)

--- a/uyuni-tools.changes.mbussolotto.pam
+++ b/uyuni-tools.changes.mbussolotto.pam
@@ -1,0 +1,1 @@
+- Allow PAM authentication

--- a/uyuni-tools.changes.mbussolotto.pam
+++ b/uyuni-tools.changes.mbussolotto.pam
@@ -1,1 +1,1 @@
-- Allow PAM authentication
+- Allow PAM and LDAP authentication using SSSD


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

- Enable SSSD authentication by default
- Persists `/etc/sssd` folder: all authentication mechanism should be configured using sssd

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22545

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

