### PR TITLE
Only colorize if the output is a terminal

### DIFF
--- a/shared/utils/logUtils.go
+++ b/shared/utils/logUtils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/term"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -24,7 +25,9 @@ func LogInit(logToConsole bool) {
 	fileWriter := getFileWriter()
 	writers := []io.Writer{fileWriter}
 	if logToConsole {
-		writers = append(writers, zerolog.NewConsoleWriter())
+		consoleWriter := zerolog.NewConsoleWriter()
+		consoleWriter.NoColor = !term.IsTerminal(int(os.Stdout.Fd()))
+		writers = append(writers, consoleWriter)
 	}
 
 	multi := zerolog.MultiLevelWriter(writers...)

--- a/uyuni-tools.changes.cbosdo.no-color
+++ b/uyuni-tools.changes.cbosdo.no-color
@@ -1,0 +1,1 @@
+- Only colorize output if outputting to a terminal


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This avoids getting ugly color codes in the files when redirecting the output.

## Test coverage
- No tests: requires a terminal

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

