### PR TITLE
Allow migration with non-root user on source server

### DIFF
--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -75,7 +75,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 
 	if err := install_shared.RunSetup(cnx, &flags.InstallFlags, args[0], envs); err != nil {
 		if stopErr := shared_kubernetes.Stop(shared_kubernetes.ServerFilter); stopErr != nil {
-			log.Error().Msgf("Failed to stop service: %v", stopErr)
+			log.Error().Msgf(L("Failed to stop service: %v"), stopErr)
 		}
 		return err
 	}

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -109,7 +109,7 @@ func installForPodman(
 
 	if err := install_shared.RunSetup(cnx, &flags.InstallFlags, fqdn, env); err != nil {
 		if stopErr := shared_podman.StopService(shared_podman.ServerService); stopErr != nil {
-			log.Error().Msgf("Failed to stop service: %v", stopErr)
+			log.Error().Msgf(L("Failed to stop service: %v"), stopErr)
 		}
 		return err
 	}

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -51,7 +51,7 @@ func migrateToKubernetes(
 	sshConfigPath, sshKnownhostsPath := migration_shared.GetSshPaths()
 
 	// Prepare the migration script and folder
-	scriptDir, err := adm_utils.GenerateMigrationScript(fqdn, true)
+	scriptDir, err := adm_utils.GenerateMigrationScript(fqdn, flags.User, true)
 	if err != nil {
 		return fmt.Errorf(L("failed to generate migration script: %s"), err)
 	}

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -34,7 +34,7 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 	sshAuthSocket := migration_shared.GetSshAuthSocket()
 	sshConfigPath, sshKnownhostsPath := migration_shared.GetSshPaths()
 
-	tz, oldPgVersion, newPgVersion, err := podman.RunMigration(serverImage, flags.Image.PullPolicy, sshAuthSocket, sshConfigPath, sshKnownhostsPath, sourceFqdn)
+	tz, oldPgVersion, newPgVersion, err := podman.RunMigration(serverImage, flags.Image.PullPolicy, sshAuthSocket, sshConfigPath, sshKnownhostsPath, sourceFqdn, flags.User)
 	if err != nil {
 		return fmt.Errorf(L("cannot run migration script: %s"), err)
 	}

--- a/mgradm/cmd/migrate/shared/flags.go
+++ b/mgradm/cmd/migrate/shared/flags.go
@@ -14,10 +14,12 @@ import (
 type MigrateFlags struct {
 	Image          types.ImageFlags `mapstructure:",squash"`
 	MigrationImage types.ImageFlags `mapstructure:"migration"`
+	User           string
 }
 
 // AddMigrateFlags add migration flags to a command.
 func AddMigrateFlags(cmd *cobra.Command) {
 	utils.AddImageFlag(cmd)
 	utils.AddMigrationImageFlag(cmd)
+	cmd.Flags().String("user", "root", "User on the source server. Non-root user must have passwordless sudo privileges (NOPASSWD tag in /etc/sudoers).")
 }

--- a/mgradm/cmd/migrate/shared/flags.go
+++ b/mgradm/cmd/migrate/shared/flags.go
@@ -7,6 +7,7 @@ package shared
 import (
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
@@ -21,5 +22,5 @@ type MigrateFlags struct {
 func AddMigrateFlags(cmd *cobra.Command) {
 	utils.AddImageFlag(cmd)
 	utils.AddMigrationImageFlag(cmd)
-	cmd.Flags().String("user", "root", "User on the source server. Non-root user must have passwordless sudo privileges (NOPASSWD tag in /etc/sudoers).")
+	cmd.Flags().String("user", "root", L("User on the source server. Non-root user must have passwordless sudo privileges (NOPASSWD tag in /etc/sudoers)."))
 }

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -158,8 +158,8 @@ func RunContainer(name string, image string, extraArgs []string, cmd []string) e
 }
 
 // RunMigration migrate an existing remote server to a container.
-func RunMigration(serverImage string, pullPolicy string, sshAuthSocket string, sshConfigPath string, sshKnownhostsPath string, sourceFqdn string) (string, string, string, error) {
-	scriptDir, err := adm_utils.GenerateMigrationScript(sourceFqdn, false)
+func RunMigration(serverImage string, pullPolicy string, sshAuthSocket string, sshConfigPath string, sshKnownhostsPath string, sourceFqdn string, user string) (string, string, string, error) {
+	scriptDir, err := adm_utils.GenerateMigrationScript(sourceFqdn, user, false)
 	if err != nil {
 		return "", "", "", fmt.Errorf(L("cannot generate migration script: %s"), err)
 	}

--- a/mgradm/shared/utils/exec.go
+++ b/mgradm/shared/utils/exec.go
@@ -152,7 +152,7 @@ func RunMigration(cnx *shared.Connection, tmpPath string, scriptName string) err
 }
 
 // GenerateMigrationScript generates the script that perform migration.
-func GenerateMigrationScript(sourceFqdn string, kubernetes bool) (string, error) {
+func GenerateMigrationScript(sourceFqdn string, user string, kubernetes bool) (string, error) {
 	scriptDir, err := os.MkdirTemp("", "mgradm-*")
 	if err != nil {
 		return "", fmt.Errorf(L("failed to create temporary directory: %s"), err)
@@ -161,6 +161,7 @@ func GenerateMigrationScript(sourceFqdn string, kubernetes bool) (string, error)
 	data := templates.MigrateScriptTemplateData{
 		Volumes:    utils.ServerVolumeMounts,
 		SourceFqdn: sourceFqdn,
+		User:       user,
 		Kubernetes: kubernetes,
 	}
 

--- a/uyuni-tools.changes.nadvornik.sudo
+++ b/uyuni-tools.changes.nadvornik.sudo
@@ -1,0 +1,1 @@
+- Allow migration with non-root user on source server


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR allows ssh to use non-root user during migration. The user must have configured passwordless sudo.
It also removes spinner in RunCmdStdMapping, because the spinner interferes with the output of the command
and makes it unreadable.

It does not handle sudo with password for the following reasons:
- sudo asks for password in each ssh connection, not just once
- I haven't found a way to enter the password when sudo is called from rsync and gets stdin from it
- the migration script is executed without stdin (this is easily fixable)


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24025

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

