### PR TITLE
add domain for internal container network

### DIFF
--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/podman run \
 	--sdnotify=conmon \
 	-d \
 	--name {{ .NamePrefix }}-server \
-	--hostname {{ .NamePrefix }}-server \
+	--hostname {{ .NamePrefix }}-server.mgr.internal \
 	{{ .Args }} \
 	{{- range .Ports }}
 	-p {{ .Exposed }}:{{ .Port }}{{if .Protocol}}/{{ .Protocol }}{{end}} \

--- a/uyuni-tools.changes.mc.add-domain-for-internal-network
+++ b/uyuni-tools.changes.mc.add-domain-for-internal-network
@@ -1,0 +1,1 @@
+- add domain for internal container network


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Configure a domain for the internal container network using `mgr.internal`

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23556

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

