### PR TITLE
Use podman mount instead of podman cp

### DIFF
--- a/uyuni-tools.changes.cbosdo.cp-rework
+++ b/uyuni-tools.changes.cbosdo.cp-rework
@@ -1,0 +1,1 @@
+- Use podman mount + cp instead of podman cp


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

podman cp seems to have some limitations. Using podman mount + cp + podman umount does the same thing but probably more reliably.

## Test coverage
- No tests: commands executed are not yet unit asserted

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

