### PR TITLE
podman-mount* flag should be used only on server installation

### DIFF
--- a/mgradm/cmd/migrate/podman/podman.go
+++ b/mgradm/cmd/migrate/podman/podman.go
@@ -41,7 +41,7 @@ NOTE: migrating to a remote podman is not supported yet!
 	}
 
 	shared.AddMigrateFlags(migrateCmd)
-	podman_utils.AddPodmanArgFlag(migrateCmd)
+	podman_utils.AddPodmanInstallFlag(migrateCmd)
 
 	return migrateCmd
 }

--- a/mgradm/cmd/migrate/podman/podman.go
+++ b/mgradm/cmd/migrate/podman/podman.go
@@ -41,7 +41,7 @@ NOTE: migrating to a remote podman is not supported yet!
 	}
 
 	shared.AddMigrateFlags(migrateCmd)
-	podman_utils.AddPodmanInstallFlag(migrateCmd)
+	podman_utils.AddPodmanArgFlag(migrateCmd)
 
 	return migrateCmd
 }

--- a/mgradm/cmd/upgrade/podman/podman.go
+++ b/mgradm/cmd/upgrade/podman/podman.go
@@ -53,7 +53,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	upgradeCmd.AddCommand(listCmd)
 
 	shared.AddUpgradeFlags(upgradeCmd)
-	podman.AddPodmanInstallFlag(upgradeCmd)
+	podman.AddPodmanArgFlag(upgradeCmd)
 
 	return upgradeCmd
 }

--- a/mgrpxy/cmd/install/podman/podman.go
+++ b/mgrpxy/cmd/install/podman/podman.go
@@ -40,7 +40,7 @@ NOTE: for now installing on a remote podman is not supported!
 	}
 
 	utils.AddInstallFlags(podmanCmd)
-	podman.AddPodmanInstallFlag(podmanCmd)
+	podman.AddPodmanArgFlag(podmanCmd)
 
 	return podmanCmd
 }

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -42,10 +42,14 @@ type PodmanMountFlags struct {
 	Spacewalk  string
 }
 
-// AddPodmanInstallFlag add the podman arguments to a command.
-func AddPodmanInstallFlag(cmd *cobra.Command) {
+// AddPodmanArgFlag add the podman arguments to a command.
+func AddPodmanArgFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("podman-arg", []string{}, L("Extra arguments to pass to podman"))
+}
 
+// AddPodmanInstallFlag add the podman install arguments to a command.
+func AddPodmanInstallFlag(cmd *cobra.Command) {
+	AddPodmanArgFlag(cmd)
 	cmd.Flags().String("podman-mount-cache", "", L("Path to custom /var/cache volume"))
 	cmd.Flags().String("podman-mount-postgresql", "", L("Path to custom /var/lib/pgsql volume"))
 	cmd.Flags().String("podman-mount-spacewalk", "", L("Path to custom /var/spacewalk volume"))

--- a/uyuni-tools.changes.mbussolotto.path_volume_flag
+++ b/uyuni-tools.changes.mbussolotto.path_volume_flag
@@ -1,1 +1,1 @@
-- podman-mount* flag should be used only on server installation
+- podman-mount* flag should be used only on server installation and migration

--- a/uyuni-tools.changes.mbussolotto.path_volume_flag
+++ b/uyuni-tools.changes.mbussolotto.path_volume_flag
@@ -1,0 +1,1 @@
+- podman-mount* flag should be used only on server installation


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

podman-mount* flag should be used only on server installation

## Test coverage
- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

