### PR TITLE
Pull policy default during upgrade

### DIFF
--- a/mgradm/cmd/upgrade/shared/flags.go
+++ b/mgradm/cmd/upgrade/shared/flags.go
@@ -18,11 +18,11 @@ type UpgradeFlags struct {
 
 // AddUpgradeFlags add upgrade flags to a command.
 func AddUpgradeFlags(cmd *cobra.Command) {
-	utils.AddImageFlag(cmd)
+	utils.AddImageUpgradeFlag(cmd)
 	utils.AddMigrationImageFlag(cmd)
 }
 
 // AddUpgradeListFlags add upgrade list flags to a command.
 func AddUpgradeListFlags(cmd *cobra.Command) {
-	utils.AddImageFlag(cmd)
+	utils.AddImageUpgradeFlag(cmd)
 }

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -64,7 +64,7 @@ func AddHelmInstallFlag(cmd *cobra.Command) {
 	cmd.Flags().String("helm-certmanager-values", "", L("Path to a values YAML file to use for cert-manager helm install"))
 }
 
-// AddimageFlag add Image flags to a command.
+// AddImageFlag add Image flags to a command.
 func AddImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("image", defaultImage, L("Image"))
 	cmd.Flags().String("tag", utils.DefaultTag, L("Tag Image"))
@@ -72,10 +72,18 @@ func AddImageFlag(cmd *cobra.Command) {
 	utils.AddPullPolicyFlag(cmd)
 }
 
+// AddImageUpgradeFlag add Image flags to an upgrade command, where pullPolicy default is always.
+func AddImageUpgradeFlag(cmd *cobra.Command) {
+	cmd.Flags().String("image", defaultImage, L("Image"))
+	cmd.Flags().String("tag", utils.DefaultTag, L("Tag Image"))
+	cmd.Flags().String("pullPolicy", "Always",
+		L("set whether to pull the images or not during upgrade. The value can be one of 'Never', 'IfNotPresent' or 'Always'"))
+}
+
 // AddMigrationImageFlag add Migration Image flags to a command.
 func AddMigrationImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("migration-image", "", L("Migration image"))
 	cmd.Flags().String("migration-tag", utils.DefaultTag, L("Migration image tag"))
 	cmd.Flags().String("migration-pullPolicy", "IfNotPresent",
-		L("set whether to pull the migrattion images or not. The value can be one of 'Never', 'IfNotPresent' or 'Always'"))
+		L("set whether to pull the migration images or not. The value can be one of 'Never', 'IfNotPresent' or 'Always'"))
 }

--- a/uyuni-tools.changes.mbussolotto.pull_policy_upgrade
+++ b/uyuni-tools.changes.mbussolotto.pull_policy_upgrade
@@ -1,0 +1,1 @@
+- change pull policy default to Always during upgrade


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Pull policy default during upgrade
- change pull policy default to Always during upgrade
- change pull policy default for migration image to Never during upgrade

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

