### PR TITLE
use LC_ALL=C to get same sort order everywhere

### DIFF
--- a/extract_strings
+++ b/extract_strings
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+export LC_ALL=C
 for MODULE in mgrctl mgradm mgrpxy shared; do
     # Generate the pot file
     echo "Generate locale/${MODULE}/${MODULE}.pot"


### PR DESCRIPTION
## What does this PR change?

try to get the same sort order by using LC_ALL=C when extracting translation strings

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

