### PR TITLE
Add `support sql` command

### DIFF
--- a/mgradm/cmd/support/sql/sql.go
+++ b/mgradm/cmd/support/sql/sql.go
@@ -7,6 +7,7 @@ package sql
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -104,6 +105,10 @@ func getBaseCommand(keepStdin bool, flags *configFlags, cnx *shared.Connection) 
 }
 
 func doSql(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Command, args []string) error {
+	if flags.Interactive && flags.OutputFile != "" {
+		return errors.New(L("interactive mode cannot work with a file output"))
+	}
+
 	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
 
 	// Validate options

--- a/mgradm/cmd/support/sql/sql.go
+++ b/mgradm/cmd/support/sql/sql.go
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sql
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func prepareSource(args []string, cnx *shared.Connection) (string, error) {
+	source := "-"
+	if len(args) > 0 {
+		source = args[0]
+		if !utils.FileExists(source) {
+			return "", fmt.Errorf(L("source %s does not exists"), source)
+		}
+		randBytes := make([]byte, 16)
+		if _, err := rand.Read(randBytes); err != nil {
+			return "", fmt.Errorf(L("unable to get random file prefix: %s"), err)
+		}
+		source = hex.EncodeToString(randBytes) + source
+		if err := cnx.Copy(args[0], "server:"+source, "", ""); err != nil {
+			return "", err
+		}
+	}
+	return source, nil
+}
+
+func cleanupSource(file string, cnx *shared.Connection) {
+	if _, err := cnx.Exec("rm", file); err != nil {
+		log.Error().Err(err).Msg(L("unable to cleanup source file"))
+	}
+}
+
+func prepareOutput(flags *configFlags) (string, error) {
+	output := "-"
+	if flags.OutputFile != "" {
+		output = flags.OutputFile
+		if utils.FileExists(output) && !flags.ForceOverwrite {
+			return "", fmt.Errorf(L("output file %s exists, use -f to force overwrite"), output)
+		}
+	}
+	return output, nil
+}
+
+func getBaseCommand(keepStdin bool, flags *configFlags, cnx *shared.Connection) (string, []string, error) {
+	podName, err := cnx.GetPodName()
+	if err != nil {
+		return "", nil, err
+	}
+
+	command, err := cnx.GetCommand()
+	if err != nil {
+		return "", nil, err
+	}
+
+	commandArgs := []string{"exec"}
+	envs := []string{}
+	if flags.Interactive {
+		commandArgs = append(commandArgs, "-i")
+		envs = append(envs, "ENV=/etc/sh.shrc.local")
+		commandArgs = append(commandArgs, "-t")
+		envs = append(envs, "TERM")
+	} else if keepStdin {
+		// To use STDIN source, we need to pass -i
+		commandArgs = append(commandArgs, "-i")
+	}
+	commandArgs = append(commandArgs, podName)
+
+	if command == "kubectl" {
+		commandArgs = append(commandArgs, "-c", "uyuni", "--")
+	}
+	newEnv := []string{}
+	for _, envValue := range envs {
+		if !strings.Contains(envValue, "=") {
+			if value, set := os.LookupEnv(envValue); set {
+				newEnv = append(newEnv, fmt.Sprintf("%s=%s", envValue, value))
+			}
+		} else {
+			newEnv = append(newEnv, envValue)
+		}
+	}
+	if len(newEnv) > 0 {
+		commandArgs = append(commandArgs, "env")
+		commandArgs = append(commandArgs, newEnv...)
+	}
+	return command, commandArgs, nil
+}
+
+func doSql(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Command, args []string) error {
+	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
+
+	// Validate options
+	source, err := prepareSource(args, cnx)
+	if err != nil {
+		return err
+	}
+	if source != "" && source != "-" {
+		defer cleanupSource(source, cnx)
+	}
+	output, err := prepareOutput(flags)
+	if err != nil {
+		return err
+	}
+
+	// For now do quick wrapper around spacewalk-sql tool.
+	// TODO - ideally use sql directly, but will need some gateway to be able to connect to the database
+	command, commandArgs, err := getBaseCommand(source == "-", flags, cnx)
+	if err != nil {
+		return err
+	}
+	commandArgs = append(commandArgs, "/usr/bin/spacewalk-sql")
+
+	sqlArgs := []string{}
+	if flags.Database == "reportdb" {
+		sqlArgs = append(sqlArgs, "--reportdb")
+	} else if flags.Database != "productdb" {
+		return fmt.Errorf(L("unknown or unsupported database %s"), flags.Database)
+	}
+
+	if flags.Interactive {
+		sqlArgs = append(sqlArgs, "-i")
+	} else {
+		sqlArgs = append(sqlArgs, "--select-mode", source)
+	}
+	commandArgs = append(commandArgs, sqlArgs...)
+
+	err = runCmd(command, output, commandArgs)
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Info().Err(err).Msg(L("Command failed"))
+			os.Exit(exitErr.ExitCode())
+		}
+	}
+	if output != "-" {
+		log.Info().Msgf(L("Result is stored in the file '%s'"), output)
+	}
+	return nil
+}
+
+type copyWriter struct {
+	Stream io.Writer
+}
+
+// Write writes an array of buffer in a stream.
+func (l copyWriter) Write(p []byte) (n int, err error) {
+	// Filter out kubectl line about terminated exit code
+	if !strings.HasPrefix(string(p), "command terminated with exit code") {
+		if _, err := l.Stream.Write(p); err != nil {
+			return 0, fmt.Errorf(L("cannot write: %s"), err)
+		}
+
+		n = len(p)
+		if n > 0 && p[n-1] == '\n' {
+			// Trim CR added by stdlog.
+			p = p[0 : n-1]
+		}
+		log.Debug().Msg(string(p))
+	}
+	return
+}
+
+func runCmd(command string, output string, args []string) error {
+	log.Info().Msgf(L("Running: %s %s"), command, strings.Join(args, " "))
+
+	runCmd := exec.Command(command, args...)
+	runCmd.Stdin = os.Stdin
+
+	if output == "" || output == "-" {
+		runCmd.Stdout = copyWriter{Stream: os.Stdout}
+	} else {
+		log.Trace().Msgf("Output is FILE %s", output)
+		f, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		runCmd.Stdout = copyWriter{Stream: f}
+	}
+	runCmd.Stderr = copyWriter{Stream: os.Stderr}
+
+	if err := runCmd.Start(); err != nil {
+		log.Debug().Err(err).Msg("error starting command")
+		return err
+	}
+
+	return runCmd.Wait()
+}

--- a/mgradm/cmd/support/sql/sql_cmd.go
+++ b/mgradm/cmd/support/sql/sql_cmd.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sql
+
+import (
+	"github.com/spf13/cobra"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type configFlags struct {
+	Database       string
+	Interactive    bool
+	ForceOverwrite bool   `mapstructure:"force"`
+	OutputFile     string `mapstructure:"output"`
+	Backend        string
+}
+
+// Add support sql command.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "sql [sql-file]",
+		Short: L("Execute SQL query"),
+		Long:  L(`Execute SQL query either provided in sql-file or passed through standard input`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags configFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, doSql)
+		},
+	}
+
+	configCmd.Flags().StringP("database", "d", "productdb", L("Target database, can be 'reportdb' or 'productdb'"))
+	configCmd.Flags().BoolP("interactive", "i", false, L("Start in interactive mode"))
+	configCmd.Flags().BoolP("force", "f", false, L("Force overwrite of output file if already exists"))
+	configCmd.Flags().StringP("output", "o", "", L("Write output to the file instead of standard output"))
+	utils.AddBackendFlag(configCmd)
+
+	return configCmd
+}

--- a/mgradm/cmd/support/sql/sql_cmd.go
+++ b/mgradm/cmd/support/sql/sql_cmd.go
@@ -24,7 +24,23 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "sql [sql-file]",
 		Short: L("Execute SQL query"),
-		Long:  L(`Execute SQL query either provided in sql-file or passed through standard input`),
+		Long: L(`Execute SQL query either provided in sql-file or passed through standard input.
+
+Examples:
+
+  Run the 'select hostname from rhnserver;' query using echo:
+
+  # echo 'select hostname from rhnserver;' | mgradm support sql
+
+  Run in interative mode:
+
+  # mgradm support sql -i
+
+  Running the SQL queries in example.sql file and output them to out.log file
+
+  # mgradm support sql example.sql -o out.log
+
+`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags configFlags
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, doSql)

--- a/mgradm/cmd/support/support.go
+++ b/mgradm/cmd/support/support.go
@@ -7,6 +7,7 @@ package support
 import (
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/support/config"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/support/sql"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
@@ -19,6 +20,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Long:  L("Commands for support operations"),
 	}
 	supportCmd.AddCommand(config.NewCommand(globalFlags))
+	supportCmd.AddCommand(sql.NewCommand(globalFlags))
 
 	return supportCmd
 }

--- a/uyuni-tools.changes.oholecek.support_sql_command
+++ b/uyuni-tools.changes.oholecek.support_sql_command
@@ -1,0 +1,1 @@
+- Add 'mgradm support sql' command


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR add `mgradm support sql` command. Usage is pretty similar to the `spacewalk-sql` but there is no need to append `--select-mode`, output is always printed to the stdout unless `-o file` is specified.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/245

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

