### PR TITLE
Fix build without ptf tag

### DIFF
--- a/mgrpxy/cmd/cmd.go
+++ b/mgrpxy/cmd/cmd.go
@@ -71,7 +71,9 @@ func NewUyuniproxyCommand() (*cobra.Command, error) {
 	}
 
 	rootCmd.AddCommand(utils.GetConfigHelpCommand())
-	rootCmd.AddCommand(support.NewCommand(globalFlags))
+	if cmd := support.NewCommand(globalFlags); cmd != nil {
+		rootCmd.AddCommand(cmd)
+	}
 
 	return rootCmd, nil
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

fix `./build.sh` segfault:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5fbd3f]

goroutine 1 [running]:
github.com/spf13/cobra.(*Command).AddCommand(0xc00016d400, {0xc000167e98, 0x1, 0x786e88?})
	/home/cbosdo/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:1135 +0x5f
github.com/uyuni-project/uyuni-tools/mgrpxy/cmd.NewUyuniproxyCommand()
	/public/src/uyuni-tools/mgrpxy/cmd/cmd.go:74 +0x656
main.Run()
	/public/src/uyuni-tools/mgrpxy/main.go:19 +0xea
main.main()
	/public/src/uyuni-tools/mgrpxy/main.go:27 +0x13
```

## Test coverage
- No tests: build issue

- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

