### PR TITLE
Fix -no-pager in mgradm status

### DIFF
--- a/mgradm/cmd/status/podman.go
+++ b/mgradm/cmd/status/podman.go
@@ -25,7 +25,7 @@ func podmanStatus(
 ) error {
 	// Show the status and that's it if the service is not running
 	if !podman.IsServiceRunning(podman.ServerService) {
-		if err := utils.RunCmdStdMapping(zerolog.DebugLevel, "systemctl", "status", "-no-pager", podman.ServerService); err != nil {
+		if err := utils.RunCmdStdMapping(zerolog.DebugLevel, "systemctl", "status", "--no-pager", podman.ServerService); err != nil {
 			return fmt.Errorf(L("failed to get status of the server service: %s"), err)
 		}
 		return nil


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fixes
```
suma-head-srv:~ # mgradm status
3:47PM INF Welcome to mgradm
3:47PM INF Executing command: status
Failed to parse lines 'o-pager'
Error: failed to get status of the server service: exit status 1
```

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

