### PR TITLE
Avoid missing whitespace between podman common and custom args

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -71,10 +71,12 @@ func GenerateSystemdService(tz string, image string, debug bool, podmanArgs []st
 	}
 
 	log.Info().Msg(L("Enabling system service"))
+	args := append(podman.GetCommonParams(), podmanArgs...)
+
 	data := templates.PodmanServiceTemplateData{
 		Volumes:    utils.ServerVolumeMounts,
 		NamePrefix: "uyuni",
-		Args:       strings.Join(podman.GetCommonParams(), " ") + strings.Join(podmanArgs, " "),
+		Args:       strings.Join(args, " "),
 		Ports:      GetExposedPorts(debug),
 		Timezone:   tz,
 		Network:    podman.UyuniNetwork,

--- a/uyuni-tools.changes.cbosdo.whitespace-fix
+++ b/uyuni-tools.changes.cbosdo.whitespace-fix
@@ -1,0 +1,2 @@
+- Add missing whitespace between podman common arguments and
+  additional ones


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Concatenate all parameters before joining them into a string avoids having to deal with additional whitespace.
This is another attempt at fixing the issue mention in pull request #277.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

