### PR TITLE
Print the URL and the admin user at the end of the setup

### DIFF
--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -50,7 +50,7 @@ func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[
 		}
 	}
 
-	log.Info().Msg(L("Server set up"))
+	log.Info().Msgf(L("Server set up, login on https://%[1]s with %[2]s user"), fqdn, flags.Admin.Login)
 	return nil
 }
 

--- a/uyuni-tools.changes.cbosdo.setup-message
+++ b/uyuni-tools.changes.cbosdo.setup-message
@@ -1,0 +1,1 @@
+- Add URL and admin username in the setup final message


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Users not reading the help wouldn't know the default admin username, print it and the FQDN in the setup end message.

## Test coverage
- No tests: message output

- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

