### PR TITLE
Disable locale environement variables when running SUSEConnect

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -44,7 +44,7 @@ var inspectValues = []types.InspectData{
 	types.NewInspectData("fqdn", "cat /etc/rhn/rhn.conf 2>/dev/null | grep 'java.hostname' | cut -d' ' -f3 || true"),
 	types.NewInspectData("image_pg_version", "rpm -qa --qf '%{VERSION}\\n' 'name=postgresql[0-8][0-9]-server'  | cut -d. -f1 | sort -n | tail -1 || true"),
 	types.NewInspectData("current_pg_version", "(test -e /var/lib/pgsql/data/PG_VERSION && cat /var/lib/pgsql/data/PG_VERSION) || true"),
-	types.NewInspectData("registration_info", "transactional-update --quiet register --status 2>/dev/null || true"),
+	types.NewInspectData("registration_info", "env LC_ALL=C LC_MESSAGES=C LANG=C transactional-update --quiet register --status 2>/dev/null || true"),
 	types.NewInspectData("scc_username", "cat /etc/zypp/credentials.d/SCCcredentials 2>&1 /dev/null | grep username | cut -d= -f2 || true"),
 	types.NewInspectData("scc_password", "cat /etc/zypp/credentials.d/SCCcredentials 2>&1 /dev/null | grep password | cut -d= -f2 || true"),
 }

--- a/uyuni-tools.changes.cbosdo.inspect-fix
+++ b/uyuni-tools.changes.cbosdo.inspect-fix
@@ -1,0 +1,2 @@
+- Disable all locales when running SUSEConnect register -s 
+  (bsc#1223483)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

SUSEConnect is sensible to locale setting. If the locale is propagated using SSH from a remote machine it may not be available on the server. Setting all locale variables to C ensures we have consistent output.

## Test coverage
- No tests: no tests of the inspect script yet

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24211

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

