### PR TITLE
Call cloudguestregistryauth before upgrade

### DIFF
--- a/uyuni-tools.changes.nadvornik.cloudguestregistryauth
+++ b/uyuni-tools.changes.nadvornik.cloudguestregistryauth
@@ -1,0 +1,1 @@
+- Call cloudguestregistryauth before upgrade


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR calls cloudguestregistryauth binary before upgrade, as long as it is installed.


## Test coverage
- No tests

- [ ] **DONE**

## Links

https://github.com/uyuni-project/uyuni-tools/issues/272

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

