### PR TITLE
configure the database to provide enough connections for our default setup

### DIFF
--- a/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
@@ -14,7 +14,7 @@ set -e
 
 {{ if .RunAutotune }}
 echo "Running smdba system-check autotuning..."
-smdba system-check autotuning
+smdba system-check autotuning --max_connections=400
 {{ end }}
 echo "Starting Postgresql..."
 su -s /bin/bash - postgres -c "/usr/share/postgresql/postgresql-script start"

--- a/uyuni-tools.changes.mc.fix-default-db-connections
+++ b/uyuni-tools.changes.mc.fix-default-db-connections
@@ -1,0 +1,1 @@
+- configure the database to provide enough connections for our default setup


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

In the container we have already the default postgresql.conf file with the default configuration of 100 connections.
smdba autotuning works this was:
1. use the value provided as parameter on the command line
2. use the configured value from the current config (this match here and 100 is used)
3. use the internal default of 400

But internally smdba has a minimal connections of "200". As 100 is not high enough, smdba configure 200 in the container.

As the minimal required connections in our SUMA/Uyuni default setup is 386, we configure it now with 400.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

