### PR TITLE
check_localizable exclude vendor dir

### DIFF
--- a/check_localizable
+++ b/check_localizable
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 res=0
-grep -r . --include '*.go' --exclude '*_test.go' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
     -e 'fmt\.Errorf("[^"]\+"' \
     -e 'errors.New("[^"]\+"' \
     -e '\(Fatal\|Error\|Info\|Warn\)()\(\.Err(err)\)\?\.Msgf\?("' \
@@ -17,7 +17,7 @@ if test $? -eq 0; then
     res=1
 fi
 
-grep -r . --include '*.go' --exclude '*_test.go' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
     -e '\(Trace\|Debug\)()\(\.Err(err)\)\?\.Msgf\?(P\?N\?L("' \
 
 if test $? -eq 0; then
@@ -25,7 +25,7 @@ if test $? -eq 0; then
     res=1
 fi
 
-grep -r . --include '*.go' --exclude '*_test.go' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
     -e '\(Short\|Long\): \+P\?N\?L(["`][a-z]'
 if test $? -eq 0; then
     echo -e "Short and Long messages shouldn't start with a lowercase letter\n"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

`go mod vendor` command can be used to download golang dependencies in `vendor` folder (e.g. `devcontainer`). We want to exclude this folder from `check_localizable`

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

