### PR TITLE
trim string before compare it

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -207,7 +207,7 @@ func ReadFile(file string) []byte {
 // Get the value of a file containing a boolean.
 // This is handy for files from the kernel API.
 func GetFileBoolean(file string) bool {
-	return string(ReadFile(file)) != "0"
+	return strings.TrimSpace(string(ReadFile(file))) != "0"
 }
 
 // Uninstalls a file.

--- a/uyuni-tools.changes.mcalmer.fix-ipv6-detection
+++ b/uyuni-tools.changes.mcalmer.fix-ipv6-detection
@@ -1,0 +1,1 @@
+- fix IPv6 enabled detection (bsc#1224080)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When reading from file, we need to trim the string before we can compare it.
This will fix the IPv6 enabled detection

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

