### PR TITLE
Require netavark network backend for podman

### DIFF
--- a/uyuni-tools.changes.oholecek.use_netavark
+++ b/uyuni-tools.changes.oholecek.use_netavark
@@ -1,0 +1,2 @@
+- Require netavark network backend for podman
+  (bsc#1224081)

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -98,7 +98,8 @@ Tools for managing uyuni container.
 %package -n %{name_adm}
 Summary:        Command line tool to install and update %{productname}
 %if 0%{?suse_version}
-Requires:       (aardvark-dns if netavark)
+Requires:       (aardvark-dns if podman)
+Requires:       (netavark if podman)
 %endif
 # 0%{?suse_version}
 %if "%{_vendor}" != "debbuild"
@@ -113,7 +114,8 @@ either on Podman or a Kubernetes cluster.
 Summary:        Command line tool to install and update %{productname} proxy
 Obsoletes:      uyuni-proxy-systemd-services
 %if 0%{?suse_version}
-Requires:       (aardvark-dns if netavark)
+Requires:       (netavark if podman)
+Requires:       (aardvark-dns if podman)
 %endif
 # 0%{?suse_version}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

We have two options for podman network backend on SLEM5.5 - legacy CNI and Netavark. CNI is on a way out and to prevent further confusion we opted to go with Netavark. Netavark will also be only upstream supported option for podman 5.

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24302

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

