### PR TITLE
Do not enable dns plugin for proxy podman network

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -67,7 +67,7 @@ Environment=database_password=%s
 
 // GenerateSystemdService creates a serverY systemd file.
 func GenerateSystemdService(tz string, image string, debug bool, podmanArgs []string) error {
-	if err := podman.SetupNetwork(); err != nil {
+	if err := podman.SetupNetwork(false); err != nil {
 		return utils.Errorf(err, L("cannot setup network"))
 	}
 

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -30,7 +30,7 @@ type PodmanProxyUpgradeFlags struct {
 // GenerateSystemdService generates all the systemd files required by proxy.
 func GenerateSystemdService(httpdImage string, saltBrokerImage string, squidImage string, sshImage string,
 	tftpdImage string, podmanArgs []string) error {
-	if err := podman.SetupNetwork(); err != nil {
+	if err := podman.SetupNetwork(true); err != nil {
 		return shared_utils.Errorf(err, L("cannot setup network"))
 	}
 

--- a/shared/podman/network.go
+++ b/shared/podman/network.go
@@ -44,7 +44,8 @@ func SetupNetwork() error {
 		}
 	}
 
-	args := []string{"network", "create"}
+	// We do not need inter-container resolution, disable dns plugin
+	args := []string{"network", "create", "--disable-dns"}
 	if ipv6Enabled {
 		// An IPv6 network on a host where IPv6 is disabled doesn't work: don't try it.
 		// Check if the networkd backend is netavark

--- a/shared/podman/network.go
+++ b/shared/podman/network.go
@@ -18,7 +18,7 @@ import (
 const UyuniNetwork = "uyuni"
 
 // SetupNetwork creates the podman network.
-func SetupNetwork() error {
+func SetupNetwork(isProxy bool) error {
 	log.Info().Msgf(L("Setting up %s network"), UyuniNetwork)
 
 	ipv6Enabled := isIpv6Enabled()
@@ -45,7 +45,10 @@ func SetupNetwork() error {
 	}
 
 	// We do not need inter-container resolution, disable dns plugin
-	args := []string{"network", "create", "--disable-dns"}
+	args := []string{"network", "create"}
+	if isProxy {
+		args = append(args, "--disable-dns")
+	}
 	if ipv6Enabled {
 		// An IPv6 network on a host where IPv6 is disabled doesn't work: don't try it.
 		// Check if the networkd backend is netavark

--- a/uyuni-tools.changes.oholecek.no-dns-in-uyuni-net
+++ b/uyuni-tools.changes.oholecek.no-dns-in-uyuni-net
@@ -1,0 +1,1 @@
+- Do not include dns plugin in proxy uyuni net (bsc#1224127)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

We do not need inter-container hostname desolution for proxy as we just use localhost in the pod. This also fixed currently broken aardvark behavior.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24305

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

