### PR TITLE
Fix colors disabling in non-interactive runs

### DIFF
--- a/shared/utils/logUtils.go
+++ b/shared/utils/logUtils.go
@@ -76,10 +76,10 @@ func LogInit(logToConsole bool) {
 	writers := []io.Writer{fileWriter}
 	if logToConsole {
 		consoleWriter := zerolog.NewConsoleWriter()
+		consoleWriter.NoColor = !term.IsTerminal(int(os.Stdout.Fd()))
 		uyuniConsoleWriter := UyuniConsoleWriter{
 			consoleWriter: consoleWriter,
 		}
-		consoleWriter.NoColor = !term.IsTerminal(int(os.Stdout.Fd()))
 		writers = append(writers, uyuniConsoleWriter)
 	}
 

--- a/uyuni-tools.changes.cbosdo.main
+++ b/uyuni-tools.changes.cbosdo.main
@@ -1,0 +1,1 @@
+- Fix colors disabling in non-interactive runs


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The `NoColor` has to be set before assigning the consoleWriter.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

