### PR TITLE
Prepare setup for CSP billing

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -74,11 +74,17 @@ func GenerateSystemdService(tz string, image string, debug bool, podmanArgs []st
 	log.Info().Msg(L("Enabling system service"))
 	args := append(podman.GetCommonParams(), podmanArgs...)
 
+	ports := GetExposedPorts(debug)
+	if _, err := exec.LookPath("csp-billing-adapter"); err == nil {
+		ports = append(ports, utils.NewPortMap("csp-billing", 10888, 10888))
+		args = append(args, "-e ISPAYG=1")
+	}
+
 	data := templates.PodmanServiceTemplateData{
 		Volumes:    utils.ServerVolumeMounts,
 		NamePrefix: "uyuni",
 		Args:       strings.Join(args, " "),
-		Ports:      GetExposedPorts(debug),
+		Ports:      ports,
 		Timezone:   tz,
 		Network:    podman.UyuniNetwork,
 	}

--- a/uyuni-tools.changes.cbosdo.main
+++ b/uyuni-tools.changes.cbosdo.main
@@ -1,1 +1,2 @@
+- Add parameters for the cloud service providers billing
 - Fix colors disabling in non-interactive runs


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

If csp-billing-adapter is found in the `PATH`, then set the `ISPAYG` variable to `1` and expose the 10888 port.

## Test coverage
- No tests: too hard to test without heavy refactoring

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24287

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

