### PR TITLE
supportconfig file name with date to avoid conflicts

### DIFF
--- a/mgradm/cmd/support/config/config.go
+++ b/mgradm/cmd/support/config/config.go
@@ -29,7 +29,7 @@ the containers for support to help debugging.`),
 		},
 	}
 
-	configCmd.Flags().StringP("output", "o", "supportconfig.tar.gz", L("path where to extract the data"))
+	configCmd.Flags().StringP("output", "o", ".", L("path where to extract the data"))
 	utils.AddBackendFlag(configCmd)
 
 	return configCmd

--- a/mgradm/cmd/support/config/extractor.go
+++ b/mgradm/cmd/support/config/extractor.go
@@ -90,7 +90,7 @@ func extract(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Comm
 	log.Info().Msg(L("Preparing the tarball"))
 
 	supportFileName := getSupportConfigFileSaveName()
-	supportFilePath := fmt.Sprintf("%s/%s", flags.Output, supportFileName)
+	supportFilePath := fmt.Sprintf("%s/%s.tar.gz", flags.Output, supportFileName)
 
 	tarball, err := utils.NewTarGz(supportFilePath)
 	if err != nil {
@@ -98,7 +98,7 @@ func extract(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Comm
 	}
 
 	for _, file := range files {
-		if err := tarball.AddFile(file, path.Base(file)); err != nil {
+		if err := tarball.AddFile(file, fmt.Sprintf("%s/%s", supportFileName, path.Base(file))); err != nil {
 			return utils.Errorf(err, L("failed to add %s to tarball"), path.Base(file))
 		}
 	}
@@ -112,23 +112,13 @@ func getSupportConfigPath(out []byte) string {
 	return re.FindString(string(out))
 }
 
-func getHostname() string {
-	hostname_b, err := utils.RunCmdOutput(zerolog.DebugLevel, "hostname")
-	if err != nil {
-		log.Warn().Err(err).Msg(L("Unable to detect hostname, using localhost"))
-		return "localhost"
-	}
-	return strings.TrimSpace(string(hostname_b))
-}
-
 func getSupportConfigFileSaveName() string {
 	hostname_b, err := utils.RunCmdOutput(zerolog.DebugLevel, "hostname")
 	hostname := "localhost"
 	if err != nil {
 		log.Warn().Err(err).Msg(L("Unable to detect hostname, using localhost"))
-
+		hostname = strings.TrimSpace(string(hostname_b))
 	}
-	hostname = strings.TrimSpace(string(hostname_b))
 	now := time.Now()
-	return fmt.Sprintf("scc_%s_%s.tar.gz", hostname, now.Format("20060102_1504"))
+	return fmt.Sprintf("scc_%s_%s", hostname, now.Format("20060102_1504"))
 }

--- a/mgradm/cmd/support/config/extractor.go
+++ b/mgradm/cmd/support/config/extractor.go
@@ -90,7 +90,7 @@ func extract(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Comm
 	log.Info().Msg(L("Preparing the tarball"))
 
 	supportFileName := getSupportConfigFileSaveName()
-	supportFilePath := fmt.Sprintf("%s/%s.tar.gz", flags.Output, supportFileName)
+	supportFilePath := path.Join(flags.Output, fmt.Sprintf("%s.tar.gz", supportFileName))
 
 	tarball, err := utils.NewTarGz(supportFilePath)
 	if err != nil {
@@ -98,7 +98,7 @@ func extract(globalFlags *types.GlobalFlags, flags *configFlags, cmd *cobra.Comm
 	}
 
 	for _, file := range files {
-		if err := tarball.AddFile(file, fmt.Sprintf("%s/%s", supportFileName, path.Base(file))); err != nil {
+		if err := tarball.AddFile(file, path.Join(supportFileName, path.Base(file))); err != nil {
 			return utils.Errorf(err, L("failed to add %s to tarball"), path.Base(file))
 		}
 	}

--- a/uyuni-tools.changes.rmateus.supportconfig_filename
+++ b/uyuni-tools.changes.rmateus.supportconfig_filename
@@ -1,0 +1,1 @@
+- supportconfig file name with date to avoid conflicts


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Implements: https://github.com/uyuni-project/uyuni-tools/issues/318

Change the behavior of -o flag to define the path and not the filename. 
Supportconfig filename contains the hostname and data, to avoid conflicts and identify the machine.

TODO: we need to change the way the tar file is made, and save all files in a directory, to avoid conflicts when exported by supports.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/318

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

