### PR TITLE
compute attestation image name from base image when not specified

### DIFF
--- a/mgradm/shared/coco/coco.go
+++ b/mgradm/shared/coco/coco.go
@@ -28,7 +28,10 @@ func SetupCocoContainer(replicas int, image types.ImageFlags, baseImage types.Im
 	}
 	cocoImage, err := utils.ComputeImage(image.Name, tag)
 	if err != nil {
-		return utils.Errorf(err, L("failed to compute image URL"))
+		cocoImage, err = utils.ComputeImage(baseImage.Name, tag, "-attestation")
+		if err != nil {
+			return utils.Errorf(err, L("failed to compute image URL"))
+		}
 	}
 
 	attestationData := templates.AttestationServiceTemplateData{

--- a/uyuni-tools.changes.mcalmer.guess-attestation-image-name
+++ b/uyuni-tools.changes.mcalmer.guess-attestation-image-name
@@ -1,0 +1,1 @@
+- compute attestation image name from base image when not specified


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The coco attestation image does not have a default.
When the name is not explicitly set, compute it based on the name of the base image.

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

