### PR TITLE
Add mgrpxy logs command

### DIFF
--- a/mgrpxy/cmd/cmd.go
+++ b/mgrpxy/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgrpxy/cmd/install"
+	"github.com/uyuni-project/uyuni-tools/mgrpxy/cmd/logs"
 	"github.com/uyuni-project/uyuni-tools/mgrpxy/cmd/restart"
 	"github.com/uyuni-project/uyuni-tools/mgrpxy/cmd/start"
 	"github.com/uyuni-project/uyuni-tools/mgrpxy/cmd/status"
@@ -43,7 +44,7 @@ func NewUyuniproxyCommand() (*cobra.Command, error) {
 		utils.SetLogLevel(globalFlags.LogLevel)
 
 		// do not log if running the completion cmd as the output is redirected to create a file to source
-		if cmd.Name() != "completion" {
+		if cmd.Name() != "completion" && cmd.Name() != "__complete" {
 			log.Info().Msgf(L("Welcome to %s"), name)
 			log.Info().Msgf(L("Executing command: %s"), cmd.Name())
 		}
@@ -65,6 +66,7 @@ func NewUyuniproxyCommand() (*cobra.Command, error) {
 	rootCmd.AddCommand(stop.NewCommand(globalFlags))
 	rootCmd.AddCommand(restart.NewCommand(globalFlags))
 	rootCmd.AddCommand(upgrade.NewCommand(globalFlags))
+	rootCmd.AddCommand(logs.NewCommand(globalFlags))
 
 	if supportCommand := support.NewCommand(globalFlags); supportCommand != nil {
 		rootCmd.AddCommand(supportCommand)

--- a/mgrpxy/cmd/logs/kubernetes.go
+++ b/mgrpxy/cmd/logs/kubernetes.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func kubernetesLogs(
+	globalFlags *types.GlobalFlags,
+	flags *logsFlags,
+	cmd *cobra.Command,
+	args []string,
+) error {
+	commandArgs := []string{"logs"}
+	if flags.Follow {
+		commandArgs = append(commandArgs, "-f")
+	}
+
+	if flags.Tail != -1 {
+		commandArgs = append(commandArgs, "--tail="+fmt.Sprintf("%d", flags.Tail))
+	}
+
+	if flags.Timestamps {
+		commandArgs = append(commandArgs, "--timestamps")
+	}
+
+	if flags.Since != "" {
+		if isRFC3339(flags.Since) {
+			commandArgs = append(commandArgs, fmt.Sprintf("--since-time=%s", flags.Since))
+		} else {
+			commandArgs = append(commandArgs, fmt.Sprintf("--since=%s", flags.Since))
+		}
+	}
+
+	if len(flags.Containers) == 0 {
+		cnx := shared.NewConnection("kubectl", "", kubernetes.ProxyFilter)
+		podName, err := cnx.GetPodName()
+		if err != nil {
+			log.Fatal().Err(err)
+		}
+		commandArgs = append(commandArgs, podName, "--all-containers")
+	} else if len(flags.Containers) == 1 {
+		commandArgs = append(commandArgs, flags.Containers[0], "--all-containers")
+	} else {
+		commandArgs = append(commandArgs, args...)
+	}
+
+	return utils.RunCmdStdMapping(zerolog.DebugLevel, "kubectl", commandArgs...)
+}
+
+func isRFC3339(timestamp string) bool {
+	_, err := time.Parse(time.RFC3339, timestamp)
+	return err == nil
+}

--- a/mgrpxy/cmd/logs/logs.go
+++ b/mgrpxy/cmd/logs/logs.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type logsFlags struct {
+	Containers []string
+	Follow     bool
+	Timestamps bool
+	Tail       int
+	Since      string
+}
+
+// NewCommand to get the logs of the server.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	var flags logsFlags
+
+	cmd := &cobra.Command{
+		Use:   "logs [pod [container] | container...]",
+		Short: L("Get the proxy logs"),
+		Long: L(`Get the proxy logs
+The command automatically detects installed backend and displays the logs for containers managed by Kubernetes or Podman
+However, you can specify the pod and/or container names to get the logs for specific container(s). See examples for more details.`),
+		Example: `  Log all relevant containers (Podman and Kubernetes)
+
+    $ mgrpxy logs                                                
+
+  Log all relevant containers in the specified pod (Kubernetes)
+
+    $ mgrpxy logs uyuni-proxy-pod                                
+
+  Log the specified container in the specified pod (Kubernetes)
+
+    $ mgrpxy logs uyuni-proxy-pod httpd                          
+
+  Log the specified containers (Podman)		
+
+    $ mgrpxy logs logs uyuni-proxy-httpd uyuni-proxy-ssh`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags.Containers = cmd.Flags().Args()
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, logs)
+		},
+		ValidArgsFunction: getContainerNames,
+	}
+
+	cmd.Flags().BoolP("follow", "f", false, L("specify if logs should be followed"))
+	cmd.Flags().BoolP("timestamps", "t", false, L("show timestamps in the log outputs"))
+	cmd.Flags().Int("tail", -1, L("number of lines to show from the end of the logs"))
+	cmd.Flags().Lookup("tail").NoOptDefVal = "-1"
+	cmd.Flags().String("since", "", L("show logs since a specific time or duration. Supports Go duration strings and RFC3339 format (e.g. 5s, 2m, 3h, 2023-01-02T15:04:05)"))
+
+	cmd.SetUsageTemplate(cmd.UsageTemplate())
+	return cmd
+}
+
+func logs(globalFlags *types.GlobalFlags, flags *logsFlags, cmd *cobra.Command, args []string) error {
+	fn, err := shared.ChooseProxyPodmanOrKubernetes(cmd.Flags(), podmanLogs, kubernetesLogs)
+	if err != nil {
+		return err
+	}
+
+	return fn(globalFlags, flags, cmd, args)
+}
+
+func getContainerNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var names []string
+
+	if podman.HasService(podman.ProxyService) {
+		names = getNames(exec.Command("podman", "ps", "--format", "{{.Names}}"), "\n", "uyuni")
+	} else if utils.IsInstalled("kubectl") && utils.IsInstalled("helm") {
+		if len(args) == 0 {
+			cnx := shared.NewConnection("kubectl", "", kubernetes.ProxyFilter)
+			podName, err := cnx.GetPodName()
+			if err != nil {
+				log.Fatal().Err(err)
+			}
+			return []string{podName}, cobra.ShellCompDirectiveNoFileComp
+		} else if len(args) == 1 {
+			names = getNames(exec.Command("kubectl", "get", "pod", args[0], "-o", "jsonpath={.spec.containers[*].name}"), " ", "")
+		} else {
+			//kubernetes log only accepts either 1 container name or the --all-containers flag.
+			return names, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	return minus(names, args), cobra.ShellCompDirectiveNoFileComp
+}
+
+// retrieves pod/container retrieve command and parses its names for auto completion.
+func getNames(cmd *exec.Cmd, cmdResultSeparator string, namesPrefix string) []string {
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	names := strings.Split(strings.TrimSpace(string(out)), cmdResultSeparator)
+	if namesPrefix == "" {
+		return names
+	}
+
+	var filteredNames []string
+	for _, name := range names {
+		if strings.HasPrefix(name, namesPrefix) {
+			filteredNames = append(filteredNames, name)
+		}
+	}
+	return filteredNames
+}
+
+// Returns the elements of a left slice minus the elements of the right slice.
+func minus(left []string, right []string) []string {
+	rightMap := make(map[string]bool)
+	for _, elementRight := range right {
+		rightMap[elementRight] = true
+	}
+
+	var result []string
+	for _, elementLeft := range left {
+		if !rightMap[elementLeft] {
+			result = append(result, elementLeft)
+		}
+	}
+
+	return result
+}

--- a/mgrpxy/cmd/logs/podman.go
+++ b/mgrpxy/cmd/logs/podman.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func podmanLogs(
+	globalFlags *types.GlobalFlags,
+	flags *logsFlags,
+	cmd *cobra.Command,
+	args []string,
+) error {
+	commandArgs := []string{"logs"}
+	if flags.Follow {
+		commandArgs = append(commandArgs, "-f")
+	}
+
+	if flags.Tail != -1 {
+		commandArgs = append(commandArgs, "--tail="+fmt.Sprintf("%d", flags.Tail))
+	}
+
+	if flags.Timestamps {
+		commandArgs = append(commandArgs, "--timestamps")
+	}
+
+	if flags.Since != "" {
+		commandArgs = append(commandArgs, fmt.Sprintf("--since=%s", flags.Since))
+	}
+
+	if len(flags.Containers) == 0 {
+		commandArgs = append(commandArgs, podman.ProxyContainerNames...)
+	} else {
+		commandArgs = append(commandArgs, args...)
+	}
+
+	return utils.RunCmdStdMapping(zerolog.DebugLevel, "podman", commandArgs...)
+}

--- a/uyuni-tools.changes.rjpmestre.add-mgrpxy-logs-command
+++ b/uyuni-tools.changes.rjpmestre.add-mgrpxy-logs-command
@@ -1,0 +1,1 @@
+- Add mgrpxy logs command


### PR DESCRIPTION
## What does this PR change?

Provides a mgrpxy  logs command that forwards automatically to podman logs or kubectl logs.
Supports the following tags:
- follow - specify if logs should be followed
- since - show logs since a specific time or duration. Supports Go duration strings and RFC3339 format (e.g. 5s, 2m, 3h, 2023-01-02T15:04:05)
-  tail - show a certain number of lines from the end of the logs
- timestamps - show timestamps in the log outputs

Also provides autocompletion for podman, suggesting suitable container names, and for kubectl, first suggesting the pod name and then its associated containers.


## Test coverage
- No tests: manual tests

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/145

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

