### PR TITLE
fix port number for billing api

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -102,7 +102,7 @@ func GenerateSystemdService(tz string, image string, debug bool, mirrorPath stri
 
 	ports := GetExposedPorts(debug)
 	if _, err := exec.LookPath("csp-billing-adapter"); err == nil {
-		ports = append(ports, utils.NewPortMap("csp-billing", 10888, 10888))
+		ports = append(ports, utils.NewPortMap("csp-billing", 18888, 18888))
 		args = append(args, "-e ISPAYG=1")
 	}
 

--- a/uyuni-tools.changes.mc.fix-scp-billing-port
+++ b/uyuni-tools.changes.mc.fix-scp-billing-port
@@ -1,0 +1,1 @@
+- fix port number for billing api


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The portnumber for the billing data API was wrong.

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

