### PR TITLE
extract payg data after setup to prevent a race condition

### DIFF
--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -128,6 +128,14 @@ func installForPodman(
 		return err
 	}
 
+	if path, err := exec.LookPath("uyuni-payg-extract-data"); err == nil {
+		// the binary is installed
+		err = utils.RunCmdStdMapping(zerolog.DebugLevel, path)
+		if err != nil {
+			return utils.Errorf(err, L("failed to extract payg data"))
+		}
+	}
+
 	if err := coco.SetupCocoContainer(flags.Coco.Replicas, flags.Coco.Image, flags.Image, flags.Db); err != nil {
 		return err
 	}

--- a/uyuni-tools.changes.mc.extract-payg-data-after-setup
+++ b/uyuni-tools.changes.mc.extract-payg-data-after-setup
@@ -1,0 +1,1 @@
+- extract payg data after setup to prevent a race condition


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When setting up PAYG, the job which extract the data run every 10 minutes.
When the container start up for the first time, it will not find the data and will behave like a standard installation.
To prevent this race condition, call the extract script - if installed - after setup to have the data early available.

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

