### PR TITLE
Exclude /var/log/lastlog from migration

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -45,6 +45,8 @@ done
 echo "-/ /etc/sysconfig/rhn/reportdb-schema-upgrade" >> exclude_list
 echo "-/ /etc/sysconfig/rhn/schema-upgrade" >> exclude_list
 
+# exclude lastlog - it is not needed and can be too large
+echo "-/ /var/log/lastlog" >> exclude_list
 
 for folder in {{ range .Volumes }}{{ .MountPath }} {{ end }};
 do

--- a/uyuni-tools.changes.nadvornik.migration-lastlog
+++ b/uyuni-tools.changes.nadvornik.migration-lastlog
@@ -1,0 +1,1 @@
+- Exclude /var/log/lastlog from migration


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Exclude /var/log/lastlog from migration.
This is a sparse file that can be too large and cause problems with rsync. Additionaly, it is not really needed.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8825

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

