### PR TITLE
add podman >= 4.5.0 requirement for all distros

### DIFF
--- a/uyuni-tools.changes.mbussolotto.podman_4.5
+++ b/uyuni-tools.changes.mbussolotto.podman_4.5
@@ -1,0 +1,1 @@
+- add podman >= 4.5.0 requirement for all distros

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -99,8 +99,8 @@ Tools for managing uyuni container.
 Summary:        Command line tool to install and update %{productname}
 %if 0%{?suse_version}
 Requires:       (aardvark-dns if netavark)
-Requires:       (podman >= 4.5.0 if podman)
 %endif
+Requires:       (podman >= 4.5.0 if podman)
 # 0%{?suse_version}
 
 %description -n %{name_adm}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

see title. Tested here: https://build.opensuse.org/project/show/home:mbussolotto:branches:systemsmanagement:Uyuni:Master:ContainerUtils . So podman 4.5.0 is not available for:
- Debian 12
- Ubuntu 20.04/22.04

## Test coverage
- No tests

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8869

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

