### PR TITLE
Fix misleading message on uninstall

### DIFF
--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -139,13 +139,15 @@ func UninstallInstantiatedService(name string, dryRun bool) {
 	servicePath := GetServicePath(name + "@")
 	serviceConfFolder := GetServiceConfFolder(name + "@")
 	serviceConfPath := GetServiceConfPath(name + "@")
-	if dryRun {
-		log.Info().Msgf(L("Would remove %s"), servicePath)
-	} else {
-		// Remove the service unit
-		log.Info().Msgf(L("Remove %s"), servicePath)
-		if err := os.Remove(servicePath); err != nil {
-			log.Error().Err(err).Msgf(L("Failed to remove %s.service file"), name)
+	if utils.FileExists(servicePath) {
+		if dryRun {
+			log.Info().Msgf(L("Would remove %s"), servicePath)
+		} else {
+			// Remove the service unit
+			log.Info().Msgf(L("Remove %s"), servicePath)
+			if err := os.Remove(servicePath); err != nil {
+				log.Error().Err(err).Msgf(L("Failed to remove %s.service file"), name)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fix misleading error message
```
ERR Failed to remove uyuni-hub-xmlrpc.service file error="remove /etc/systemd/system/uyuni-hub-xmlrpc@.service: no such file or directory"
```

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

