### PR TITLE
Require podman >= 4.5.0 only on RPM based systems. Revert/Edit #350

### DIFF
--- a/uyuni-tools.changes.deneb-alpha.revert_#350_podman
+++ b/uyuni-tools.changes.deneb-alpha.revert_#350_podman
@@ -1,0 +1,1 @@
+- Require podman >= 4.5.0 on RPM based systems

--- a/uyuni-tools.changes.deneb-alpha.revert_#350_podman
+++ b/uyuni-tools.changes.deneb-alpha.revert_#350_podman
@@ -1,1 +1,2 @@
-- Require podman >= 4.5.0 on RPM based systems
+- Require podman >= 4.5.0 on RPM based systems only,
+  do not require it for DEB based systems.

--- a/uyuni-tools.changes.mbussolotto.podman_4.5
+++ b/uyuni-tools.changes.mbussolotto.podman_4.5
@@ -1,1 +1,0 @@
-- add podman >= 4.5.0 requirement for all distros

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -100,8 +100,10 @@ Summary:        Command line tool to install and update %{productname}
 %if 0%{?suse_version}
 Requires:       (aardvark-dns if netavark)
 %endif
-Requires:       (podman >= 4.5.0 if podman)
 # 0%{?suse_version}
+%if "%{_vendor}" != "debbuild"
+Requires: (podman >= 4.5.0 if podman)
+%endif
 
 %description -n %{name_adm}
 %{name_adm} is a convenient tool to install and update %{productname} components as containers running


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Require `podman >= 4.5.0` only on RPM based systems. Revert/Edit #350 because the debian control file doesn't handle conditional dependencies like `(podman >= 4.5.0 if podman)`

Please note that I also  dropped  the previous changelog  entry from  Michele given that the change wasn't working and the  package still  needed  to be  tagged. I didn't use a  direct git revert  because I  had to make  changes to the  spec in any case. 

## Test coverage
- Build tested on: https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master:ContainerUtils/uyuni-tools

- [x] **DONE**

## Links

Related: 
* https://github.com/uyuni-project/uyuni-tools/pull/350 
* https://github.com/SUSE/spacewalk/issues/23749 
* https://github.com/SUSE/spacewalk/issues/23747

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

