### PR TITLE
Allow installing with existing volumes

### DIFF
--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -6,6 +6,7 @@ package podman
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -67,14 +68,18 @@ func installForPodman(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	flags.CheckParameters(cmd, "podman")
-	if _, err := exec.LookPath("podman"); err != nil {
-		return errors.New(L("install podman before running this command"))
-	}
-
 	inspectedHostValues, err := utils.InspectHost(false)
 	if err != nil {
 		return utils.Errorf(err, L("cannot inspect host values"))
+	}
+
+	if _, present := inspectedHostValues["host_uyuni_server"]; present {
+		return fmt.Errorf(L("Server is already initialized! Uninstall before attempting new installation or use upgrade command"))
+	}
+
+	flags.CheckParameters(cmd, "podman")
+	if _, err := exec.LookPath("podman"); err != nil {
+		return errors.New(L("install podman before running this command"))
 	}
 
 	fqdn, err := getFqdn(args)

--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -24,6 +24,13 @@ const setup_name = "setup.sh"
 
 // RunSetup execute the setup.
 func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[string]string) error {
+	// Containers should be running now, check storage if it is using volume from already configured server
+	preconfigured := false
+	if isServerConfigured(cnx) {
+		log.Warn().Msg(L("Server appears to be already configured. Installation will continue, but installation options may be ignored."))
+		preconfigured = true
+	}
+
 	tmpFolder := generateSetupScript(flags, fqdn, env)
 	defer os.RemoveAll(tmpFolder)
 
@@ -132,4 +139,8 @@ func boolToString(value bool) string {
 		return "Y"
 	}
 	return "N"
+}
+
+func isServerConfigured(cnx *shared.Connection) bool {
+	return cnx.TestExistenceInPod("/root/.MANAGER_SETUP_COMPLETE")
 }

--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -5,6 +5,8 @@
 package shared
 
 import (
+	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -49,10 +51,37 @@ func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[
 		apiCnx := api.ConnectionDetails{
 			Server:   fqdn,
 			Insecure: true, // TODO Get the CA Cert and toggle this to false
+			User:     flags.Admin.Login,
+			Password: flags.Admin.Password,
 		}
-		_, err := org.CreateFirst(&apiCnx, flags.Organization, &flags.Admin)
-		if err != nil {
-			return err
+
+		// Check if there is already admin user with given password and organization with same name
+		if _, err := api.Init(&apiCnx); err == nil {
+			if _, err := org.GetOrganizationDetails(&apiCnx, flags.Organization); err == nil {
+				log.Info().Msgf(L("Server organization already exists, reusing"))
+			} else {
+				log.Debug().Err(err).Msg("Error returned by server")
+				log.Warn().Msgf(L("Administration user already exists, but organization %s could not be found"), flags.Organization)
+			}
+		} else {
+			var connError *url.Error
+			if errors.As(err, &connError) {
+				// We were not able to connect to the server at all
+				return err
+			}
+			// We do not have any user existing, do not try to login
+			apiCnx = api.ConnectionDetails{
+				Server:   fqdn,
+				Insecure: true, // TODO Get the CA Cert and toggle this to false
+			}
+			_, err := org.CreateFirst(&apiCnx, flags.Organization, &flags.Admin)
+			if err != nil {
+				if preconfigured {
+					log.Warn().Msgf(L("Administration user already exists, but provided credentials are not valid"))
+				} else {
+					return err
+				}
+			}
 		}
 	}
 

--- a/shared/api/org/getDetails.go
+++ b/shared/api/org/getDetails.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	"github.com/uyuni-project/uyuni-tools/shared/api/types"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+// Get details of organization based on organization name.
+func GetOrganizationDetails(cnxDetails *api.ConnectionDetails, orgName string) (*types.Organization, error) {
+	client, err := api.Init(cnxDetails)
+	if err != nil {
+		return nil, utils.Errorf(err, L("failed to connect to the server"))
+	}
+	res, err := api.Get[types.Organization](client, fmt.Sprintf("org/getDetails?name=%s", orgName))
+	if err != nil {
+		return nil, utils.Errorf(err, L("failed to get organization details"))
+	}
+	if !res.Success {
+		return nil, errors.New(res.Message)
+	}
+
+	return &res.Result, nil
+}

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -46,13 +46,14 @@ var inspectValues = []types.InspectData{
 	types.NewInspectData("fqdn", "cat /etc/rhn/rhn.conf 2>/dev/null | grep 'java.hostname' | cut -d' ' -f3 || true", false),
 	types.NewInspectData("image_pg_version", "rpm -qa --qf '%{VERSION}\\n' 'name=postgresql[0-8][0-9]-server'  | cut -d. -f1 | sort -n | tail -1 || true", false),
 	types.NewInspectData("current_pg_version", "(test -e /var/lib/pgsql/data/PG_VERSION && cat /var/lib/pgsql/data/PG_VERSION) || true", false),
-	types.NewInspectData("registration_info", "env LC_ALL=C LC_MESSAGES=C LANG=C transactional-update --quiet register --status 2>/dev/null || true", false),
+	types.NewInspectData("registration_info", "env LC_ALL=C LC_MESSAGES=C LANG=C SUSEConnect --status 2>/dev/null || true", false),
 	types.NewInspectData("scc_username", "cat /etc/zypp/credentials.d/SCCcredentials 2>&1 /dev/null | grep username | cut -d= -f2 || true", true),
 	types.NewInspectData("scc_password", "cat /etc/zypp/credentials.d/SCCcredentials 2>&1 /dev/null | grep password | cut -d= -f2 || true", true),
 	types.NewInspectData("db_user", "cat /etc/rhn/rhn.conf 2>/dev/null | grep '^db_user' | cut -d' ' -f3 || true", false),
 	types.NewInspectData("db_password", "cat /etc/rhn/rhn.conf 2>/dev/null | grep '^db_password' | cut -d' ' -f3 || true", false),
 	types.NewInspectData("db_name", "cat /etc/rhn/rhn.conf 2>/dev/null | grep '^db_name' | cut -d' ' -f3 || true", false),
 	types.NewInspectData("db_port", "cat /etc/rhn/rhn.conf 2>/dev/null | grep '^db_port' | cut -d' ' -f3 || true", false),
+	types.NewInspectData("uyuni_server", "systemctl list-unit-files uyuni-server.service >/dev/null && echo present || true", false),
 }
 
 // InspectOutputFile represents the directory and the basename where the inspect values are stored.

--- a/uyuni-tools.changes.oholecek.mgradm_reinstall
+++ b/uyuni-tools.changes.oholecek.mgradm_reinstall
@@ -1,0 +1,1 @@
+- allow server installation with prexexisting storage volumes


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR add check for existing uyuni-server service and if exists, refuse installation. It also add check for existing volume and display warning that not all installation options are preserved and make sure correct passwords are used.

At the end this PR adds new API call to try to verify if existing organization from pre existing volumes matches what would be created.

One small unrelated change is to use directly SUSEConnect instead of transactional-update --register. For plain status check, which is r/o operation, calling directly SUSEConnect is fine and we don't spend unnecessary time creating and discarding snapshots.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/347

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

