### PR TITLE
Improved Hub XML-RPC support

### DIFF
--- a/mgradm/cmd/inspect/kubernetes.go
+++ b/mgradm/cmd/inspect/kubernetes.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/shared"
 	shared_kubernetes "github.com/uyuni-project/uyuni-tools/shared/kubernetes"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
@@ -36,7 +35,7 @@ func kuberneteInspect(
 	if len(serverImage) <= 0 {
 		log.Debug().Msg("Use deployed image")
 
-		serverImage, err = adm_utils.RunningImage(cnx)
+		serverImage, err = shared_kubernetes.GetRunningImage("uyuni")
 		if err != nil {
 			return errors.New(L("failed to find the image of the currently running server container: %s"))
 		}

--- a/mgradm/cmd/inspect/podman.go
+++ b/mgradm/cmd/inspect/podman.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
-	"github.com/uyuni-project/uyuni-tools/shared"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
-	shared_podman "github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -31,13 +29,12 @@ func podmanInspect(
 	if len(serverImage) <= 0 {
 		log.Debug().Msg("Use deployed image")
 
-		cnx := shared.NewConnection("podman", shared_podman.ServerContainerName, "")
-		serverImage, err = adm_utils.RunningImage(cnx)
+		serverImage, err = podman.GetRunningImage(podman.ServerContainerName)
 		if err != nil {
 			return utils.Errorf(err, L("failed to find the image of the currently running server container"))
 		}
 	}
-	inspectResult, err := shared_podman.Inspect(serverImage, flags.Image.PullPolicy, flags.SCC)
+	inspectResult, err := podman.Inspect(serverImage, flags.Image.PullPolicy, flags.SCC)
 	if err != nil {
 		return utils.Errorf(err, L("inspect command failed"))
 	}

--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -74,7 +74,8 @@ func installForKubernetes(_ *types.GlobalFlags,
 	}
 
 	// Deploy Uyuni and wait for it to be up
-	if err := kubernetes.Deploy(cnx, flags.Image.Registry, &flags.Image, &flags.Helm,
+	if err := kubernetes.Deploy(
+		cnx, flags.Image.Registry, &flags.Image, &flags.HubXmlrpc, &flags.Helm,
 		clusterInfos, fqdn, flags.Debug.Java, false, helmArgs...,
 	); err != nil {
 		return shared_utils.Errorf(err, L("cannot deploy uyuni"))

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -209,6 +209,8 @@ func migrateToKubernetes(
 		return err
 	}
 
+	// Reinitialize the connection since the pod name has changed since we first checked
+	cnx = shared.NewConnection("kubectl", "", shared_kubernetes.ServerFilter)
 	if err := cnx.CopyCaCertificate(fqdn); err != nil {
 		return utils.Errorf(err, L("failed to add SSL CA certificate to host trusted certificates"))
 	}

--- a/mgradm/cmd/scale/podman.go
+++ b/mgradm/cmd/scale/podman.go
@@ -31,7 +31,7 @@ func podmanScale(
 	}
 	if service == podman.HubXmlrpcService {
 		if newReplicas > 1 {
-			return errors.New(L("Multiple Hub XML-RPC container replicas are not currently supported."))
+			return errors.New(L("Multiple Hub XML-RPC API container replicas are not currently supported."))
 		}
 		return systemd.ScaleService(newReplicas, service)
 	}

--- a/mgradm/cmd/upgrade/kubernetes/utils.go
+++ b/mgradm/cmd/upgrade/kubernetes/utils.go
@@ -18,5 +18,7 @@ func upgradeKubernetes(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	return kubernetes.Upgrade(globalFlags, &flags.Image, &flags.DBUpgradeImage, flags.Helm, cmd, args)
+	return kubernetes.Upgrade(
+		globalFlags, &flags.UpgradeFlags.Image, &flags.DBUpgradeImage, &flags.HubXmlrpc.Image, flags.Helm, cmd, args,
+	)
 }

--- a/mgradm/shared/kubernetes/certificates.go
+++ b/mgradm/shared/kubernetes/certificates.go
@@ -113,6 +113,7 @@ func installCertManager(helmFlags *cmd_utils.HelmFlags, kubeconfig string, image
 
 		args := []string{
 			"--set", "crds.enabled=true",
+			"--set", "crds.keep=true",
 			"--set-json", "global.commonLabels={\"installedby\": \"mgradm\"}",
 			"--set", "image.pullPolicy=" + kubernetes.GetPullPolicy(imagePullPolicy),
 		}

--- a/mgradm/shared/kubernetes/install.go
+++ b/mgradm/shared/kubernetes/install.go
@@ -74,7 +74,7 @@ func Deploy(
 	return cnx.WaitForServer()
 }
 
-// DeployCertificate executre a deploy a new certificate given an helm.
+// DeployCertificate deploys a new SSL certificate.
 func DeployCertificate(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.InstallSSLFlags, rootCa string,
 	ca *types.SSLPair, kubeconfig string, fqdn string, imagePullPolicy string) ([]string, error) {
 	helmArgs := []string{}

--- a/mgradm/shared/kubernetes/k3s.go
+++ b/mgradm/shared/kubernetes/k3s.go
@@ -15,15 +15,18 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-// InstallK3sTraefikConfig installs the K3s Traefik configuration.
-func InstallK3sTraefikConfig(debug bool) {
+// GetPortLists returns compiled lists of tcp and udp ports..
+func GetPortLists(hub bool, debug bool) ([]types.PortMap, []types.PortMap) {
 	tcpPorts := []types.PortMap{}
 	tcpPorts = append(tcpPorts, utils.TCPPorts...)
 	if debug {
 		tcpPorts = append(tcpPorts, utils.DebugPorts...)
 	}
+	if hub {
+		tcpPorts = append(tcpPorts, utils.HubXmlrpcPorts...)
+	}
 
-	kubernetes.InstallK3sTraefikConfig(tcpPorts, utils.UDPPorts)
+	return tcpPorts, utils.UDPPorts
 }
 
 // RunPgsqlVersionUpgrade perform a PostgreSQL major upgrade.

--- a/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
@@ -23,8 +23,9 @@ test -d /usr/lib/postgresql$NEW_VERSION/bin
 echo "Testing presence of postgresql$OLD_VERSION..."
 test -d /usr/lib/postgresql$OLD_VERSION/bin
 
-echo "Create a backup at /var/lib/pgsql/data-pg$OLD_VERSION..."
-mv /var/lib/pgsql/data /var/lib/pgsql/data-pg$OLD_VERSION
+# Data have already been backed up at the end of the migration script
+# Reset the potentially created new pgsql data
+rm -rf /var/lib/pgsql/data
 echo "Create new database directory..."
 mkdir -p /var/lib/pgsql/data
 chown -R postgres:postgres /var/lib/pgsql
@@ -45,6 +46,8 @@ echo "Running initdb using postgres user"
 echo "Any suggested command from the console should be run using postgres user"
 su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_LANG"
 echo "Successfully initialized new postgresql $NEW_VERSION database."
+
+
 su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql$OLD_VERSION/bin --new-bindir=/usr/lib/postgresql$NEW_VERSION/bin --old-datadir=/var/lib/pgsql/data-pg$OLD_VERSION --new-datadir=/var/lib/pgsql/data $FAST_UPGRADE"
 
 cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data

--- a/mgradm/shared/utils/exec.go
+++ b/mgradm/shared/utils/exec.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/templates"
 	"github.com/uyuni-project/uyuni-tools/shared"
-	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -135,37 +134,6 @@ func GenerateMigrationScript(sourceFqdn string, user string, kubernetes bool, pr
 	}
 
 	return scriptDir, cleaner, nil
-}
-
-// RunningImage returns the image running in the current system.
-func RunningImage(cnx *shared.Connection) (string, error) {
-	command, err := cnx.GetCommand()
-
-	switch command {
-	case "podman":
-		args := []string{"ps", "--format", "{{.Image}}", "--noheading"}
-		image, err := utils.RunCmdOutput(zerolog.DebugLevel, "podman", args...)
-		if err != nil {
-			return "", err
-		}
-		return strings.Trim(string(image), "\n"), nil
-
-	case "kubectl":
-
-		// FIXME this will work until containers 0 is uyuni. Then jsonpath should be something like
-		// {.items[0].spec.containers[?(@.name=="` + containerName + `")].image but there are problems
-		// using RunCmdOutput with an arguments with round brackets
-		args := []string{"get", "pods", kubernetes.ServerFilter, "-o", "jsonpath={.items[0].spec.containers[0].image}"}
-		image, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", args...)
-
-		log.Info().Msgf(L("Image is: %s"), image)
-		if err != nil {
-			return "", err
-		}
-		return strings.Trim(string(image), "\n"), nil
-	}
-
-	return command, err
 }
 
 // SanityCheck verifies if an upgrade can be run.

--- a/shared/kubernetes/k3s.go
+++ b/shared/kubernetes/k3s.go
@@ -44,10 +44,12 @@ func waitForTraefik() {
 		if err == nil {
 			completionTime, err := time.Parse(time.RFC3339, string(out))
 			if err == nil && time.Since(completionTime).Seconds() < 60 {
-				break
+				return
 			}
 		}
+		time.Sleep(1 * time.Second)
 	}
+	log.Error().Msg(L("Failed to reload K3s Traefik"))
 }
 
 // UninstallK3sTraefikConfig uninstall K3s Traefik configuration.

--- a/shared/kubernetes/utils.go
+++ b/shared/kubernetes/utils.go
@@ -389,3 +389,18 @@ func GenerateOverrideDeployment(deployData types.Deployment) (string, error) {
 	}
 	return string(ret), nil
 }
+
+// GetRunningImage returns the image of containerName for the server running in the current system.
+func GetRunningImage(containerName string) (string, error) {
+	args := []string{
+		"get", "pods", "-A", ServerFilter,
+		"-o", "jsonpath={.items[0].spec.containers[?(@.name=='" + containerName + "')].image}",
+	}
+	image, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", args...)
+
+	log.Debug().Msgf("%[1]s container image is: %[2]s", containerName, image)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(image), "\n"), nil
+}

--- a/uyuni-tools.changes.nadvornik.hub-xmlrpc2
+++ b/uyuni-tools.changes.nadvornik.hub-xmlrpc2
@@ -1,0 +1,1 @@
+- Handle Hub XML-RPC during migration and upgrade and add Kubernetes support


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR adds Hub XML-RPC support to podman migrate and upgrade and to all kubernetes commands.

Also, it fixes some kubernetes problems:
- incorrect arg to GetNode calls
- error detection on traefik setup

This PR depends on https://github.com/uyuni-project/uyuni/pull/8902

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/292


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

