### PR TITLE
Re-add podman extra args for install and migrate

### DIFF
--- a/mgradm/cmd/install/podman/podman.go
+++ b/mgradm/cmd/install/podman/podman.go
@@ -38,6 +38,7 @@ NOTE: installing on a remote podman is not supported yet!
 	}
 
 	shared.AddInstallFlags(podmanCmd)
+	podman.AddPodmanArgFlag(podmanCmd)
 
 	return podmanCmd
 }

--- a/mgradm/cmd/migrate/podman/podman.go
+++ b/mgradm/cmd/migrate/podman/podman.go
@@ -43,6 +43,7 @@ NOTE: migrating to a remote podman is not supported yet!
 	}
 
 	shared.AddMigrateFlags(migrateCmd)
+	podman_utils.AddPodmanArgFlag(migrateCmd)
 
 	return migrateCmd
 }

--- a/uyuni-tools.changes.rmateus.addPodmanExtra
+++ b/uyuni-tools.changes.rmateus.addPodmanExtra
@@ -1,0 +1,1 @@
+- Re-add podman extra args for install and migrate


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Followup on this PR, where the mount part was removed, but the extra arg where also removed. This PR adds the podman extra args back:
https://github.com/uyuni-project/uyuni-tools/pull/328/

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

