### PR TITLE
Disable node exporter port for kubernetes, other fixes

### DIFF
--- a/mgradm/cmd/restart/kubernetes.go
+++ b/mgradm/cmd/restart/kubernetes.go
@@ -18,5 +18,5 @@ func kubernetesRestart(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	return kubernetes.Restart(kubernetes.ServerFilter)
+	return kubernetes.Restart(kubernetes.ServerApp)
 }

--- a/mgradm/cmd/start/kubernetes.go
+++ b/mgradm/cmd/start/kubernetes.go
@@ -18,5 +18,5 @@ func kubernetesStart(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	return kubernetes.Start(kubernetes.ServerFilter)
+	return kubernetes.Start(kubernetes.ServerApp)
 }

--- a/mgradm/cmd/stop/kubernetes.go
+++ b/mgradm/cmd/stop/kubernetes.go
@@ -18,5 +18,5 @@ func kubernetesStop(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	return kubernetes.Stop(kubernetes.ServerFilter)
+	return kubernetes.Stop(kubernetes.ServerApp)
 }

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -34,6 +34,7 @@ func GetExposedPorts(debug bool) []types.PortMap {
 		utils.NewPortMap("http", 80, 80),
 	}
 	ports = append(ports, utils.TCP_PORTS...)
+	ports = append(ports, utils.TCP_PODMAN_PORTS...)
 	ports = append(ports, utils.UDP_PORTS...)
 
 	if debug {

--- a/shared/kubernetes/k3s.go
+++ b/shared/kubernetes/k3s.go
@@ -35,7 +35,7 @@ func InstallK3sTraefikConfig(tcpPorts []types.PortMap, udpPorts []types.PortMap)
 	// Wait for traefik to be back
 	log.Info().Msg(L("Waiting for Traefik to be reloaded"))
 	for i := 0; i < 60; i++ {
-		out, err := utils.RunCmdOutput(zerolog.TraceLevel, "kubectl", "get", "job", "-A",
+		out, err := utils.RunCmdOutput(zerolog.TraceLevel, "kubectl", "get", "job", "-n", "kube-system",
 			"-o", "jsonpath={.status.completionTime}", "helm-install-traefik")
 		if err == nil {
 			completionTime, err := time.Parse(time.RFC3339, string(out))

--- a/shared/kubernetes/kubernetes.go
+++ b/shared/kubernetes/kubernetes.go
@@ -99,7 +99,7 @@ func Restart(app string) error {
 // Start starts the pod.
 func Start(app string) error {
 	// if something is running, we don't need to set replicas to 1
-	if _, err := GetNode(app); err != nil {
+	if _, err := GetNode("-lapp=" + app); err != nil {
 		return ReplicasTo(app, 1)
 	}
 	log.Debug().Msgf("Already running")

--- a/shared/kubernetes/utils.go
+++ b/shared/kubernetes/utils.go
@@ -59,14 +59,14 @@ func WaitForDeployment(namespace string, name string, appName string) error {
 
 	log.Info().Msgf(L("Waiting for %[1]s deployment to be ready in %[2]s namespace\n"), name, namespace)
 	// Wait for a replica to be ready
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 120; i++ {
 		// TODO Look for pod failures
 		if IsDeploymentReady(namespace, name) {
 			return nil
 		}
 		time.Sleep(1 * time.Second)
 	}
-	return fmt.Errorf(L("failed to find a ready replica for deployment %[1]s in namespace %[2]s after 60s"), name, namespace)
+	return fmt.Errorf(L("failed to find a ready replica for deployment %[1]s in namespace %[2]s after 120s"), name, namespace)
 }
 
 // WaitForPulledImage wait that image is pulled.

--- a/shared/utils/ports.go
+++ b/shared/utils/ports.go
@@ -25,9 +25,13 @@ var TCP_PORTS = []types.PortMap{
 	NewPortMap("psql-mtrx", 9187, 9187),
 	NewPortMap("tasko-jmx-mtrx", 5556, 5556),
 	NewPortMap("tomcat-jmx-mtrx", 5557, 5557),
+	NewPortMap("tasko-mtrx", 9800, 9800),
+}
+
+// TCP_PODMAN_PORTS are the tcp ports required by the server on podman.
+var TCP_PODMAN_PORTS = []types.PortMap{
 	// TODO: Replace Node exporter with cAdvisor
 	NewPortMap("node-exporter", 9100, 9100),
-	NewPortMap("tasko-mtrx", 9800, 9800),
 }
 
 // DEBUG_PORTS are the port used by dev for debugging applications.

--- a/uyuni-tools.changes.nadvornik.kubernetes-fix
+++ b/uyuni-tools.changes.nadvornik.kubernetes-fix
@@ -1,0 +1,4 @@
+- Disable node exporter port for kubernetes
+- Fix start, stop and restart in kubernetes
+- Increase start timeout in kubernetes
+- Fix traefik query


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

- Disable node exporter port for kubernetes https://github.com/uyuni-project/uyuni-tools/issues/362
- Fix app name in start, stop and restart command on kubernetes
- Increase start timeout - 60s is not enough on my test machine


## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/362

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

