### PR TITLE
Correctly prepend default namespace for mgrpxy containers

### DIFF
--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -36,8 +36,12 @@ type Tuning struct {
 
 // Get the full container image name and tag for a container name.
 func (f *ProxyImageFlags) GetContainerImage(name string) string {
+	registry := utils.DefaultNamespace
+	if len(f.Registry) != 0 {
+		registry = f.Registry
+	}
 	computedImage := types.ImageFlags{
-		Name: path.Join(f.Registry, "proxy-"+name),
+		Name: path.Join(registry, "proxy-"+name),
 		Tag:  f.Tag,
 	}
 

--- a/uyuni-tools.changes.oholecek.fix_proxy_namespaceprefix
+++ b/uyuni-tools.changes.oholecek.fix_proxy_namespaceprefix
@@ -1,0 +1,1 @@
+- Correctly prepend default namespace for mgrpxy containers


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Proxy container image name computation was not prepending DefaultNamespace. This PR fixes it.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

