### PR TITLE
Fix --registry option (bsc#1226436)

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -172,7 +172,7 @@ func ComputeImage(imageFlags types.ImageFlags, appendToName ...string) (string, 
 	}
 	name := imageFlags.Name
 	if !strings.Contains(imageFlags.Name, imageFlags.Registry) {
-		name = path.Join(imageFlags.Registry, imageFlags.Name)
+		name = path.Join(imageFlags.Registry, path.Base(imageFlags.Name))
 		log.Info().Msgf(L("The image name provided is %[1]s and does not contains the registry %[2]s. The image name used will be %[3]s. You can set the flag --registry to change this behaviour."), imageFlags.Name, imageFlags.Registry, name)
 	}
 	tag := imageFlags.Tag

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -188,13 +188,13 @@ func TestComputeImage(t *testing.T) {
 		{"registry:5000/path/to/image:bar", "registry:5000/path/to/image", "bar", ""},
 		{"registry/path/to/image:foo", "registry/path/to/image:foo", "bar", ""},
 		{"registry/path/to/image:bar", "registry/path/to/image", "bar", ""},
-		{"registry/path/to/image:bar", "path/to/image", "bar", "registry"},
-		{"registry:5000/path/to/image:foo", "path/to/image:foo", "BAR", "REGISTRY:5000"},
+		{"registry/path/to/image:bar", "orig/path/to/image", "bar", "registry/path/to/"},
+		{"registry:5000/path/to/image:foo", "path/to/image:foo", "BAR", "REGISTRY:5000/path/to"},
 		{"registry:5000/path/to/image-migration-14-16:foo", "registry:5000/path/to/image:foo", "bar", "", "-migration-14-16"},
 		{"registry:5000/path/to/image-migration-14-16:bar", "registry:5000/path/to/image", "bar", "", "-migration-14-16"},
 		{"registry/path/to/image-migration-14-16:foo", "registry/path/to/image:foo", "bar", "", "-migration-14-16"},
 		{"registry/path/to/image-migration-14-16:bar", "registry/path/to/image", "bar", "", "-migration-14-16"},
-		{"registry/path/to/image-migration-14-16:bar", "path/to/image", "bar", "registry", "-migration-14-16"},
+		{"registry/path/to/image-migration-14-16:bar", "path/to/image", "bar", "registry/path/to", "-migration-14-16"},
 	}
 
 	for i, testCase := range data {

--- a/uyuni-tools.changes.nadvornik.registry
+++ b/uyuni-tools.changes.nadvornik.registry
@@ -1,0 +1,1 @@
+- Fix --registry option (bsc#1226436)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR fixes merging of a container image name with a registry specified separately.

## Test coverage
- No tests: manual testing

- [ ] **DONE**

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1226436

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

