### PR TITLE
Make k8s always enabled when using mgrpxy

### DIFF
--- a/shared/connection.go
+++ b/shared/connection.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -302,7 +304,8 @@ func ChoosePodmanOrKubernetes[F interface{}](
 	kubernetesFn utils.CommandFunc[F],
 ) (utils.CommandFunc[F], error) {
 	backend := "podman"
-	if utils.KubernetesBuilt {
+	runningBinary := filepath.Base(os.Args[0])
+	if utils.KubernetesBuilt || runningBinary == "mgrpxy" {
 		backend, _ = flags.GetString("backend")
 	}
 

--- a/uyuni-tools.changes.oholecek.allow_k8s_onproxy
+++ b/uyuni-tools.changes.oholecek.allow_k8s_onproxy
@@ -1,0 +1,1 @@
+- detection of k8s on proxy was wrongly influenced by server setting


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Proxy officially supports k8s, but some of our shared libs where checking settings meant for server and thus breaking k8s detection on the proxy. This commit uses args[0] to workaround this.

## Test coverage
- No tests: No test for now as this whole check should be later removed

- [X] **DONE**

## Links

Issue(s): none

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

