### PR TITLE
setup coco attestation on migration

### DIFF
--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -214,13 +214,7 @@ func AddInstallFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("debug-java", false, L("Enable tomcat and taskomatic remote debugging"))
 	cmd_utils.AddImageFlag(cmd)
 
-	cmd_utils.AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"))
-	cmd.Flags().Int("coco-replicas", 0, L("How many replicas of the confidential computing container should be started. (only 0 or 1 supported for now)"))
-
-	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "coco-container", Title: L("Confidential Computing Flags")})
-	_ = utils.AddFlagToHelpGroupID(cmd, "coco-replicas", "coco-container")
-	_ = utils.AddFlagToHelpGroupID(cmd, "coco-image", "coco-container")
-	_ = utils.AddFlagToHelpGroupID(cmd, "coco-tag", "coco-container")
+	cmd_utils.AddCocoFlag(cmd)
 
 	cmd.Flags().Int("hubxmlrpc-replicas", 0, L("How many replicas of the Hub XML-RPC API service container should be started. (only 0 or 1 supported for now)"))
 	hubXmlrpcImage := path.Join(utils.DefaultNamespace, "server-hub-xmlrpc-api")

--- a/mgradm/cmd/migrate/shared/flags.go
+++ b/mgradm/cmd/migrate/shared/flags.go
@@ -6,6 +6,7 @@ package shared
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/install/shared"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
@@ -15,6 +16,7 @@ import (
 type MigrateFlags struct {
 	Image          types.ImageFlags `mapstructure:",squash"`
 	DbUpgradeImage types.ImageFlags `mapstructure:"dbupgrade"`
+	Coco           shared.CocoFlags
 	User           string
 	Mirror         string
 }
@@ -24,5 +26,6 @@ func AddMigrateFlags(cmd *cobra.Command) {
 	utils.AddMirrorFlag(cmd)
 	utils.AddImageFlag(cmd)
 	utils.AddDbUpgradeImageFlag(cmd)
+	utils.AddCocoFlag(cmd)
 	cmd.Flags().String("user", "root", L("User on the source server. Non-root user must have passwordless sudo privileges (NOPASSWD tag in /etc/sudoers)."))
 }

--- a/mgradm/cmd/status/podman.go
+++ b/mgradm/cmd/status/podman.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/shared"
-	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
@@ -29,9 +28,7 @@ func podmanStatus(
 	} else {
 		// Run spacewalk-service status in the container
 		cnx := shared.NewConnection("podman", podman.ServerContainerName, "")
-		if err := adm_utils.ExecCommand(zerolog.InfoLevel, cnx, "spacewalk-service", "status"); err != nil {
-			return utils.Errorf(err, L("failed to run spacewalk-service status"))
-		}
+		_ = adm_utils.ExecCommand(zerolog.InfoLevel, cnx, "spacewalk-service", "status")
 	}
 
 	for i := 0; i < podman.CurrentReplicaCount(podman.ServerAttestationService); i++ {

--- a/mgradm/shared/kubernetes/install.go
+++ b/mgradm/shared/kubernetes/install.go
@@ -199,8 +199,8 @@ func Upgrade(
 	}
 
 	schemaUpdateRequired := inspectedValues["current_pg_version"] != inspectedValues["image_pg_version"]
-	if err := RunPgsqlFinalizeScript(serverImage, image.PullPolicy, nodeName, schemaUpdateRequired); err != nil {
-		return utils.Errorf(err, L("cannot run PostgreSQL version upgrade script"))
+	if err := RunPgsqlFinalizeScript(serverImage, image.PullPolicy, nodeName, schemaUpdateRequired, false); err != nil {
+		return utils.Errorf(err, L("cannot run PostgreSQL finalize script"))
 	}
 
 	if err := RunPostUpgradeScript(serverImage, image.PullPolicy, nodeName); err != nil {

--- a/mgradm/shared/kubernetes/k3s.go
+++ b/mgradm/shared/kubernetes/k3s.go
@@ -98,14 +98,16 @@ func RunPgsqlVersionUpgrade(image types.ImageFlags, upgradeImage types.ImageFlag
 }
 
 // RunPgsqlFinalizeScript run the script with all the action required to a db after upgrade.
-func RunPgsqlFinalizeScript(serverImage string, pullPolicy string, nodeName string, schemaUpdateRequired bool) error {
+func RunPgsqlFinalizeScript(
+	serverImage string, pullPolicy string, nodeName string, schemaUpdateRequired bool, migration bool,
+) error {
 	scriptDir, err := os.MkdirTemp("", "mgradm-*")
 	defer os.RemoveAll(scriptDir)
 	if err != nil {
 		return fmt.Errorf(L("failed to create temporary directory: %s"))
 	}
 	pgsqlFinalizeContainer := "uyuni-finalize-pgsql"
-	pgsqlFinalizeScriptName, err := adm_utils.GenerateFinalizePostgresScript(scriptDir, true, schemaUpdateRequired, true, true, true)
+	pgsqlFinalizeScriptName, err := adm_utils.GenerateFinalizePostgresScript(scriptDir, true, schemaUpdateRequired, true, migration, true)
 	if err != nil {
 		return utils.Errorf(err, L("cannot generate PostgreSQL finalization script"))
 	}

--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -80,8 +80,8 @@ echo "Extracting time zone..."
 $SSH {{ .SourceFqdn }} timedatectl show -p Timezone >/var/lib/uyuni-tools/data
 
 echo "Extracting postgresql versions..."
-echo "new_pg_version=$(rpm -qa --qf '%{VERSION}\n' 'name=postgresql[0-8][0-9]-server'  | cut -d. -f1 | sort -n | tail -1)" >> /var/lib/uyuni-tools/data
-echo "old_pg_version=$(cat /var/lib/pgsql/data/PG_VERSION)" >> /var/lib/uyuni-tools/data
+echo "image_pg_version=$(rpm -qa --qf '%{VERSION}\n' 'name=postgresql[0-8][0-9]-server'  | cut -d. -f1 | sort -n | tail -1)" >> /var/lib/uyuni-tools/data
+echo "current_pg_version=$(cat /var/lib/pgsql/data/PG_VERSION)" >> /var/lib/uyuni-tools/data
 
 echo "Altering configuration for domain resolution..."
 sed 's/report_db_host = {{ .SourceFqdn }}/report_db_host = localhost/' -i /etc/rhn/rhn.conf;

--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -83,6 +83,11 @@ echo "Extracting postgresql versions..."
 echo "image_pg_version=$(rpm -qa --qf '%{VERSION}\n' 'name=postgresql[0-8][0-9]-server'  | cut -d. -f1 | sort -n | tail -1)" >> /var/lib/uyuni-tools/data
 echo "current_pg_version=$(cat /var/lib/pgsql/data/PG_VERSION)" >> /var/lib/uyuni-tools/data
 
+grep '^db_user' /etc/rhn/rhn.conf | sed 's/[ \t]//g' >>/var/lib/uyuni-tools/data
+grep '^db_password' /etc/rhn/rhn.conf | sed 's/[ \t]//g' >>/var/lib/uyuni-tools/data
+grep '^db_name' /etc/rhn/rhn.conf | sed 's/[ \t]//g' >>/var/lib/uyuni-tools/data
+grep '^db_port' /etc/rhn/rhn.conf | sed 's/[ \t]//g' >>/var/lib/uyuni-tools/data
+
 echo "Altering configuration for domain resolution..."
 sed 's/report_db_host = {{ .SourceFqdn }}/report_db_host = localhost/' -i /etc/rhn/rhn.conf;
 sed 's/server\.jabber_server/java\.hostname/' -i /etc/rhn/rhn.conf;

--- a/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
@@ -29,7 +29,7 @@ echo "Schema update..."
 /usr/sbin/spacewalk-startup-helper check-database
 {{ end }}
 
-{{ if .RunDistroMigration }}
+{{ if .Migration }}
 echo "Updating auto-installable distributions..."
 spacewalk-sql --select-mode - <<EOT
 SELECT MIN(CONCAT(org_id, '-', label)) AS target, base_path INTO TEMP TABLE dist_map FROM rhnKickstartableTree GROUP BY base_path;
@@ -56,11 +56,11 @@ echo "DONE"
 
 // FinalizePostgresTemplateData represents information used to create PostgreSQL migration script.
 type FinalizePostgresTemplateData struct {
-	RunAutotune        bool
-	RunReindex         bool
-	RunSchemaUpdate    bool
-	RunDistroMigration bool
-	Kubernetes         bool
+	RunAutotune     bool
+	RunReindex      bool
+	RunSchemaUpdate bool
+	Migration       bool
+	Kubernetes      bool
 }
 
 // Render will create script for finalizing PostgreSQL upgrade.

--- a/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlFinalizeScriptTemplate.go
@@ -12,6 +12,14 @@ import (
 const postgresFinalizeScriptTemplate = `#!/bin/bash
 set -e
 
+{{ if .Migration }}
+echo "Adding database access for other containers..."
+db_user=$(sed -n '/^db_user/{s/^.*=[ \t]\+\(.*\)$/\1/ ; p}' /etc/rhn/rhn.conf)
+db_name=$(sed -n '/^db_name/{s/^.*=[ \t]\+\(.*\)$/\1/ ; p}' /etc/rhn/rhn.conf)
+ip=$(ip -o -4 addr show up scope global | head -1 | awk '{print $4}' || true)
+echo "host $db_name $db_user $ip scram-sha-256" >> /var/lib/pgsql/data/pg_hba.conf
+{{ end }}
+
 {{ if .RunAutotune }}
 echo "Running smdba system-check autotuning..."
 smdba system-check autotuning

--- a/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
@@ -46,6 +46,9 @@ su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_
 echo "Successfully initialized new postgresql $NEW_VERSION database."
 su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql$OLD_VERSION/bin --new-bindir=/usr/lib/postgresql$NEW_VERSION/bin --old-datadir=/var/lib/pgsql/data-pg$OLD_VERSION --new-datadir=/var/lib/pgsql/data $FAST_UPGRADE"
 
+cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data
+cp /var/lib/pgsql/data-pg$OLD_VERSION/postgresql.conf /var/lib/pgsql/data/
+
 echo "DONE"`
 
 // PostgreSQLVersionUpgradeTemplateData represents information used to create PostgreSQL upgrade script.

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -112,3 +112,14 @@ func AddDbUpgradeImageFlag(cmd *cobra.Command) {
 func AddMirrorFlag(cmd *cobra.Command) {
 	cmd.Flags().String("mirror", "", L("Path to mirrored packages mounted on the host"))
 }
+
+// AddCocoFlag adds the confidential computing related parameters to cmd.
+func AddCocoFlag(cmd *cobra.Command) {
+	AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"))
+	cmd.Flags().Int("coco-replicas", 0, L("How many replicas of the confidential computing container should be started. (only 0 or 1 supported for now)"))
+
+	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "coco-container", Title: L("Confidential Computing Flags")})
+	_ = utils.AddFlagToHelpGroupID(cmd, "coco-replicas", "coco-container")
+	_ = utils.AddFlagToHelpGroupID(cmd, "coco-image", "coco-container")
+	_ = utils.AddFlagToHelpGroupID(cmd, "coco-tag", "coco-container")
+}

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -277,7 +277,7 @@ func GenerateSystemdConfFile(serviceName string, section string, body string) er
 	systemdConfFilePath := path.Join(systemdConfFolder, section+".conf")
 
 	content := []byte("[" + section + "]" + "\n" + body + "\n")
-	if err := os.WriteFile(systemdConfFilePath, content, 0644); err != nil {
+	if err := os.WriteFile(systemdConfFilePath, content, 0640); err != nil {
 		return utils.Errorf(err, L("cannot write %s file"), systemdConfFilePath)
 	}
 

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -55,6 +55,17 @@ var inspectValues = []types.InspectData{
 	types.NewInspectData("db_port", "cat /etc/rhn/rhn.conf 2>/dev/null | grep '^db_port' | cut -d' ' -f3 || true", false),
 }
 
+// InspectResult holds the results of the inspection scripts.
+type InspectResult struct {
+	Timezone         string `mapstructure:"Timezone"`
+	CurrentPgVersion string `mapstructure:"current_pg_version"`
+	ImagePgVersion   string `mapstructure:"image_pg_version"`
+	DbUser           string `mapstructure:"db_user"`
+	DbPassword       string `mapstructure:"db_password"`
+	DbName           string `mapstructure:"db_name"`
+	DbPort           int    `mapstructure:"db_port"`
+}
+
 // InspectOutputFile represents the directory and the basename where the inspect values are stored.
 var InspectOutputFile = types.InspectFile{
 	Directory: "/var/lib/uyuni-tools",

--- a/uyuni-tools.changes.cbosdo.coco-migrate
+++ b/uyuni-tools.changes.cbosdo.coco-migrate
@@ -1,0 +1,2 @@
+- Setup confidential computing container during migration 
+  (bsc#1227588)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This makes sure coco attestation is usable right after migrating from an old installation.

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24323

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

