### PR TITLE
Fixes the way images URLs are computed

### DIFF
--- a/mgradm/cmd/inspect/kubernetes.go
+++ b/mgradm/cmd/inspect/kubernetes.go
@@ -27,7 +27,7 @@ func kuberneteInspect(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	serverImage, err := utils.ComputeImage(*flags)
+	serverImage, err := utils.ComputeImage("", utils.DefaultTag, *flags)
 	if err != nil && len(serverImage) > 0 {
 		return utils.Errorf(err, L("failed to determine image"))
 	}

--- a/mgradm/cmd/inspect/podman.go
+++ b/mgradm/cmd/inspect/podman.go
@@ -24,7 +24,7 @@ func podmanInspect(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	serverImage, err := utils.ComputeImage(*flags)
+	serverImage, err := utils.ComputeImage("", utils.DefaultTag, *flags)
 	if err != nil && len(serverImage) > 0 {
 		return utils.Errorf(err, L("failed to determine image"))
 	}

--- a/mgradm/cmd/install/kubernetes/kubernetes.go
+++ b/mgradm/cmd/install/kubernetes/kubernetes.go
@@ -38,7 +38,6 @@ NOTE: installing on a remote cluster is not supported yet!
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags kubernetesInstallFlags
-			flags.Image.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, installForKubernetes)
 		},
 	}

--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -65,7 +65,9 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	helmArgs = append(helmArgs, sslArgs...)
 
 	// Deploy Uyuni and wait for it to be up
-	if err := kubernetes.Deploy(cnx, &flags.Image, &flags.Helm, &flags.Ssl, clusterInfos, fqdn, flags.Debug.Java, helmArgs...); err != nil {
+	if err := kubernetes.Deploy(cnx, globalFlags.Registry, &flags.Image, &flags.Helm, &flags.Ssl,
+		clusterInfos, fqdn, flags.Debug.Java, helmArgs...,
+	); err != nil {
 		return shared_utils.Errorf(err, L("cannot deploy uyuni"))
 	}
 

--- a/mgradm/cmd/install/podman/podman.go
+++ b/mgradm/cmd/install/podman/podman.go
@@ -32,7 +32,6 @@ NOTE: installing on a remote podman is not supported yet!
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags podmanInstallFlags
-			flags.Image.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, installForPodman)
 		},
 	}

--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -214,13 +214,12 @@ func AddInstallFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("debug-java", false, L("Enable tomcat and taskomatic remote debugging"))
 	cmd_utils.AddImageFlag(cmd)
 
-	cmd_utils.AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"))
+	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "coco-container", Title: L("Confidential Computing Flags")})
+
+	cmd_utils.AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"), "coco-container", "server-attestation")
 	cmd.Flags().Int("coco-replicas", 0, L("How many replicas of the confidential computing container should be started. (only 0 or 1 supported for now)"))
 
-	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "coco-container", Title: L("Confidential Computing Flags")})
 	_ = utils.AddFlagToHelpGroupID(cmd, "coco-replicas", "coco-container")
-	_ = utils.AddFlagToHelpGroupID(cmd, "coco-image", "coco-container")
-	_ = utils.AddFlagToHelpGroupID(cmd, "coco-tag", "coco-container")
 
 	cmd.Flags().Int("hubxmlrpc-replicas", 0, L("How many replicas of the Hub XML-RPC API service container should be started. (only 0 or 1 supported for now)"))
 	hubXmlrpcImage := path.Join(utils.DefaultNamespace, "server-hub-xmlrpc-api")

--- a/mgradm/cmd/migrate/kubernetes/kubernetes.go
+++ b/mgradm/cmd/migrate/kubernetes/kubernetes.go
@@ -44,8 +44,6 @@ NOTE: migrating to a remote cluster is not supported yet!
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags kubernetesMigrateFlags
-			flags.Image.Registry = globalFlags.Registry
-			flags.DbUpgradeImage.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, migrateToKubernetes)
 		},
 	}

--- a/mgradm/cmd/migrate/podman/podman.go
+++ b/mgradm/cmd/migrate/podman/podman.go
@@ -36,8 +36,6 @@ NOTE: migrating to a remote podman is not supported yet!
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags podmanMigrateFlags
-			flags.Image.Registry = globalFlags.Registry
-			flags.DbUpgradeImage.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, migrateToPodman)
 		},
 	}

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -26,7 +26,7 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 		return fmt.Errorf(L("install podman before running this command"))
 	}
 	sourceFqdn := args[0]
-	serverImage, err := utils.ComputeImage(flags.Image)
+	serverImage, err := utils.ComputeImage(globalFlags.Registry, utils.DefaultTag, flags.Image)
 	if err != nil {
 		return utils.Errorf(err, L("cannot compute image"))
 	}
@@ -59,7 +59,9 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 	}
 
 	if oldPgVersion != newPgVersion {
-		if err := podman.RunPgsqlVersionUpgrade(flags.Image, flags.DbUpgradeImage, oldPgVersion, newPgVersion); err != nil {
+		if err := podman.RunPgsqlVersionUpgrade(
+			globalFlags.Registry, flags.Image, flags.DbUpgradeImage, oldPgVersion, newPgVersion,
+		); err != nil {
 			return utils.Errorf(err, L("cannot run PostgreSQL version upgrade script"))
 		}
 	}

--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -32,7 +32,7 @@ the host machine is register to SCC.
 
 NOTE: for now installing on a remote podman is not supported!
 `),
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags podmanPTFFlags
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, ptfForPodman)

--- a/mgradm/cmd/support/ptf/podman/utils.go
+++ b/mgradm/cmd/support/ptf/podman/utils.go
@@ -30,7 +30,7 @@ func ptfForPodman(
 	if err := flags.checkParameters(); err != nil {
 		return err
 	}
-	return podman.Upgrade(flags.Image, dummyMigration, dummyCoco, args)
+	return podman.Upgrade("", flags.Image, dummyMigration, dummyCoco)
 }
 
 func (flags *podmanPTFFlags) checkParameters() error {

--- a/mgradm/cmd/upgrade/kubernetes/kubernetes.go
+++ b/mgradm/cmd/upgrade/kubernetes/kubernetes.go
@@ -29,8 +29,6 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags kubernetesUpgradeFlags
-			flags.Image.Registry = globalFlags.Registry
-			flags.DbUpgradeImage.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, upgradeKubernetes)
 		},
 	}

--- a/mgradm/cmd/upgrade/podman/podman.go
+++ b/mgradm/cmd/upgrade/podman/podman.go
@@ -25,17 +25,19 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	upgradeCmd := &cobra.Command{
 		Use:   "podman",
 		Short: L("Upgrade a local server on podman"),
-		Args:  cobra.RangeArgs(0, 1),
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var flags podmanUpgradeFlags
-			flags.Image.Registry = globalFlags.Registry
-			flags.DbUpgradeImage.Registry = globalFlags.Registry
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, upgradePodman)
 		},
 	}
+	shared.AddUpgradeFlags(upgradeCmd)
+	podman.AddPodmanArgFlag(upgradeCmd)
+
+	// TODO Help blocks on this command
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: L("List available tag for an image"),
+		Short: L("List available tags for an image"),
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			viper, _ := utils.ReadConfig(cmd, utils.GlobalConfigFilename, globalFlags.ConfigPath)
@@ -44,7 +46,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 			if err := viper.Unmarshal(&flags); err != nil {
 				log.Fatal().Err(err).Msg(L("failed to unmarshall configuration"))
 			}
-			tags, _ := podman.ShowAvailableTag(flags.Image)
+			tags, _ := podman.ShowAvailableTag(globalFlags.Registry, flags.Image)
 			log.Info().Msgf(L("Available Tags for image: %s"), flags.Image.Name)
 			for _, value := range tags {
 				log.Info().Msgf(value)
@@ -53,9 +55,6 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	}
 	shared.AddUpgradeListFlags(listCmd)
 	upgradeCmd.AddCommand(listCmd)
-
-	shared.AddUpgradeFlags(upgradeCmd)
-	podman.AddPodmanArgFlag(upgradeCmd)
 
 	return upgradeCmd
 }

--- a/mgradm/cmd/upgrade/podman/utils.go
+++ b/mgradm/cmd/upgrade/podman/utils.go
@@ -11,5 +11,5 @@ import (
 )
 
 func upgradePodman(globalFlags *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.Command, args []string) error {
-	return podman.Upgrade(flags.Image, flags.DbUpgradeImage, flags.Coco.Image, args)
+	return podman.Upgrade(globalFlags.Registry, flags.Image, flags.DbUpgradeImage, flags.Coco.Image)
 }

--- a/mgradm/cmd/upgrade/shared/flags.go
+++ b/mgradm/cmd/upgrade/shared/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
+	shared_utils "github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 // UpgradeFlags represents flags used for upgrading a server.
@@ -23,7 +24,12 @@ type UpgradeFlags struct {
 func AddUpgradeFlags(cmd *cobra.Command) {
 	utils.AddImageFlag(cmd)
 	utils.AddDbUpgradeImageFlag(cmd)
-	utils.AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"))
+
+	_ = shared_utils.AddFlagHelpGroup(cmd, &shared_utils.Group{
+		ID:    "coco-container",
+		Title: L("Confidential Computing Flags"),
+	})
+	utils.AddContainerImageFlags(cmd, "coco", L("confidential computing attestation"), "coco-container", "server-attestation")
 }
 
 // AddUpgradeListFlags add upgrade list flags to a command.

--- a/mgradm/shared/kubernetes/k3s.go
+++ b/mgradm/shared/kubernetes/k3s.go
@@ -29,7 +29,7 @@ func InstallK3sTraefikConfig(debug bool) {
 }
 
 // RunPgsqlVersionUpgrade perform a PostgreSQL major upgrade.
-func RunPgsqlVersionUpgrade(image types.ImageFlags, upgradeImage types.ImageFlags, nodeName string, oldPgsql string, newPgsql string) error {
+func RunPgsqlVersionUpgrade(registry string, image types.ImageFlags, upgradeImage types.ImageFlags, nodeName string, oldPgsql string, newPgsql string) error {
 	scriptDir, err := os.MkdirTemp("", "mgradm-*")
 	defer os.RemoveAll(scriptDir)
 	if err != nil {
@@ -42,13 +42,12 @@ func RunPgsqlVersionUpgrade(image types.ImageFlags, upgradeImage types.ImageFlag
 
 		upgradeImageUrl := ""
 		if upgradeImage.Name == "" {
-			upgradeImageUrl, err = utils.ComputeImage(image, fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql))
+			upgradeImageUrl, err = utils.ComputeImage(registry, image.Tag, image, fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql))
 			if err != nil {
 				return utils.Errorf(err, L("failed to compute image URL"))
 			}
 		} else {
-			upgradeImage.Tag = image.Tag
-			upgradeImageUrl, err = utils.ComputeImage(upgradeImage)
+			upgradeImageUrl, err = utils.ComputeImage(registry, image.Tag, upgradeImage)
 			if err != nil {
 				return utils.Errorf(err, L("failed to compute image URL"))
 			}

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -214,7 +214,7 @@ func RunMigration(preparedImage string, sshAuthSocket string, sshConfigPath stri
 }
 
 // RunPgsqlVersionUpgrade perform a PostgreSQL major upgrade.
-func RunPgsqlVersionUpgrade(image types.ImageFlags, upgradeImage types.ImageFlags, oldPgsql string, newPgsql string) error {
+func RunPgsqlVersionUpgrade(registry string, image types.ImageFlags, upgradeImage types.ImageFlags, oldPgsql string, newPgsql string) error {
 	log.Info().Msgf(L("Previous PostgreSQL is %[1]s, new one is %[2]s. Performing a DB version upgrade…"), oldPgsql, newPgsql)
 
 	scriptDir, err := os.MkdirTemp("", "mgradm-*")
@@ -231,13 +231,13 @@ func RunPgsqlVersionUpgrade(image types.ImageFlags, upgradeImage types.ImageFlag
 
 		upgradeImageUrl := ""
 		if upgradeImage.Name == "" {
-			upgradeImageUrl, err = utils.ComputeImage(image, fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql))
+			upgradeImageUrl, err = utils.ComputeImage(registry, utils.DefaultTag, image,
+				fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql))
 			if err != nil {
 				return utils.Errorf(err, L("failed to compute image URL"))
 			}
 		} else {
-			upgradeImage.Tag = image.Tag
-			upgradeImageUrl, err = utils.ComputeImage(upgradeImage)
+			upgradeImageUrl, err = utils.ComputeImage(registry, image.Tag, upgradeImage)
 			if err != nil {
 				return utils.Errorf(err, L("failed to compute image URL"))
 			}
@@ -326,12 +326,17 @@ func RunPostUpgradeScript(serverImage string) error {
 }
 
 // Upgrade will upgrade server to the image given as attribute.
-func Upgrade(image types.ImageFlags, upgradeImage types.ImageFlags, cocoImage types.ImageFlags, args []string) error {
+func Upgrade(
+	registry string,
+	image types.ImageFlags,
+	upgradeImage types.ImageFlags,
+	cocoImage types.ImageFlags,
+) error {
 	if err := CallCloudGuestRegistryAuth(); err != nil {
 		return err
 	}
 
-	serverImage, err := utils.ComputeImage(image)
+	serverImage, err := utils.ComputeImage(registry, utils.DefaultTag, image)
 	if err != nil {
 		return fmt.Errorf(L("failed to compute image URL"))
 	}
@@ -372,8 +377,13 @@ func Upgrade(image types.ImageFlags, upgradeImage types.ImageFlags, cocoImage ty
 		err = podman.StartService(podman.ServerService)
 	}()
 	if inspectedValues["image_pg_version"] > inspectedValues["current_pg_version"] {
-		log.Info().Msgf(L("Previous postgresql is %[1]s, instead new one is %[2]s. Performing a DB version upgrade…"), inspectedValues["current_pg_version"], inspectedValues["image_pg_version"])
-		if err := RunPgsqlVersionUpgrade(image, upgradeImage, inspectedValues["current_pg_version"], inspectedValues["image_pg_version"]); err != nil {
+		log.Info().Msgf(
+			L("Previous postgresql is %[1]s, instead new one is %[2]s. Performing a DB version upgrade…"),
+			inspectedValues["current_pg_version"], inspectedValues["image_pg_version"],
+		)
+		if err := RunPgsqlVersionUpgrade(
+			registry, image, upgradeImage, inspectedValues["current_pg_version"], inspectedValues["image_pg_version"],
+		); err != nil {
 			return utils.Errorf(err, L("cannot run PostgreSQL version upgrade script"))
 		}
 	} else if inspectedValues["image_pg_version"] == inspectedValues["current_pg_version"] {
@@ -401,7 +411,7 @@ func Upgrade(image types.ImageFlags, upgradeImage types.ImageFlags, cocoImage ty
 		return utils.Errorf(err, L("error %s is not a valid port number."), inspectedValues["db_port"])
 	}
 
-	err = coco.Upgrade(cocoImage, image,
+	err = coco.Upgrade(registry, cocoImage, image,
 		dbPort, inspectedValues["db_name"], inspectedValues["db_user"], inspectedValues["db_password"])
 	if err != nil {
 		return utils.Errorf(err, L("error upgrading confidential computing service."))

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -75,11 +75,23 @@ func AddHelmInstallFlag(cmd *cobra.Command) {
 }
 
 // AddContainerImageFlags add container image flags to command.
-func AddContainerImageFlags(cmd *cobra.Command, container string, displayName string) {
-	cmd.Flags().String(container+"-image", "",
-		fmt.Sprintf(L("Image for %s container, overrides the namespace if set"), displayName))
+func AddContainerImageFlags(
+	cmd *cobra.Command,
+	container string,
+	displayName string,
+	groupName string,
+	imageName string,
+) {
+	defaultImage := path.Join(utils.DefaultNamespace, imageName)
+	cmd.Flags().String(container+"-image", defaultImage,
+		fmt.Sprintf(L("Image for %s container"), displayName))
 	cmd.Flags().String(container+"-tag", "",
 		fmt.Sprintf(L("Tag for %s container, overrides the global value if set"), displayName))
+
+	if groupName != "" {
+		_ = utils.AddFlagToHelpGroupID(cmd, container+"-image", groupName)
+		_ = utils.AddFlagToHelpGroupID(cmd, container+"-tag", groupName)
+	}
 }
 
 // AddImageFlag add Image flags to a command.

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -36,15 +36,6 @@ type Tuning struct {
 
 // Get the full container image name and tag for a container name.
 func (f *ProxyImageFlags) GetContainerImage(name string) string {
-	registry := utils.DefaultNamespace
-	if len(f.Registry) != 0 {
-		registry = f.Registry
-	}
-	computedImage := types.ImageFlags{
-		Name: path.Join(registry, "proxy-"+name),
-		Tag:  f.Tag,
-	}
-
 	var containerImage *types.ImageFlags
 	switch name {
 	case "httpd":
@@ -58,19 +49,10 @@ func (f *ProxyImageFlags) GetContainerImage(name string) string {
 	case "tftpd":
 		containerImage = &f.Tftpd
 	default:
-		log.Warn().Msgf(L("Invalid proxy container name: %s"), name)
+		log.Fatal().Msgf(L("Invalid proxy container name: %s"), name)
 	}
 
-	if containerImage != nil {
-		if containerImage.Name != "" {
-			computedImage.Name = containerImage.Name
-		}
-		if containerImage.Tag != "" {
-			computedImage.Tag = containerImage.Tag
-		}
-	}
-
-	imageUrl, err := utils.ComputeImage(computedImage)
+	imageUrl, err := utils.ComputeImage(f.Registry, f.Tag, *containerImage)
 	if err != nil {
 		log.Fatal().Err(err).Msg(L("failed to compute image URL"))
 	}
@@ -83,7 +65,7 @@ func AddImageFlags(cmd *cobra.Command) {
 	utils.AddPullPolicyFlag(cmd)
 
 	addContainerImageFlags(cmd, "httpd")
-	addContainerImageFlags(cmd, "saltBroker")
+	addContainerImageFlags(cmd, "salt-broker")
 	addContainerImageFlags(cmd, "squid")
 	addContainerImageFlags(cmd, "ssh")
 	addContainerImageFlags(cmd, "tftpd")
@@ -93,8 +75,9 @@ func AddImageFlags(cmd *cobra.Command) {
 }
 
 func addContainerImageFlags(cmd *cobra.Command, container string) {
-	cmd.Flags().String(container+"-image", "",
-		fmt.Sprintf(L("Image for %s container, overrides the namespace if set"), container))
+	defaultImage := path.Join(utils.DefaultNamespace, "proxy-"+container)
+	cmd.Flags().String(container+"-image", defaultImage,
+		fmt.Sprintf(L("Image for %s container"), container))
 	cmd.Flags().String(container+"-tag", "",
 		fmt.Sprintf(L("Tag for %s container, overrides the global value if set"), container))
 }

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -64,20 +64,20 @@ func AddImageFlags(cmd *cobra.Command) {
 	cmd.Flags().String("tag", utils.DefaultTag, L("image tag"))
 	utils.AddPullPolicyFlag(cmd)
 
-	addContainerImageFlags(cmd, "httpd")
-	addContainerImageFlags(cmd, "salt-broker")
-	addContainerImageFlags(cmd, "squid")
-	addContainerImageFlags(cmd, "ssh")
-	addContainerImageFlags(cmd, "tftpd")
+	addContainerImageFlags(cmd, "httpd", "httpd")
+	addContainerImageFlags(cmd, "saltbroker", "salt-broker")
+	addContainerImageFlags(cmd, "squid", "squid")
+	addContainerImageFlags(cmd, "ssh", "ssh")
+	addContainerImageFlags(cmd, "tftpd", "tftpd")
 
 	cmd.Flags().String("tuning-httpd", "", L("HTTPD tuning configuration file"))
 	cmd.Flags().String("tuning-squid", "", L("Squid tuning configuration file"))
 }
 
-func addContainerImageFlags(cmd *cobra.Command, container string) {
-	defaultImage := path.Join(utils.DefaultNamespace, "proxy-"+container)
-	cmd.Flags().String(container+"-image", defaultImage,
-		fmt.Sprintf(L("Image for %s container"), container))
-	cmd.Flags().String(container+"-tag", "",
-		fmt.Sprintf(L("Tag for %s container, overrides the global value if set"), container))
+func addContainerImageFlags(cmd *cobra.Command, paramName string, imageName string) {
+	defaultImage := path.Join(utils.DefaultNamespace, "proxy-"+imageName)
+	cmd.Flags().String(paramName+"-image", defaultImage,
+		fmt.Sprintf(L("Image for %s container"), imageName))
+	cmd.Flags().String(paramName+"-tag", "",
+		fmt.Sprintf(L("Tag for %s container, overrides the global value if set"), imageName))
 }

--- a/mgrpxy/shared/utils/flags_test.go
+++ b/mgrpxy/shared/utils/flags_test.go
@@ -7,30 +7,31 @@ package utils
 import (
 	"testing"
 
-	"github.com/uyuni-project/uyuni-tools/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-func TestGetContainerImageDefaultNamespace(t *testing.T) {
-	utils.DefaultNamespace = "mynamespace"
-	proxyFlags := ProxyImageFlags{
-		Tag: "mytag",
+func TestGetContainerImage(t *testing.T) {
+	data := [][]string{
+		// Expectect image, value of --registry, value of --tag, value of --http-image, value of --http-tag
+		{"registry/default/image/proxy-httpd:tag", "registry/default/image/", "tag", "registry/default/image/proxy-httpd", ""},
+		{"registry/default/image/proxy-httpd:tag", "registry", "tag", "registry/default/image/proxy-httpd", ""},
+		{"myregistry.example.com/default/image/proxy-httpd:tag", "myregistry.example.com", "tag", "default/image/proxy-httpd", ""},
+		{"default/image/proxy-httpd:mytag", "default/image", "tag", "default/image/proxy-httpd", "mytag"},
+		{"myregistry/path/proxy-httpd:tag", "registry/path", "tag", "myregistry/path/proxy-httpd", ""},
 	}
-	imageName := proxyFlags.GetContainerImage("httpd")
-	imageExpected := "mynamespace/proxy-httpd:mytag"
-	if imageName != imageExpected {
-		t.Errorf("Image name %s does not match expected %s", imageName, imageExpected)
-	}
-}
 
-func TestGetContainerImageCustomRegistry(t *testing.T) {
-	utils.DefaultNamespace = "mynamespace"
-	proxyFlags := ProxyImageFlags{
-		Registry: "mytestregistry.example.com",
-		Tag:      "mytag",
-	}
-	imageName := proxyFlags.GetContainerImage("httpd")
-	imageExpected := "mytestregistry.example.com/proxy-httpd:mytag"
-	if imageName != imageExpected {
-		t.Errorf("Image name %s does not match expected %s", imageName, imageExpected)
+	for i, testCase := range data {
+		proxyFlags := ProxyImageFlags{
+			Tag:      testCase[2],
+			Registry: testCase[1],
+			Httpd: types.ImageFlags{
+				Name: testCase[3],
+				Tag:  testCase[4],
+			},
+		}
+		imageName := proxyFlags.GetContainerImage("httpd")
+		if imageName != testCase[0] {
+			t.Errorf("Testcase %d: Image name %s does not match expected %s", i, imageName, testCase[0])
+		}
 	}
 }

--- a/shared/podman/images.go
+++ b/shared/podman/images.go
@@ -221,10 +221,10 @@ func pullImage(image string, args ...string) error {
 }
 
 // ShowAvailableTag  returns the list of available tag for a given image.
-func ShowAvailableTag(image types.ImageFlags) ([]string, error) {
+func ShowAvailableTag(registry string, image types.ImageFlags) ([]string, error) {
 	log.Info().Msgf(L("Running podman image search --list-tags %s --format={{.Tag}}"), image.Name)
 
-	name, err := utils.ComputeImage(image)
+	name, err := utils.ComputeImage(registry, utils.DefaultTag, image)
 	if err != nil {
 		return []string{}, err
 	}

--- a/shared/types/images.go
+++ b/shared/types/images.go
@@ -6,7 +6,6 @@ package types
 
 // ImageFlags represents the flags used by an image.
 type ImageFlags struct {
-	Registry   string `mapstructure:"registry"`
 	Name       string `mapstructure:"image"`
 	Tag        string `mapstructure:"tag"`
 	PullPolicy string `mapstructure:"pullPolicy"`

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -182,16 +182,17 @@ func RemoveRegistryFromImage(imagePath string) string {
 }
 
 // ComputeImage assembles the container image from its name and tag.
-func ComputeImage(imageFlags types.ImageFlags, appendToName ...string) (string, error) {
-	if !strings.Contains(DefaultNamespace, imageFlags.Registry) {
-		log.Info().Msgf(L("Registry %[1]s would be used instead of namespace %[2]s"), imageFlags.Registry, DefaultNamespace)
-	}
+func ComputeImage(registry string, globalTag string, imageFlags types.ImageFlags, appendToName ...string) (string, error) {
 	name := imageFlags.Name
-	if !strings.Contains(imageFlags.Name, imageFlags.Registry) {
-		name = path.Join(imageFlags.Registry, RemoveRegistryFromImage(imageFlags.Name))
-		log.Info().Msgf(L("The image name provided is %[1]s and does not contains the registry %[2]s. The image name used will be %[3]s. You can set the flag --registry to change this behaviour."), imageFlags.Name, imageFlags.Registry, name)
+	if !strings.Contains(imageFlags.Name, registry) {
+		name = path.Join(registry, RemoveRegistryFromImage(imageFlags.Name))
 	}
-	tag := imageFlags.Tag
+
+	// Compute the tag
+	tag := globalTag
+	if imageFlags.Tag != "" {
+		tag = imageFlags.Tag
+	}
 
 	submatches := imageValid.FindStringSubmatch(name)
 	if submatches == nil {
@@ -207,12 +208,12 @@ func ComputeImage(imageFlags types.ImageFlags, appendToName ...string) (string, 
 		// No tag provided in the URL name, append the one passed
 		imageName := fmt.Sprintf("%s:%s", name, tag)
 		imageName = strings.ToLower(imageName) // podman does not accept repo in upper case
-		log.Debug().Msgf("Computed image name is %s", imageName)
+		log.Info().Msgf(L("Computed image name is %s"), imageName)
 		return imageName, nil
 	}
 	imageName := submatches[1] + strings.Join(appendToName, ``) + `:` + submatches[2]
 	imageName = strings.ToLower(imageName) // podman does not accept repo in upper case
-	log.Debug().Msgf("Computed image name is %s", imageName)
+	log.Info().Msgf(L("Computed image name is %s"), imageName)
 	return imageName, nil
 }
 

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -236,13 +236,12 @@ func TestComputeImage(t *testing.T) {
 	for i, testCase := range data {
 		result := testCase[0]
 		image := types.ImageFlags{
-			Name:     testCase[1],
-			Tag:      testCase[2],
-			Registry: testCase[3],
+			Name: testCase[1],
+			Tag:  testCase[2],
 		}
 		appendToImage := testCase[4:]
 
-		actual, err := ComputeImage(image, appendToImage...)
+		actual, err := ComputeImage(testCase[3], "defaulttag", image, appendToImage...)
 
 		if err != nil {
 			t.Errorf("Testcase %d: Unexpected error while computing image with %s, %s, %s: %s", i, image.Name, image.Tag, appendToImage, err)
@@ -264,7 +263,7 @@ func TestComputeImageError(t *testing.T) {
 			Tag:  testCase[1],
 		}
 
-		_, err := ComputeImage(image)
+		_, err := ComputeImage("defaultregistry", "defaulttag", image)
 		if err == nil {
 			t.Errorf("Expected error for %s with tag %s, got none", image.Name, image.Tag)
 		}

--- a/uyuni-tools.changes.cbosdo.defaults-fix
+++ b/uyuni-tools.changes.cbosdo.defaults-fix
@@ -1,0 +1,1 @@
+- Use the same logic for image computation in mgradm and mgrpxy (bsc#1228026)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This fixes a few issues in the image URLs computing:

* The registry had to be copied from the global flags to the `ImageFlags`. This is quite error prone and already some images didn't have it.
* Don't use a different way to compute images in the proxy and the server tools.

This PR changes the `ComputeImage()` function to pass the registry and flags as parameters to avoid mistakes and move the tags computation there.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24849

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

