### PR TITLE
Add --prepare option to migrate command

### DIFF
--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -65,7 +65,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	helmArgs = append(helmArgs, sslArgs...)
 
 	// Deploy Uyuni and wait for it to be up
-	if err := kubernetes.Deploy(cnx, &flags.Image, &flags.Helm, &flags.Ssl, clusterInfos, fqdn, flags.Debug.Java, helmArgs...); err != nil {
+	if err := kubernetes.Deploy(cnx, &flags.Image, &flags.Helm, &flags.Ssl, clusterInfos, fqdn, flags.Debug.Java, false, helmArgs...); err != nil {
 		return shared_utils.Errorf(err, L("cannot deploy uyuni"))
 	}
 

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -52,7 +52,7 @@ func migrateToKubernetes(
 	sshConfigPath, sshKnownhostsPath := migration_shared.GetSshPaths()
 
 	// Prepare the migration script and folder
-	scriptDir, err := adm_utils.GenerateMigrationScript(fqdn, flags.User, true)
+	scriptDir, err := adm_utils.GenerateMigrationScript(fqdn, flags.User, true, flags.Prepare)
 	if err != nil {
 		return utils.Errorf(err, L("failed to generate migration script"))
 	}
@@ -88,6 +88,11 @@ func migrateToKubernetes(
 	// Run the actual migration
 	if err := adm_utils.RunMigration(cnx, scriptDir, "migrate.sh"); err != nil {
 		return utils.Errorf(err, L("cannot run migration"))
+	}
+
+	if flags.Prepare {
+		log.Info().Msg(L("Migration prepared. Run the 'migrate' command without '--prepare' to finish the migration."))
+		return nil
 	}
 
 	tz, oldPgVersion, newPgVersion, err := adm_utils.ReadContainerData(scriptDir)

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -35,9 +35,13 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 	sshAuthSocket := migration_shared.GetSshAuthSocket()
 	sshConfigPath, sshKnownhostsPath := migration_shared.GetSshPaths()
 
-	tz, oldPgVersion, newPgVersion, err := podman.RunMigration(serverImage, flags.Image.PullPolicy, sshAuthSocket, sshConfigPath, sshKnownhostsPath, sourceFqdn, flags.User)
+	tz, oldPgVersion, newPgVersion, err := podman.RunMigration(serverImage, flags.Image.PullPolicy, sshAuthSocket, sshConfigPath, sshKnownhostsPath, sourceFqdn, flags.User, flags.Prepare)
 	if err != nil {
 		return utils.Errorf(err, L("cannot run migration script"))
+	}
+	if flags.Prepare {
+		log.Info().Msg(L("Migration prepared. Run the 'migrate' command without '--prepare' to finish the migration."))
+		return nil
 	}
 
 	if oldPgVersion != newPgVersion {

--- a/mgradm/cmd/migrate/shared/flags.go
+++ b/mgradm/cmd/migrate/shared/flags.go
@@ -13,6 +13,7 @@ import (
 
 // MigrateFlags represents flag required by migration command.
 type MigrateFlags struct {
+	Prepare        bool
 	Image          types.ImageFlags `mapstructure:",squash"`
 	DbUpgradeImage types.ImageFlags `mapstructure:"dbupgrade"`
 	User           string
@@ -21,6 +22,7 @@ type MigrateFlags struct {
 
 // AddMigrateFlags add migration flags to a command.
 func AddMigrateFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("prepare", false, L("Prepare the mgration - copy the data without stopping the source server."))
 	utils.AddMirrorFlag(cmd)
 	utils.AddImageFlag(cmd)
 	utils.AddDbUpgradeImageFlag(cmd)

--- a/mgradm/shared/kubernetes/install.go
+++ b/mgradm/shared/kubernetes/install.go
@@ -26,14 +26,16 @@ const HELM_APP_NAME = "uyuni"
 // Deploy execute a deploy of a given image and helm to a cluster.
 func Deploy(cnx *shared.Connection, imageFlags *types.ImageFlags,
 	helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.SslCertFlags, clusterInfos *kubernetes.ClusterInfos,
-	fqdn string, debug bool, helmArgs ...string) error {
+	fqdn string, debug bool, prepare bool, helmArgs ...string) error {
 	// If installing on k3s, install the traefik helm config in manifests
 	isK3s := clusterInfos.IsK3s()
 	IsRke2 := clusterInfos.IsRke2()
-	if isK3s {
-		InstallK3sTraefikConfig(debug)
-	} else if IsRke2 {
-		kubernetes.InstallRke2NginxConfig(utils.TCP_PORTS, utils.UDP_PORTS, helmFlags.Uyuni.Namespace)
+	if !prepare {
+		if isK3s {
+			InstallK3sTraefikConfig(debug)
+		} else if IsRke2 {
+			kubernetes.InstallRke2NginxConfig(utils.TCP_PORTS, utils.UDP_PORTS, helmFlags.Uyuni.Namespace)
+		}
 	}
 
 	serverImage, err := utils.ComputeImage(*imageFlags)

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -177,8 +177,8 @@ func UpdateSslCertificate(cnx *shared.Connection, chain *ssl.CaChain, serverPair
 }
 
 // RunMigration migrate an existing remote server to a container.
-func RunMigration(serverImage string, pullPolicy string, sshAuthSocket string, sshConfigPath string, sshKnownhostsPath string, sourceFqdn string, user string) (string, string, string, error) {
-	scriptDir, err := adm_utils.GenerateMigrationScript(sourceFqdn, user, false)
+func RunMigration(serverImage string, pullPolicy string, sshAuthSocket string, sshConfigPath string, sshKnownhostsPath string, sourceFqdn string, user string, prepare bool) (string, string, string, error) {
+	scriptDir, err := adm_utils.GenerateMigrationScript(sourceFqdn, user, false, prepare)
 	if err != nil {
 		return "", "", "", utils.Errorf(err, L("cannot generate migration script"))
 	}

--- a/mgradm/shared/utils/exec.go
+++ b/mgradm/shared/utils/exec.go
@@ -131,7 +131,7 @@ func RunMigration(cnx *shared.Connection, tmpPath string, scriptName string) err
 }
 
 // GenerateMigrationScript generates the script that perform migration.
-func GenerateMigrationScript(sourceFqdn string, user string, kubernetes bool) (string, error) {
+func GenerateMigrationScript(sourceFqdn string, user string, kubernetes bool, prepare bool) (string, error) {
 	scriptDir, err := os.MkdirTemp("", "mgradm-*")
 	if err != nil {
 		return "", utils.Errorf(err, L("failed to create temporary directory"))
@@ -142,6 +142,7 @@ func GenerateMigrationScript(sourceFqdn string, user string, kubernetes bool) (s
 		SourceFqdn: sourceFqdn,
 		User:       user,
 		Kubernetes: kubernetes,
+		Prepare:    prepare,
 	}
 
 	scriptPath := filepath.Join(scriptDir, "migrate.sh")

--- a/uyuni-tools.changes.nadvornik.prepare
+++ b/uyuni-tools.changes.nadvornik.prepare
@@ -1,0 +1,1 @@
+- Add --prepare option to migrate command


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR adds `--prepare` option to `migrate` command.
With this option, the migration does not stop the services on source server and ends after syncing
the data.


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/181

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

