### PR TITLE
Fix password entry usability (bsc#1226437)

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -100,9 +100,12 @@ func CheckValidPassword(value *string, prompt string, min int, max int) string {
 		return ""
 	}
 
-	if !invalidChars && checkValueSize(tmpValue, min, max) {
-		*value = tmpValue
+	if !checkValueSize(tmpValue, min, max) {
+		fmt.Println()
+		return ""
 	}
+	fmt.Println()
+	*value = tmpValue
 	return *value
 }
 
@@ -114,7 +117,7 @@ func AskPasswordIfMissing(value *string, prompt string, min int, max int) {
 		if firstRound == "" {
 			continue
 		}
-		secondRound := CheckValidPassword(value, "\nConfirm the password", min, max)
+		secondRound := CheckValidPassword(value, "Confirm the password", min, max)
 		if secondRound != firstRound {
 			fmt.Println(L("Two different passwords have been provided"))
 			*value = ""

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -117,7 +117,7 @@ func AskPasswordIfMissing(value *string, prompt string, min int, max int) {
 		if firstRound == "" {
 			continue
 		}
-		secondRound := CheckValidPassword(value, "Confirm the password", min, max)
+		secondRound := CheckValidPassword(value, L("Confirm the password"), min, max)
 		if secondRound != firstRound {
 			fmt.Println(L("Two different passwords have been provided"))
 			*value = ""

--- a/uyuni-tools.changes.nadvornik.password
+++ b/uyuni-tools.changes.nadvornik.password
@@ -1,0 +1,1 @@
+- Fix password entry usability (bsc#1226437)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

- print a new line to indicate that a password was entered
- print new lines consistently during password validation
- fix a bug when valid password followed by too short confirmation got through the validation

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24640
https://bugzilla.suse.com/show_bug.cgi?id=1226437

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

