### PR TITLE
Define --registry flag behaviour (bsc#1226793)

### DIFF
--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -188,13 +188,49 @@ func TestComputeImage(t *testing.T) {
 		{"registry:5000/path/to/image:bar", "registry:5000/path/to/image", "bar", ""},
 		{"registry/path/to/image:foo", "registry/path/to/image:foo", "bar", ""},
 		{"registry/path/to/image:bar", "registry/path/to/image", "bar", ""},
-		{"registry/path/to/image:bar", "orig/path/to/image", "bar", "registry/path/to/"},
-		{"registry:5000/path/to/image:foo", "path/to/image:foo", "BAR", "REGISTRY:5000/path/to"},
+		{"registry/path/to/image:bar", "path/to/image", "bar", "registry"},
+		{"registry:5000/path/to/image:foo", "path/to/image:foo", "BAR", "REGISTRY:5000"},
 		{"registry:5000/path/to/image-migration-14-16:foo", "registry:5000/path/to/image:foo", "bar", "", "-migration-14-16"},
 		{"registry:5000/path/to/image-migration-14-16:bar", "registry:5000/path/to/image", "bar", "", "-migration-14-16"},
 		{"registry/path/to/image-migration-14-16:foo", "registry/path/to/image:foo", "bar", "", "-migration-14-16"},
 		{"registry/path/to/image-migration-14-16:bar", "registry/path/to/image", "bar", "", "-migration-14-16"},
-		{"registry/path/to/image-migration-14-16:bar", "path/to/image", "bar", "registry/path/to", "-migration-14-16"},
+		{"registry/path/to/image-migration-14-16:bar", "path/to/image", "bar", "registry", "-migration-14-16"},
+		{
+			// bsc#1226436
+			"registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64/server:bar",
+			"registry.suse.com/suse/manager/5.0/x86_64/server",
+			"bar",
+			"registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile",
+			"",
+		},
+		{
+			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
+			"registry.suse.com/suse/manager/5.0/x86_64/server",
+			"5.0.0",
+			"cloud.com",
+			"",
+		},
+		{
+			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
+			"/suse/manager/5.0/x86_64/server",
+			"5.0.0",
+			"cloud.com",
+			"",
+		},
+		{
+			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
+			"suse/manager/5.0/x86_64/server",
+			"5.0.0",
+			"cloud.com",
+			"",
+		},
+		{
+			"cloud.com/my/path/server:5.0.0",
+			"my/path/server",
+			"5.0.0",
+			"cloud.com",
+			"",
+		},
 	}
 
 	for i, testCase := range data {

--- a/uyuni-tools.changes.nadvornik.registry2
+++ b/uyuni-tools.changes.nadvornik.registry2
@@ -1,0 +1,1 @@
+- Define --registry flag behaviour (bsc#1226793)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This is a minimal change to implement the --registry flag behaviour as described in https://github.com/uyuni-project/uyuni-tools/issues/378 , except for default values.

The defaults are not changed - `--image` contains the registry and `--registry` is empty.
This PR has an effect only if non-empty `--registry` is specified.

Changing the defaults would require much more changes and testing.


## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s):
https://github.com/uyuni-project/uyuni-tools/issues/378
https://github.com/SUSE/spacewalk/issues/24638
https://bugzilla.suse.com/show_bug.cgi?id=1226793

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

