### PR TITLE
Prefer local images in all migration steps (bsc#1227244)

### DIFF
--- a/uyuni-tools.changes.rmateus.fix_local_image_migrate
+++ b/uyuni-tools.changes.rmateus.fix_local_image_migrate
@@ -1,0 +1,1 @@
+- Prefer local images in all migration steps (bsc#1227244)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fix: https://bugzilla.suse.com/show_bug.cgi?id=1227244

The migration process has several different steps that need to use images. The image path, and if it should be local or remote was done in the first to steps but not on the next ones. Move the server image computation to outside, and passed that as an argument.


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

