### PR TITLE
Fix random error during installation of CA certificate (bsc#1227245)

### DIFF
--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -89,6 +89,11 @@ func migrateToPodman(globalFlags *types.GlobalFlags, flags *podmanMigrateFlags, 
 	}
 
 	cnx := shared.NewConnection("podman", podman_utils.ServerContainerName, "")
+
+	if err := cnx.WaitForContainer(); err != nil {
+		return err
+	}
+
 	if err := cnx.CopyCaCertificate(sourceFqdn); err != nil {
 		return utils.Errorf(err, L("failed to add SSL CA certificate to host trusted certificates"))
 	}

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -169,13 +169,43 @@ func (c *Connection) Exec(command string, args ...string) ([]byte, error) {
 	return utils.RunCmdOutput(zerolog.DebugLevel, cmd, cmdArgs...)
 }
 
+// WaitForContainer waits up to 10 sec for the container to appear.
+func (c *Connection) WaitForContainer() error {
+	for i := 0; i < 10; i++ {
+		podName, err := c.GetPodName()
+		if err != nil {
+			log.Warn().Err(err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		args := []string{"exec", podName}
+		command, err := c.GetCommand()
+		if err != nil {
+			log.Fatal().Err(err)
+		}
+
+		if command == "kubectl" {
+			args = append(args, "--")
+		}
+		args = append(args, "true")
+		err = utils.RunCmd(command, args...)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return errors.New(L("container didn't start within 10s."))
+}
+
 // WaitForServer waits at most 60s for multi-user systemd target to be reached.
 func (c *Connection) WaitForServer() error {
 	// Wait for the system to be up
 	for i := 0; i < 60; i++ {
 		podName, err := c.GetPodName()
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Warn().Err(err)
+			time.Sleep(1 * time.Second)
+			continue
 		}
 
 		args := []string{"exec", podName}

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -174,14 +174,14 @@ func (c *Connection) WaitForContainer() error {
 	for i := 0; i < 10; i++ {
 		podName, err := c.GetPodName()
 		if err != nil {
-			log.Warn().Err(err)
+			log.Debug().Err(err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		args := []string{"exec", podName}
 		command, err := c.GetCommand()
 		if err != nil {
-			log.Fatal().Err(err)
+			return err
 		}
 
 		if command == "kubectl" {
@@ -203,7 +203,7 @@ func (c *Connection) WaitForServer() error {
 	for i := 0; i < 60; i++ {
 		podName, err := c.GetPodName()
 		if err != nil {
-			log.Warn().Err(err)
+			log.Debug().Err(err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -211,7 +211,7 @@ func (c *Connection) WaitForServer() error {
 		args := []string{"exec", podName}
 		command, err := c.GetCommand()
 		if err != nil {
-			log.Fatal().Err(err)
+			return err
 		}
 
 		if command == "kubectl" {

--- a/uyuni-tools.changes.nadvornik.waitforserver
+++ b/uyuni-tools.changes.nadvornik.waitforserver
@@ -1,0 +1,1 @@
+- Fix random error during installation of CA certificate (bsc#1227245)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When a container is started via systemd, there is a short period when
GetPodName() can fail or GetPodName() succeeds and the following command fails.

It was reported on migration, but I think it can happen on install too. It is more likely on migration, probably because of large writes.

This PR fixes it.

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): 
https://github.com/SUSE/spacewalk/issues/24705
https://bugzilla.suse.com/show_bug.cgi?id=1227245

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

