### PR TITLE
Break recursion in the help of child commands of flags grouped ones

### DIFF
--- a/shared/utils/flaggroups.go
+++ b/shared/utils/flaggroups.go
@@ -62,7 +62,8 @@ func usageFunc(cmd *cobra.Command) error {
 	cmd.SetUsageTemplate(template)
 
 	// call the original UsageFunc with the modified template
-	cmd.SetUsageFunc(nil)
+	blankCmd := cobra.Command{}
+	cmd.SetUsageFunc(blankCmd.UsageFunc())
 	origUsageFunc := cmd.UsageFunc()
 	cmd.SetUsageFunc(usageFunc)
 

--- a/uyuni-tools.changes.cbosdo.defaults-fix
+++ b/uyuni-tools.changes.cbosdo.defaults-fix
@@ -1,0 +1,1 @@
+- Fix recursion in mgradm upgrade podman list --help


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Cobra inherits the `UsageFunc` from the parent classes, and the implementation for the grouped flags was recursing: using the function of a blank command object rather than setting to default breaks the loop.

## Test coverage
- No tests: help fix
- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

