### PR TITLE
Strip the new line when checking for IPv6 on podman network

### DIFF
--- a/shared/podman/network.go
+++ b/shared/podman/network.go
@@ -17,6 +17,15 @@ import (
 // The name of the podman network for Uyuni and its proxies.
 const UyuniNetwork = "uyuni"
 
+func hasIpv6Enabled(network string) bool {
+	hasIpv6, err := utils.RunCmdOutput(zerolog.DebugLevel, "podman", "network", "inspect",
+		"--format", "{{.IPv6Enabled}}", network)
+	if err == nil && strings.TrimSpace(string(hasIpv6)) == "true" {
+		return true
+	}
+	return false
+}
+
 // SetupNetwork creates the podman network.
 func SetupNetwork(isProxy bool) error {
 	log.Info().Msgf(L("Setting up %s network"), UyuniNetwork)
@@ -28,19 +37,17 @@ func SetupNetwork(isProxy bool) error {
 	if networkExists {
 		log.Debug().Msgf("%s network already present", UyuniNetwork)
 		// Check if the uyuni network exists and is IPv6 enabled
-		hasIpv6, err := utils.RunCmdOutput(zerolog.DebugLevel, "podman", "network", "inspect", "--format", "{{.IPv6Enabled}}", UyuniNetwork)
-		if err == nil {
-			if string(hasIpv6) != "true" && ipv6Enabled {
-				log.Info().Msgf(L("%s network doesn't have IPv6, deleting existing network to enable IPv6 on it"), UyuniNetwork)
-				err := utils.RunCmd("podman", "network", "rm", UyuniNetwork,
-					"--log-level", log.Logger.GetLevel().String())
-				if err != nil {
-					return utils.Errorf(err, L("failed to remove %s podman network"), UyuniNetwork)
-				}
-			} else {
-				log.Info().Msgf(L("Reusing existing %s network"), UyuniNetwork)
-				return nil
+		hasIpv6 := hasIpv6Enabled(UyuniNetwork)
+		if !hasIpv6 && ipv6Enabled {
+			log.Info().Msgf(L("%s network doesn't have IPv6, deleting existing network to enable IPv6 on it"), UyuniNetwork)
+			err := utils.RunCmd("podman", "network", "rm", UyuniNetwork,
+				"--log-level", log.Logger.GetLevel().String())
+			if err != nil {
+				return utils.Errorf(err, L("failed to remove %s podman network"), UyuniNetwork)
 			}
+		} else {
+			log.Info().Msgf(L("Reusing existing %s network"), UyuniNetwork)
+			return nil
 		}
 	}
 

--- a/uyuni-tools.changes.cbosdo.ipv6-fix
+++ b/uyuni-tools.changes.cbosdo.ipv6-fix
@@ -1,0 +1,1 @@
+- Properly detect IPv6 enabled on podman network (bsc#1224349)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The command outputs usually have a trailing new line, which fails value != "true" in all cases. This is forcing the update of the podman network even if it's not needed.

## Test coverage
- No tests: testing command outputs is still not possible without a big refactoring
- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24353

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

