### PR TITLE
Use the basename of the SQL file as filename in the container

### DIFF
--- a/mgradm/cmd/support/sql/sql.go
+++ b/mgradm/cmd/support/sql/sql.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -25,9 +26,10 @@ import (
 )
 
 func prepareSource(args []string, cnx *shared.Connection) (string, error) {
-	source := "-"
+	target := "-"
 	if len(args) > 0 {
-		source = args[0]
+		source := args[0]
+		target = path.Base(source)
 		if !utils.FileExists(source) {
 			return "", fmt.Errorf(L("source %s does not exists"), source)
 		}
@@ -35,12 +37,12 @@ func prepareSource(args []string, cnx *shared.Connection) (string, error) {
 		if _, err := rand.Read(randBytes); err != nil {
 			return "", utils.Errorf(err, L("unable to get random file prefix"))
 		}
-		source = hex.EncodeToString(randBytes) + source
-		if err := cnx.Copy(args[0], "server:"+source, "", ""); err != nil {
+		target = hex.EncodeToString(randBytes) + target
+		if err := cnx.Copy(args[0], "server:"+target, "", ""); err != nil {
 			return "", err
 		}
 	}
-	return source, nil
+	return target, nil
 }
 
 func cleanupSource(file string, cnx *shared.Connection) {
@@ -176,7 +178,6 @@ func (l copyWriter) Write(p []byte) (n int, err error) {
 			// Trim CR added by stdlog.
 			p = p[0 : n-1]
 		}
-		log.Debug().Msg(string(p))
 	}
 	return
 }

--- a/uyuni-tools.changes.cbosdo.sql-file-fix
+++ b/uyuni-tools.changes.cbosdo.sql-file-fix
@@ -1,0 +1,1 @@
+- Use path in mgradm support sql file input (bsc#1227505)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

To make sure there is no slash in the path of the SQL file in the container use the basename to compute the temporary filename.

## Test coverage
- No tests: executed commands cannot be unit tested yet

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24745

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

