### PR TITLE
Create config flags for helm charts registry path

### DIFF
--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -223,7 +223,7 @@ func AddInstallFlags(cmd *cobra.Command) {
 	_ = utils.AddFlagToHelpGroupID(cmd, "coco-tag", "coco-container")
 
 	cmd.Flags().Int("hubxmlrpc-replicas", 0, L("How many replicas of the Hub XML-RPC API service container should be started. (only 0 or 1 supported for now)"))
-	hubXmlrpcImage := path.Join(utils.DefaultNamespace, "server-hub-xmlrpc-api")
+	hubXmlrpcImage := path.Join(utils.DefaultRegistry, "server-hub-xmlrpc-api")
 	cmd.Flags().String("hubxmlrpc-image", hubXmlrpcImage, L("Hub XML-RPC API Image"))
 	cmd.Flags().String("hubxmlrpc-tag", utils.DefaultTag, L("Hub XML-RPC API Image Tag"))
 

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var defaultImage = path.Join(utils.DefaultNamespace, "server")
+var defaultImage = path.Join(utils.DefaultRegistry, "server")
 
 // HelmFrags stores Uyuni and Cert Manager Helm information.
 type HelmFlags struct {
@@ -52,7 +52,7 @@ func (f *SslCertFlags) CheckParameters() {
 
 // AddHelmInstallFlag add Helm install flags to a command.
 func AddHelmInstallFlag(cmd *cobra.Command) {
-	defaultChart := fmt.Sprintf("oci://%s/server-helm", utils.DefaultNamespace)
+	defaultChart := fmt.Sprintf("oci://%s/server-helm", utils.DefaultHelmRegistry)
 
 	cmd.Flags().String("helm-uyuni-namespace", "default", L("Kubernetes namespace where to install uyuni"))
 	cmd.Flags().String("helm-uyuni-chart", defaultChart, L("URL to the uyuni helm chart"))

--- a/mgrpxy/shared/kubernetes/cmd.go
+++ b/mgrpxy/shared/kubernetes/cmd.go
@@ -20,7 +20,7 @@ type HelmFlags struct {
 
 // AddHelmFlags add helm flags to a command.
 func AddHelmFlags(cmd *cobra.Command) {
-	defaultChart := fmt.Sprintf("oci://%s/proxy-helm", utils.DefaultNamespace)
+	defaultChart := fmt.Sprintf("oci://%s/proxy-helm", utils.DefaultHelmRegistry)
 
 	cmd.Flags().String("helm-proxy-namespace", "default", L("Kubernetes namespace where to install the proxy"))
 	cmd.Flags().String("helm-proxy-chart", defaultChart, L("URL to the proxy helm chart"))

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -36,7 +36,7 @@ type Tuning struct {
 
 // Get the full container image name and tag for a container name.
 func (f *ProxyImageFlags) GetContainerImage(name string) string {
-	registry := utils.DefaultNamespace
+	registry := utils.DefaultRegistry
 	if len(f.Registry) != 0 {
 		registry = f.Registry
 	}

--- a/mgrpxy/shared/utils/flags_test.go
+++ b/mgrpxy/shared/utils/flags_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGetContainerImageDefaultNamespace(t *testing.T) {
-	utils.DefaultNamespace = "mynamespace"
+	utils.DefaultRegistry = "mynamespace"
 	proxyFlags := ProxyImageFlags{
 		Tag: "mytag",
 	}
@@ -23,7 +23,7 @@ func TestGetContainerImageDefaultNamespace(t *testing.T) {
 }
 
 func TestGetContainerImageCustomRegistry(t *testing.T) {
-	utils.DefaultNamespace = "mynamespace"
+	utils.DefaultRegistry = "mynamespace"
 	proxyFlags := ProxyImageFlags{
 		Registry: "mytestregistry.example.com",
 		Tag:      "mytag",

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -16,8 +16,11 @@ import (
 // On SUSE distros this should be overridden with /usr/share/locale.
 var LocaleRoot = "locale"
 
-// DefaultNamespace represents the default name used for image.
-var DefaultNamespace = "registry.opensuse.org/uyuni"
+// DefaultRegistry represents the default name used for container image.
+var DefaultRegistry = "registry.opensuse.org/uyuni"
+
+// DefaultHelmRegistry represents the default name used for helm charts.
+var DefaultHelmRegistry = "registry.opensuse.org/uyuni"
 
 // DefaultTag represents the default tag used for image.
 var DefaultTag = "latest"

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -183,8 +183,8 @@ func RemoveRegistryFromImage(imagePath string) string {
 
 // ComputeImage assembles the container image from its name and tag.
 func ComputeImage(imageFlags types.ImageFlags, appendToName ...string) (string, error) {
-	if !strings.Contains(DefaultNamespace, imageFlags.Registry) {
-		log.Info().Msgf(L("Registry %[1]s would be used instead of namespace %[2]s"), imageFlags.Registry, DefaultNamespace)
+	if !strings.Contains(DefaultRegistry, imageFlags.Registry) {
+		log.Info().Msgf(L("Registry %[1]s would be used instead of namespace %[2]s"), imageFlags.Registry, DefaultRegistry)
 	}
 	name := imageFlags.Name
 	if !strings.Contains(imageFlags.Name, imageFlags.Registry) {

--- a/uyuni-tools.changes.cbosdo.helm-paths
+++ b/uyuni-tools.changes.cbosdo.helm-paths
@@ -1,0 +1,2 @@
+- Allow building with different helm and container default 
+  registry paths (bsc#1226191)

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -313,11 +313,20 @@ pull_policy=%{!?_default_pull_policy:Always}
 %endif
 # "%{?_default_pull_policy}" != ""
 
-image=%{namespace}
+namespace=%{namespace}
+helm_registry=%{namespace}
 %if "%{?_default_namespace}" != ""
+  # Set both container and helm chart namespaces as this can be the same value
   namespace='%{_default_namespace}'
+  helm_registry='%{_default_namespace}'
 %endif
 # "%{?_default_namespace}" != ""
+
+# We may have additional config for helm registry as the path is different in OBS devel projects
+%if "%{?_default_helm_registry}" != ""
+  helm_registry='%{_default_helm_registry}'
+%endif
+# "%{?_default_helm_registry}" != ""
 
 go_tags=""
 %if "%{?_uyuni_tools_tags}" != ""
@@ -339,7 +348,11 @@ go_path=""
 
 GOLD_FLAGS="-X '${UTILS_PATH}.Version=%{version} (%{version_details})' -X ${UTILS_PATH}.LocaleRoot=%{_datadir}/locale"
 if test -n "${namespace}"; then
-    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultNamespace=${namespace} -X ${UTILS_PATH}.DefaultTag=${tag}"
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultRegistry=${namespace}"
+fi
+
+if test -n "${helm_registry}"; then
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultHelmRegistry=${helm_registry}"
 fi
 
 if test -n "${tag}"; then


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The Helm chart path on the registry may be different from the one of the container images. Create two separate variables to set those paths.

## Test coverage
- No tests: default value config

- [X] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/358

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

