### PR TITLE
Preserve PAGER settings from the host

### DIFF
--- a/mgradm/cmd/support/sql/sql.go
+++ b/mgradm/cmd/support/sql/sql.go
@@ -77,7 +77,7 @@ func getBaseCommand(keepStdin bool, flags *configFlags, cnx *shared.Connection) 
 		commandArgs = append(commandArgs, "-i")
 		envs = append(envs, "ENV=/etc/sh.shrc.local")
 		commandArgs = append(commandArgs, "-t")
-		envs = append(envs, "TERM")
+		envs = append(envs, "TERM", "PAGER", "LESS")
 	} else if keepStdin {
 		// To use STDIN source, we need to pass -i
 		commandArgs = append(commandArgs, "-i")

--- a/mgradm/cmd/support/sql/sql.go
+++ b/mgradm/cmd/support/sql/sql.go
@@ -77,7 +77,7 @@ func getBaseCommand(keepStdin bool, flags *configFlags, cnx *shared.Connection) 
 		commandArgs = append(commandArgs, "-i")
 		envs = append(envs, "ENV=/etc/sh.shrc.local")
 		commandArgs = append(commandArgs, "-t")
-		envs = append(envs, "TERM", "PAGER", "LESS")
+		envs = append(envs, utils.GetEnvironmentVarsList()...)
 	} else if keepStdin {
 		// To use STDIN source, we need to pass -i
 		commandArgs = append(commandArgs, "-i")

--- a/mgrctl/cmd/exec/exec.go
+++ b/mgrctl/cmd/exec/exec.go
@@ -69,7 +69,7 @@ func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, ar
 	}
 	if flags.Tty {
 		commandArgs = append(commandArgs, "-t")
-		envs = append(envs, "TERM")
+		envs = append(envs, utils.GetEnvironmentVarsList()...)
 	}
 	commandArgs = append(commandArgs, podName)
 

--- a/shared/utils/exec.go
+++ b/shared/utils/exec.go
@@ -78,3 +78,11 @@ func IsInstalled(tool string) bool {
 	_, err := exec.LookPath("kubectl")
 	return err == nil
 }
+
+// Return list of environmental variables to be passed to exec.
+func GetEnvironmentVarsList() []string {
+	// Taken from /etc/profile and /etc/profile.d/lang
+	return []string{"TERM", "PAGER",
+		"LESS", "LESSOPEN", "LESSKEY", "LESSCLOSE", "LESS_ADVANCED_PREPROCESSOR", "MORE",
+		"LANG", "LC_CTYPE", "LC_ALL"}
+}

--- a/uyuni-tools.changes.oholecek.pager_sql_setting
+++ b/uyuni-tools.changes.oholecek.pager_sql_setting
@@ -1,0 +1,2 @@
+- preserve PAGER settings from the host for interactive
+  sql usage (bsc#1226914)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This fixes pager in `mgradm support sql -i`, however I am not 100% sure if this is correct as is.
On one hand, respecting host PAGER should be valid approach, but if someone set custom one which we don't have on the container image this will cause annoying problems.
On the other hand, if I let use setting from the container, that might be different from what people have in their setups and furthermore override will not work anymore.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24649

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

