### PR TITLE
Use local images for CoCo and Hub containers (bsc#1227586)

### DIFF
--- a/uyuni-tools.changes.rmateus.useLocalImagesCoCoHub
+++ b/uyuni-tools.changes.rmateus.useLocalImagesCoCoHub
@@ -1,0 +1,1 @@
+- Use local images for CoCo and Hub containers (bsc#1227586)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When installing server verify is local images for CoCo attestation and HUB XML-RPC API are available locally and load them to podman, preparing the local image in the configuration.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] https://bugzilla.suse.com/show_bug.cgi?id=1227586

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

