### PR TITLE
replace not working Fatal error by plain error return

### DIFF
--- a/mgrctl/cmd/cmd.go
+++ b/mgrctl/cmd/cmd.go
@@ -38,7 +38,7 @@ func NewUyunictlCommand() (*cobra.Command, error) {
 	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "logLevel", "", L("application log level")+"(trace|debug|info|warn|error|fatal|panic)")
 
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		utils.LogInit(cmd.Name() != "exec" && cmd.Name() != "term")
+		utils.LogInit((cmd.Name() != "exec" && cmd.Name() != "term") || globalFlags.LogLevel == "trace")
 		utils.SetLogLevel(globalFlags.LogLevel)
 
 		// do not log if running the completion cmd as the output is redirect to create a file to source

--- a/mgrctl/cmd/exec/exec.go
+++ b/mgrctl/cmd/exec/exec.go
@@ -52,12 +52,12 @@ func run(globalFlags *types.GlobalFlags, flags *flagpole, cmd *cobra.Command, ar
 	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
 	podName, err := cnx.GetPodName()
 	if err != nil {
-		log.Fatal().Err(err)
+		return err
 	}
 
 	command, err := cnx.GetCommand()
 	if err != nil {
-		log.Fatal().Err(err)
+		return err
 	}
 
 	commandArgs := []string{"exec"}

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -119,7 +119,7 @@ func (c *Connection) GetPodName() (string, error) {
 	if c.podName == "" {
 		command, cmdErr := c.GetCommand()
 		if cmdErr != nil {
-			log.Fatal().Err(cmdErr)
+			return "", cmdErr
 		}
 
 		switch command {
@@ -129,6 +129,7 @@ func (c *Connection) GetPodName() (string, error) {
 			if out, _ := utils.RunCmdOutput(zerolog.DebugLevel, c.command, "ps", "-q", "-f", "name="+c.podmanContainer); len(out) == 0 {
 				err = fmt.Errorf(L("container %s is not running on podman"), c.podmanContainer)
 			} else {
+				log.Trace().Msgf("Found container ID '%s'", out)
 				c.podName = c.podmanContainer
 			}
 		case "kubectl":

--- a/uyuni-tools.changes.oholecek.fix_fatal_exec
+++ b/uyuni-tools.changes.oholecek.fix_fatal_exec
@@ -1,0 +1,2 @@
+- replace not working Fatal error by plain error return
+  (bsc#1220136)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Calling Fatal().Err() is not enough without .Msg(), but instead just return error.

This also enables term and exec logging with trace log level.

## Test coverage
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23774

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

