### PR TITLE
Check if volume directory is mounted when purging

### DIFF
--- a/mgradm/cmd/uninstall/podman.go
+++ b/mgradm/cmd/uninstall/podman.go
@@ -36,16 +36,22 @@ func uninstallForPodman(
 
 	// Remove the volumes
 	if flags.Purge.Volumes {
+		allOk := true
 		volumes := []string{"cgroup"}
 		for _, volume := range utils.ServerVolumeMounts {
 			volumes = append(volumes, volume.Name)
 		}
 		for _, volume := range volumes {
 			if err := podman.DeleteVolume(volume, !flags.Force); err != nil {
-				return utils.Errorf(err, L("cannot delete volume %s"), volume)
+				log.Warn().Err(err).Msgf(L("Failed to remove volume %s"), volume)
+				allOk = false
 			}
 		}
-		log.Info().Msg(L("All volumes have been removed"))
+		if allOk {
+			log.Info().Msg(L("All volumes have been removed"))
+		} else {
+			log.Warn().Msg(L("Some volumes have not been removed completely"))
+		}
 	}
 
 	if flags.Purge.Images {

--- a/uyuni-tools.changes.oholecek.mounted_volume_purge_fix
+++ b/uyuni-tools.changes.oholecek.mounted_volume_purge_fix
@@ -1,0 +1,2 @@
+- do not report error when purging mounted volume
+  (bsc#1225349)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Mounted volume cannot be removed and podman thus exits with non- zero return even though data and internal record were purged. This commit adds mount check on podman data removal and reports error only when volume dir is not empty and not mounted.

This commit also fixes error handling when volume purge was not successful.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24417

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

