### PR TITLE
Split the systemd configuration files to avoid loosing config on upgrade

### DIFF
--- a/mgradm/shared/coco/coco.go
+++ b/mgradm/shared/coco/coco.go
@@ -57,11 +57,13 @@ func writeCocoServiceFiles(image types.ImageFlags, baseImage types.ImageFlags, d
 	}
 
 	environment := fmt.Sprintf(`Environment=UYUNI_IMAGE=%s
-	Environment=database_connection=jdbc:postgresql://uyuni-server.mgr.internal:%d/%s
-	Environment=database_user=%s
-	Environment=database_password=%s`, cocoImage, dbPort, dbName, dbUser, dbPassword)
+Environment=database_connection=jdbc:postgresql://uyuni-server.mgr.internal:%d/%s
+Environment=database_user=%s
+Environment=database_password=%s`, cocoImage, dbPort, dbName, dbUser, dbPassword)
 
-	if err := podman.GenerateSystemdConfFile(podman.ServerAttestationService+"@", "Service", environment); err != nil {
+	if err := podman.GenerateSystemdConfFile(
+		podman.ServerAttestationService+"@", "generated.conf", environment, true,
+	); err != nil {
 		return utils.Errorf(err, L("cannot generate systemd conf file"))
 	}
 

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -56,9 +56,8 @@ func GenerateHubXmlrpcSystemdService(image string) error {
 		return utils.Errorf(err, L("failed to generate systemd service unit file"))
 	}
 
-	environment := fmt.Sprintf(`Environment=UYUNI_IMAGE=%s
-	`, image)
-	if err := podman.GenerateSystemdConfFile(podman.HubXmlrpcService+"@", "Service", environment); err != nil {
+	environment := fmt.Sprintf("Environment=UYUNI_IMAGE=%s", image)
+	if err := podman.GenerateSystemdConfFile(podman.HubXmlrpcService+"@", "generated.conf", environment, true); err != nil {
 		return utils.Errorf(err, L("cannot generate systemd conf file"))
 	}
 
@@ -95,13 +94,18 @@ func GenerateSystemdService(tz string, image string, debug bool, mirrorPath stri
 		return utils.Errorf(err, L("failed to generate systemd service unit file"))
 	}
 
-	config := fmt.Sprintf(`Environment=UYUNI_IMAGE=%s
-Environment=TZ=%s
-Environment="PODMAN_EXTRA_ARGS=%s"
-`, image, strings.TrimSpace(tz), strings.Join(podmanArgs, " "))
-
-	if err := podman.GenerateSystemdConfFile("uyuni-server", "Service", config); err != nil {
+	if err := podman.GenerateSystemdConfFile("uyuni-server", "generated.conf",
+		"Environment=UYUNI_IMAGE="+image, true,
+	); err != nil {
 		return utils.Errorf(err, L("cannot generate systemd conf file"))
+	}
+
+	config := fmt.Sprintf(`Environment=TZ=%s
+Environment="PODMAN_EXTRA_ARGS=%s"
+`, strings.TrimSpace(tz), strings.Join(podmanArgs, " "))
+
+	if err := podman.GenerateSystemdConfFile("uyuni-server", "custom.conf", config, false); err != nil {
+		return utils.Errorf(err, L("cannot generate systemd user configuration file"))
 	}
 	return podman.ReloadDaemon(false)
 }
@@ -391,7 +395,13 @@ func Upgrade(image types.ImageFlags, upgradeImage types.ImageFlags, cocoImage ty
 		return utils.Errorf(err, L("cannot run post upgrade script"))
 	}
 
-	if err := podman.GenerateSystemdConfFile("uyuni-server", "Service", "Environment=UYUNI_IMAGE="+preparedImage); err != nil {
+	if err := podman.CleanSystemdConfFile("uyuni-server"); err != nil {
+		return err
+	}
+
+	if err := podman.GenerateSystemdConfFile("uyuni-server", "generated.conf",
+		"Environment=UYUNI_IMAGE="+preparedImage, true,
+	); err != nil {
 		return err
 	}
 	log.Info().Msg(L("Waiting for the server to start…"))

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -130,11 +130,16 @@ func generateSystemdFile(template shared_utils.Template, service string, image s
 		return shared_utils.Errorf(err, L("failed to generate systemd file '%s'"), path)
 	}
 
-	if image != "" || config != "" {
-		configBody := fmt.Sprintf(`%s
-Environment=UYUNI_IMAGE=%s`, config, image)
-		if err := podman.GenerateSystemdConfFile("uyuni-proxy-"+service, "Service", configBody); err != nil {
+	if image != "" {
+		configBody := fmt.Sprintf("Environment=UYUNI_IMAGE=%s", image)
+		if err := podman.GenerateSystemdConfFile("uyuni-proxy-"+service, "generated.conf", configBody, true); err != nil {
 			return shared_utils.Errorf(err, L("cannot generate systemd conf file"))
+		}
+	}
+
+	if config != "" {
+		if err := podman.GenerateSystemdConfFile("uyuni-proxy-"+service, "custom.conf", config, false); err != nil {
+			return shared_utils.Errorf(err, L("cannot generate systemd conf user configuration file"))
 		}
 	}
 	return nil

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -10,13 +10,14 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-const servicesPath = "/etc/systemd/system/"
+var servicesPath = "/etc/systemd/system/"
 
 // Name of the systemd service for the server.
 const ServerService = "uyuni-server"
@@ -63,17 +64,14 @@ func GetServiceConfFolder(name string) string {
 	return path.Join(servicesPath, name+".service.d")
 }
 
-// GetServiceConfPath return the path for Service.conf file.
+// GetServiceConfPath return the path for generated.conf file.
 func GetServiceConfPath(name string) string {
-	return path.Join(GetServiceConfFolder(name), "Service.conf")
+	return path.Join(GetServiceConfFolder(name), "generated.conf")
 }
 
 // UninstallService stops and remove a systemd service.
 // If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
 func UninstallService(name string, dryRun bool) {
-	servicePath := GetServicePath(name)
-	serviceConfFolder := GetServiceConfFolder(name)
-	serviceConfPath := GetServiceConfPath(name)
 	if !HasService(name) {
 		log.Info().Msgf(L("Systemd has no %s.service unit"), name)
 	} else {
@@ -87,38 +85,50 @@ func UninstallService(name string, dryRun bool) {
 				log.Error().Err(err).Msgf(L("Failed to disable %s service"), name)
 			}
 		}
+		uninstallServiceFiles(name, dryRun)
+	}
+}
 
-		if dryRun {
-			log.Info().Msgf(L("Would remove %s"), servicePath)
-		} else {
-			// Remove the service unit
-			log.Info().Msgf(L("Remove %s"), servicePath)
-			if err := os.Remove(servicePath); err != nil {
-				log.Error().Err(err).Msgf(L("Failed to remove %s.service file"), name)
-			}
+func uninstallServiceFiles(name string, dryRun bool) {
+	servicePath := GetServicePath(name)
+	serviceConfFolder := GetServiceConfFolder(name)
+
+	if dryRun {
+		log.Info().Msgf(L("Would remove %s"), servicePath)
+	} else {
+		// Remove the service unit
+		log.Info().Msgf(L("Remove %s"), servicePath)
+		if err := os.Remove(servicePath); err != nil {
+			log.Error().Err(err).Msgf(L("Failed to remove %s.service file"), name)
 		}
+	}
 
-		if utils.FileExists(serviceConfFolder) {
-			if utils.FileExists(serviceConfPath) {
+	if utils.FileExists(serviceConfFolder) {
+		confPaths := []string{
+			GetServiceConfPath(name),
+			path.Join(serviceConfFolder, "Service.conf"),
+		}
+		for _, confPath := range confPaths {
+			if utils.FileExists(confPath) {
 				if dryRun {
-					log.Info().Msgf(L("Would remove %s"), serviceConfPath)
+					log.Info().Msgf(L("Would remove %s"), confPath)
 				} else {
-					log.Info().Msgf(L("Remove %s"), serviceConfPath)
-					if err := os.Remove(serviceConfPath); err != nil {
-						log.Error().Err(err).Msgf(L("Failed to remove %s file"), serviceConfPath)
+					log.Info().Msgf(L("Remove %s"), confPath)
+					if err := os.Remove(confPath); err != nil {
+						log.Error().Err(err).Msgf(L("Failed to remove %s file"), confPath)
 					}
 				}
 			}
+		}
 
-			if dryRun {
-				log.Info().Msgf(L("Would remove %s if empty"), serviceConfFolder)
+		if dryRun {
+			log.Info().Msgf(L("Would remove %s if empty"), serviceConfFolder)
+		} else {
+			if utils.IsEmptyDirectory(serviceConfFolder) {
+				log.Debug().Msgf("Removing %s folder, since it's empty", serviceConfFolder)
+				_ = utils.RemoveDirectory(serviceConfFolder)
 			} else {
-				if utils.IsEmptyDirectory(serviceConfFolder) {
-					log.Debug().Msgf("Removing %s folder, since it's empty", serviceConfFolder)
-					_ = utils.RemoveDirectory(serviceConfFolder)
-				} else {
-					log.Warn().Msgf(L("%s folder contains file created by the user. Please remove them when uninstallation is completed."), serviceConfFolder)
-				}
+				log.Warn().Msgf(L("%s folder contains file created by the user. Please remove them when uninstallation is completed."), serviceConfFolder)
 			}
 		}
 	}
@@ -135,45 +145,7 @@ func UninstallInstantiatedService(name string, dryRun bool) {
 		}
 	}
 
-	// Remove the service unit
-	servicePath := GetServicePath(name + "@")
-	serviceConfFolder := GetServiceConfFolder(name + "@")
-	serviceConfPath := GetServiceConfPath(name + "@")
-	if utils.FileExists(servicePath) {
-		if dryRun {
-			log.Info().Msgf(L("Would remove %s"), servicePath)
-		} else {
-			// Remove the service unit
-			log.Info().Msgf(L("Remove %s"), servicePath)
-			if err := os.Remove(servicePath); err != nil {
-				log.Error().Err(err).Msgf(L("Failed to remove %s.service file"), name)
-			}
-		}
-	}
-
-	if utils.FileExists(serviceConfFolder) {
-		if utils.FileExists(serviceConfPath) {
-			if dryRun {
-				log.Info().Msgf(L("Would remove %s"), serviceConfPath)
-			} else {
-				log.Info().Msgf(L("Remove %s"), serviceConfPath)
-				if err := os.Remove(serviceConfPath); err != nil {
-					log.Error().Err(err).Msgf(L("Failed to remove %s file"), serviceConfPath)
-				}
-			}
-		}
-
-		if dryRun {
-			log.Info().Msgf(L("Would remove %s if empty"), serviceConfFolder)
-		} else {
-			if utils.IsEmptyDirectory(serviceConfFolder) {
-				log.Debug().Msgf("Removing %s folder, since it's empty", serviceConfFolder)
-				_ = utils.RemoveDirectory(serviceConfFolder)
-			} else {
-				log.Warn().Msgf(L("%s folder contains file created by the user. Please remove them when uninstallation is completed."), serviceConfFolder)
-			}
-		}
-	}
+	uninstallServiceFiles(name+"@", dryRun)
 }
 
 // ReloadDaemon resets the failed state of services and reload the systemd daemon.
@@ -266,19 +238,80 @@ func StopInstantiated(service string) error {
 	return utils.JoinErrors(errList...)
 }
 
+// confHeader is the header for the generated systemd configuration files.
+const confHeader = `# This file is generated by mgradm and will be overwritten during upgrades.
+# Custom configuration should go in another .conf file in the same folder.
+
+`
+
 // Create new systemd service configuration file (e.g. Service.conf).
-func GenerateSystemdConfFile(serviceName string, section string, body string) error {
+func GenerateSystemdConfFile(serviceName string, filename string, body string, withHeader bool) error {
 	systemdFilePath := GetServicePath(serviceName)
 
 	systemdConfFolder := systemdFilePath + ".d"
 	if err := os.MkdirAll(systemdConfFolder, 0750); err != nil {
 		return utils.Errorf(err, L("failed to create %s folder"), systemdConfFolder)
 	}
-	systemdConfFilePath := path.Join(systemdConfFolder, section+".conf")
+	systemdConfFilePath := path.Join(systemdConfFolder, filename)
 
-	content := []byte("[" + section + "]" + "\n" + body + "\n")
+	header := ""
+	if withHeader {
+		header = confHeader
+	}
+	content := []byte(fmt.Sprintf("%s[Service]\n%s\n", header, body))
 	if err := os.WriteFile(systemdConfFilePath, content, 0644); err != nil {
 		return utils.Errorf(err, L("cannot write %s file"), systemdConfFilePath)
+	}
+
+	return nil
+}
+
+// CleanSystemdConfFile separates the Service.conf file once generated into generated.conf and custom.conf.
+func CleanSystemdConfFile(serviceName string) error {
+	systemdFilePath := GetServicePath(serviceName) + ".d"
+	oldConfPath := path.Join(systemdFilePath, "Service.conf")
+
+	// The first containerized release generated a Service.conf where the image and the configuration
+	// where stored. This had the side effect to remove the conf at upgrade time.
+	// If this file exists split it in two:
+	// - generated.conf with the image
+	// - custom.conf with everything that shouldn't be touched at upgrade
+	if utils.FileExists(oldConfPath) {
+		content := string(utils.ReadFile(oldConfPath))
+		lines := strings.Split(content, "\n")
+
+		generated := ""
+		custom := ""
+		hasCustom := false
+
+		for _, line := range lines {
+			trimmedLine := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmedLine, "Environment=UYUNI_IMAGE=") {
+				generated = generated + trimmedLine
+			} else {
+				custom = custom + trimmedLine + "\n"
+				if trimmedLine != "" && trimmedLine != "[Service]" {
+					hasCustom = true
+				}
+			}
+		}
+
+		if generated != "" {
+			if err := GenerateSystemdConfFile(serviceName, "generated.conf", generated, true); err != nil {
+				return err
+			}
+		}
+
+		if hasCustom {
+			customPath := path.Join(systemdFilePath, "custom.conf")
+			if err := os.WriteFile(customPath, []byte(custom), 0644); err != nil {
+				return utils.Errorf(err, L("failed to write %s file"), customPath)
+			}
+		}
+
+		if err := os.Remove(oldConfPath); err != nil {
+			return utils.Errorf(err, L("failed to remove old %s systemd service configuration file"), oldConfPath)
+		}
 	}
 
 	return nil

--- a/shared/podman/systemd_test.go
+++ b/shared/podman/systemd_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/test_utils"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func TestCleanSystemdConfFile(t *testing.T) {
+	currentFile := `[Service]
+# Some comment
+Environment=TZ=Europe/Berlin
+Environment="PODMAN_EXTRA_ARGS="
+Environment=UYUNI_IMAGE=path/to/image
+`
+
+	generatedFile := confHeader + `[Service]
+Environment=UYUNI_IMAGE=path/to/image
+`
+
+	customFile := `[Service]
+# Some comment
+Environment=TZ=Europe/Berlin
+Environment="PODMAN_EXTRA_ARGS="
+
+`
+
+	testDir, cleaner := test_utils.CreateTmpFolder(t)
+	defer cleaner()
+
+	serviceConfDir := path.Join(testDir, "uyuni-server.service.d")
+	if err := os.Mkdir(serviceConfDir, 0750); err != nil {
+		t.Fatalf("failed to create fake service configuration directory: %s", err)
+	}
+
+	servicesPath = testDir
+
+	test_utils.WriteFile(t, path.Join(serviceConfDir, "Service.conf"), currentFile)
+
+	if err := CleanSystemdConfFile("uyuni-server"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	actual := test_utils.ReadFile(t, path.Join(serviceConfDir, "generated.conf"))
+	test_utils.AssertEquals(t, "invalid generated.conf file", generatedFile, actual)
+
+	actual = test_utils.ReadFile(t, path.Join(serviceConfDir, "custom.conf"))
+	test_utils.AssertEquals(t, "invalid custom.conf file", customFile, actual)
+
+	if utils.FileExists(path.Join(serviceConfDir, "Service.conf")) {
+		t.Error("the old Service.conf file is not removed")
+	}
+}
+
+func TestCleanSystemdConfFileNoop(t *testing.T) {
+	generatedFile := confHeader + `[Service]
+Environment=UYUNI_IMAGE=path/to/image
+`
+
+	customFile := `[Service]
+# Some comment
+Environment=TZ=Europe/Berlin
+Environment="PODMAN_EXTRA_ARGS="
+`
+
+	testDir, cleaner := test_utils.CreateTmpFolder(t)
+	defer cleaner()
+
+	serviceConfDir := path.Join(testDir, "uyuni-server.service.d")
+	if err := os.Mkdir(serviceConfDir, 0750); err != nil {
+		t.Fatalf("failed to create fake service configuration directory: %s", err)
+	}
+
+	servicesPath = testDir
+
+	test_utils.WriteFile(t, path.Join(serviceConfDir, "generated.conf"), generatedFile)
+	test_utils.WriteFile(t, path.Join(serviceConfDir, "custom.conf"), customFile)
+
+	if err := CleanSystemdConfFile("uyuni-server"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	actual := test_utils.ReadFile(t, path.Join(serviceConfDir, "generated.conf"))
+	test_utils.AssertEquals(t, "invalid generated.conf file", generatedFile, actual)
+
+	actual = test_utils.ReadFile(t, path.Join(serviceConfDir, "custom.conf"))
+	test_utils.AssertEquals(t, "invalid custom.conf file", customFile, actual)
+}

--- a/shared/test_utils/asserts.go
+++ b/shared/test_utils/asserts.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package test_utils
+
+import "testing"
+
+// AssertEquals ensures two values are equals and raises and error if not.
+func AssertEquals[T comparable](t *testing.T, message string, expected T, actual T) {
+	if actual != expected {
+		t.Errorf(message+": got '%v' expected '%v'", actual, expected)
+	}
+}

--- a/shared/test_utils/files.go
+++ b/shared/test_utils/files.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package test_utils
+
+import (
+	"os"
+	"testing"
+)
+
+// CreateTmpFolder creates a temporary folder for testing purposes and returns its path and a cleanup function.
+func CreateTmpFolder(t *testing.T) (string, func()) {
+	testDir, err := os.MkdirTemp("", "uyuni-tools-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %s", err)
+	}
+
+	return testDir, func() {
+		defer os.RemoveAll(testDir)
+	}
+}
+
+// WriteFile writes the content in a file at the given path and fails if anything wrong happens.
+func WriteFile(t *testing.T, path string, content string) {
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("failed to write test file %s: %s", path, err)
+	}
+}
+
+// ReadFile returns the content of a file as a string and fails is anything wrong happens.
+func ReadFile(t *testing.T, path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %s", path, err)
+	}
+	return string(content)
+}

--- a/uyuni-tools.changes.cbosdo.config-refactoring
+++ b/uyuni-tools.changes.cbosdo.config-refactoring
@@ -1,0 +1,2 @@
+- Split systemd config files to not loose configuration at upgrade 
+  (bsc#1227718)


### PR DESCRIPTION
## What does this PR change?

Splits the `Service.conf` files into:

- `generated.conf` only containing the `UYUNI_IMAGE` variable and a comment stating this is rewritten
- `custom.conf` holding everything else

This way the `TZ`, `PODMAN_EXTRA_ARGS` or other variables won't be lost at upgrade.

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24812

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

