### PR TITLE
Clarify and fix distro name guessing when not provided

### DIFF
--- a/mgradm/cmd/distro/detect.go
+++ b/mgradm/cmd/distro/detect.go
@@ -6,7 +6,9 @@ package distro
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -113,8 +115,9 @@ func getDistroFromTreeinfo(path string, flags *flagpole) (types.Distribution, er
 	return getDistroFromDetails(dname, dversion, types.GetArch(darch), flags)
 }
 
-func detectDistro(path string, distroDetails types.DistributionDetails, channelLabel string, flags *flagpole, distro *types.Distribution) error {
+func detectDistro(path string, distroDetails types.DistributionDetails, flags *flagpole, distro *types.Distribution) error {
 	treeinfopath := filepath.Join(path, ".treeinfo")
+	channelLabel := flags.ChannelLabel
 	if !utils.FileExists(treeinfopath) {
 		log.Debug().Msgf(".treeinfo %s does not exists", treeinfopath)
 		if distroDetails.Name != "" {
@@ -132,7 +135,6 @@ func detectDistro(path string, distroDetails types.DistributionDetails, channelL
 				*distro, err = getDistroFromDetails(distroDetails.Name, distroDetails.Version, distroDetails.Arch, flags)
 				return err
 			}
-			return fmt.Errorf(L("distribution treeinfo %s does not exists. Please provide distribution details and/or channel label"), treeinfopath)
 		}
 		return fmt.Errorf(L("distribution treeinfo %s does not exists. Please provide distribution details and/or channel label"), treeinfopath)
 	} else {
@@ -152,4 +154,8 @@ func detectDistro(path string, distroDetails types.DistributionDetails, channelL
 	}
 
 	return nil
+}
+
+func getNameFromSource(source string) string {
+	return strings.TrimSuffix(path.Base(source), ".iso")
 }

--- a/mgradm/cmd/distro/distro.go
+++ b/mgradm/cmd/distro/distro.go
@@ -74,11 +74,15 @@ func NewCommand(globalFlags *types.GlobalFlags) (*cobra.Command, error) {
 	}
 
 	cpCmd := &cobra.Command{
-		Use:   "copy path-to-source [distribution-name version arch]",
+		Use:   "copy path-to-source [distribution-name [version arch]]",
 		Short: L("Copy distribution files from iso to the container"),
 		Long: L(`Takes a path to source iso file or directory with mounted iso and copies it into the container.
 
-Optional parameters 'distribution-name', 'version' and 'arch' specifies custom distribution. If not set, distribution name is autodetected.
+Optional parameters 'distribution-name', 'version' and 'arch' specifies custom distribution.
+If not set, distribution name is attempted to be autodetected:
+
+- use name from '.treeinfo' file if exists
+- use name of the ISO or passed directory
 
 Note: API details are required for auto registration.`),
 		Aliases: []string{"cp"},

--- a/uyuni-tools.changes.oholecek.distro_copy_name_optional_fix
+++ b/uyuni-tools.changes.oholecek.distro_copy_name_optional_fix
@@ -1,0 +1,2 @@
+- clarify and fix distro name guessing when not provided
+  (bsc#1226284)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When distro name is not provided and treeinfo is not found use ISO or source directory name as distro name

This commit also do some small refactoring


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24561

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

