### PR TITLE
Expose port on IPv6 network (bsc#1227951)

### DIFF
--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -38,6 +38,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	{{ .Args }} \
 	{{- range .Ports }}
 	-p {{ .Exposed }}:{{ .Port }}{{if .Protocol}}/{{ .Protocol }}{{end}} \
+	-p [::]:{{ .Exposed }}:{{ .Port }}{{if .Protocol}}/{{ .Protocol }}{{end}} \
 	{{- end }}
 	{{- range .Volumes }}
 	-v {{ .Name }}:{{ .MountPath }} \

--- a/shared/podman/network.go
+++ b/shared/podman/network.go
@@ -81,9 +81,11 @@ func isIpv6Enabled() bool {
 	for _, file := range files {
 		// Mind that we are checking disable files, the semantic is inverted
 		if utils.GetFileBoolean(file) {
+			log.Debug().Msgf("IPv6 is disabled")
 			return false
 		}
 	}
+	log.Debug().Msgf("IPv6 is enabled")
 	return true
 }
 

--- a/uyuni-tools.changes.mbussolotto.ipv6
+++ b/uyuni-tools.changes.mbussolotto.ipv6
@@ -1,0 +1,1 @@
+- Expose port on IPv6 network (bsc#1227951)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Expose port on IPv6 network (bsc#1227951)

after this change, running `ss -nltp | grep 450[56]` on host machine :
```
uyuni:~ # ss -nltp | grep 450[56]
LISTEN 0      4096         0.0.0.0:4505       0.0.0.0:*    users:(("conmon",pid=84336,fd=7)) 
LISTEN 0      4096         0.0.0.0:4506       0.0.0.0:*    users:(("conmon",pid=84336,fd=8)) 
LISTEN 0      4096            [::]:4505          [::]:*    users:(("conmon",pid=84336,fd=19))
LISTEN 0      4096            [::]:4506          [::]:*    users:(("conmon",pid=84336,fd=20))
```
## Test coverage
- No tests 

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24848

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

