### PR TITLE
Add support for login and logout api options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/creack/pty v1.1.17 // indirect
 	github.com/fatih/color v1.7.0 // indirect
+	golang.org/x/crypto v0.25.0 // indirect
 )
 
 require (
@@ -30,9 +31,9 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/sys v0.12.0 // indirect
-	golang.org/x/term v0.10.0
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/term v0.22.0
+	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/crypto v0.25.0
 )
 
 require (
 	github.com/creack/pty v1.1.17 // indirect
 	github.com/fatih/color v1.7.0 // indirect
-	golang.org/x/crypto v0.25.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/spf13/cobra v1.8.0
-	golang.org/x/crypto v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
+golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -272,12 +274,18 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.10.0 h1:3R7pNqamzBraeqj/Tj8qt1aQ2HpmlC+Cx/qL/7hn4/c=
 golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
+golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
+golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -272,17 +272,12 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.10.0 h1:3R7pNqamzBraeqj/Tj8qt1aQ2HpmlC+Cx/qL/7hn4/c=
-golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
 golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
 golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,6 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
-golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/mgradm/cmd/distro/cp.go
+++ b/mgradm/cmd/distro/cp.go
@@ -44,9 +44,13 @@ func registerDistro(connection *api.ConnectionDetails, distro *types.Distributio
 	}
 
 	client, err := api.Init(connection)
+	if err == nil {
+		err = client.Login()
+	}
 	if err != nil {
 		return utils.Errorf(err, L("unable to login and register the distribution. Manual distro registration is required"))
 	}
+
 	data := map[string]interface{}{
 		"treeLabel":    distro.TreeLabel,
 		"basePath":     distro.BasePath,

--- a/mgradm/cmd/distro/distro.go
+++ b/mgradm/cmd/distro/distro.go
@@ -110,9 +110,7 @@ Note: API details are required for auto registration.`),
 	}
 	cpCmdHelp.SetHelpTemplate(helpBuilder.String())
 
-	if err := api.AddAPIFlags(distroCmd, true); err != nil {
-		return distroCmd, err
-	}
+	api.AddAPIFlags(distroCmd)
 	distroCmd.AddCommand(cpCmd)
 	distroCmd.AddCommand(cpCmdHelp)
 

--- a/mgradm/cmd/hub/register/register.go
+++ b/mgradm/cmd/hub/register/register.go
@@ -43,9 +43,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		utils.AddBackendFlag(registerCmd)
 	}
 
-	if err := api.AddAPIFlags(registerCmd, false); err != nil {
-		return nil
-	}
+	api.AddAPIFlags(registerCmd)
 
 	return registerCmd
 }

--- a/mgradm/cmd/hub/register/register.go
+++ b/mgradm/cmd/hub/register/register.go
@@ -93,9 +93,13 @@ func registerToHub(config map[string]string, cnxDetails *api.ConnectionDetails) 
 	}
 	log.Info().Msgf(L("Hub API server: %s"), cnxDetails.Server)
 	client, err := api.Init(cnxDetails)
+	if err == nil {
+		err = client.Login()
+	}
 	if err != nil {
 		return utils.Errorf(err, L("failed to connect to the Hub server"))
 	}
+
 	data := map[string]interface{}{
 		"fqdn": config["java.hostname"],
 	}

--- a/mgrctl/cmd/api/api.go
+++ b/mgrctl/cmd/api/api.go
@@ -31,11 +31,10 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Short: L("Call API GET request"),
 		Long: L(`Takes an API path and optional parameters and then issues GET request with them.
 
-		If user and password are provided, calls login before API call
+If user and password are provided, calls login before API call
 
-		Example:
-		# mgrctl api get user/getDetails login=test
-		`),
+Example:
+# mgrctl api get user/getDetails login=test`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runGet)
 		},
@@ -45,16 +44,15 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Use:   "post path parameters...",
 		Short: L("Call API POST request"),
 		Long: L(`Takes an API path and parameters and then issues POST request with them.
-		User and password are mandatory.
+User and password are mandatory.
 
-		Parameters can be either JSON encoded string or one or more key=value pairs.
+Parameters can be either JSON encoded string or one or more key=value pairs.
 
-		Key=Value pairs example:
-		# mgrctl api post user/create login=test password=testXX firstName=F lastName=L email=test@localhost
+Key=Value pairs example:
+# mgrctl api post user/create login=test password=testXX firstName=F lastName=L email=test@localhost
 
-		JSON example:
-		# mgrctl api post user/create '{"login":"test", "password":"testXX", "firstName":"F", "lastName":"L", "email":"test@localhost"}'
-		`),
+JSON example:
+# mgrctl api post user/create '{"login":"test", "password":"testXX", "firstName":"F", "lastName":"L", "email":"test@localhost"}'`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runPost)
 		},
@@ -65,8 +63,8 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Short: L("Store login information for future API usage"),
 		Long: L(`Login stores login information for next API calls.
 
-		User name, password and remote host can be provided using flags or will be asked interactively.
-		Environmental variables are also supported.`),
+User name, password and remote host can be provided using flags or will be asked interactively.
+Environmental variables are also supported.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runLogin)
 		},

--- a/mgrctl/cmd/api/api.go
+++ b/mgrctl/cmd/api/api.go
@@ -43,8 +43,28 @@ func NewCommand(globalFlags *types.GlobalFlags) (*cobra.Command, error) {
 		},
 	}
 
+	apiLogin := &cobra.Command{
+		Use:   "login",
+		Short: L("Store login information for future API usage"),
+		Long:  L("Login stores login information for next API calls. User name, password and remote host can be provided using flag or will be asked interactively. Environmental variables are also supported."),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, runLogin)
+		},
+	}
+
+	apiLogout := &cobra.Command{
+		Use:   "logout",
+		Short: L("Remove stored login information"),
+		Long:  L("Logout removes stored login information."),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, runLogout)
+		},
+	}
+
 	apiCmd.AddCommand(apiGet)
 	apiCmd.AddCommand(apiPost)
+	apiCmd.AddCommand(apiLogin)
+	apiCmd.AddCommand(apiLogout)
 
 	if err := api.AddAPIFlags(apiCmd, false); err != nil {
 		return apiCmd, err

--- a/mgrctl/cmd/api/api.go
+++ b/mgrctl/cmd/api/api.go
@@ -17,7 +17,7 @@ type apiFlags struct {
 }
 
 // NewCommand generates a JSON over HTTP API helper tool command.
-func NewCommand(globalFlags *types.GlobalFlags) (*cobra.Command, error) {
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	var flags apiFlags
 
 	apiCmd := &cobra.Command{
@@ -65,9 +65,7 @@ func NewCommand(globalFlags *types.GlobalFlags) (*cobra.Command, error) {
 	apiCmd.AddCommand(apiPost)
 	apiCmd.AddCommand(apiLogin)
 	apiCmd.AddCommand(apiLogout)
+	api.AddAPIFlags(apiCmd)
 
-	if err := api.AddAPIFlags(apiCmd, false); err != nil {
-		return apiCmd, err
-	}
-	return apiCmd, nil
+	return apiCmd
 }

--- a/mgrctl/cmd/api/api.go
+++ b/mgrctl/cmd/api/api.go
@@ -14,6 +14,7 @@ import (
 
 type apiFlags struct {
 	api.ConnectionDetails `mapstructure:"api"`
+	ForceLogin            bool `mapstructure:"force"`
 }
 
 // NewCommand generates a JSON over HTTP API helper tool command.
@@ -28,7 +29,13 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	apiGet := &cobra.Command{
 		Use:   "get path [parameters]...",
 		Short: L("Call API GET request"),
-		Long:  L("Takes an API path and optional parameters and then issues GET request with them. If user and password are provided, calls login before API call"),
+		Long: L(`Takes an API path and optional parameters and then issues GET request with them.
+
+		If user and password are provided, calls login before API call
+
+		Example:
+		# mgrctl api get user/getDetails login=test
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runGet)
 		},
@@ -37,7 +44,17 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	apiPost := &cobra.Command{
 		Use:   "post path parameters...",
 		Short: L("Call API POST request"),
-		Long:  L("Takes an API path and parameters and then issues POST request with them. User and password are mandatory. Parameters can be either JSON encoded string or one or more key=value pairs."),
+		Long: L(`Takes an API path and parameters and then issues POST request with them.
+		User and password are mandatory.
+
+		Parameters can be either JSON encoded string or one or more key=value pairs.
+
+		Key=Value pairs example:
+		# mgrctl api post user/create login=test password=testXX firstName=F lastName=L email=test@localhost
+
+		JSON example:
+		# mgrctl api post user/create '{"login":"test", "password":"testXX", "firstName":"F", "lastName":"L", "email":"test@localhost"}'
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runPost)
 		},
@@ -46,11 +63,15 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	apiLogin := &cobra.Command{
 		Use:   "login",
 		Short: L("Store login information for future API usage"),
-		Long:  L("Login stores login information for next API calls. User name, password and remote host can be provided using flag or will be asked interactively. Environmental variables are also supported."),
+		Long: L(`Login stores login information for next API calls.
+
+		User name, password and remote host can be provided using flags or will be asked interactively.
+		Environmental variables are also supported.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runLogin)
 		},
 	}
+	apiLogin.Flags().BoolP("force", "f", false, L("Overwrite existing login if exists"))
 
 	apiLogout := &cobra.Command{
 		Use:   "logout",

--- a/mgrctl/cmd/api/api.go
+++ b/mgrctl/cmd/api/api.go
@@ -31,8 +31,6 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 		Short: L("Call API GET request"),
 		Long: L(`Takes an API path and optional parameters and then issues GET request with them.
 
-If user and password are provided, calls login before API call
-
 Example:
 # mgrctl api get user/getDetails login=test`),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -44,7 +42,6 @@ Example:
 		Use:   "post path parameters...",
 		Short: L("Call API POST request"),
 		Long: L(`Takes an API path and parameters and then issues POST request with them.
-User and password are mandatory.
 
 Parameters can be either JSON encoded string or one or more key=value pairs.
 
@@ -64,7 +61,7 @@ JSON example:
 		Long: L(`Login stores login information for next API calls.
 
 User name, password and remote host can be provided using flags or will be asked interactively.
-Environmental variables are also supported.`),
+Environment variables are also supported.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, runLogin)
 		},

--- a/mgrctl/cmd/api/api_test.go
+++ b/mgrctl/cmd/api/api_test.go
@@ -12,10 +12,7 @@ import (
 
 func TestNewCommand(t *testing.T) {
 	var globalflags types.GlobalFlags
-	cmd, err := NewCommand(&globalflags)
-	if err != nil {
-		t.Errorf("Unexpected error creating command: %s", err)
-	}
+	cmd := NewCommand(&globalflags)
 	if cmd == nil {
 		t.Error("Unexpected nil command")
 	}

--- a/mgrctl/cmd/api/get.go
+++ b/mgrctl/cmd/api/get.go
@@ -21,7 +21,7 @@ import (
 func runGet(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
 	log.Debug().Msgf("Running GET command %s", args[0])
 	client, err := api.Init(&flags.ConnectionDetails)
-	if err == nil && client.Details.User != "" {
+	if err == nil && (client.Details.User != "" || client.Details.InSession) {
 		err = client.Login()
 	}
 	if err != nil {

--- a/mgrctl/cmd/api/get.go
+++ b/mgrctl/cmd/api/get.go
@@ -32,7 +32,7 @@ func runGet(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command,
 
 	res, err := api.Get[interface{}](client, fmt.Sprintf("%s?%s", path, strings.Join(options, "&")))
 	if err != nil {
-		return utils.Errorf(err, L("error in query %s"), path)
+		return utils.Errorf(err, L("error in query '%s'"), path)
 	}
 
 	// TODO do this only when result is JSON or TEXT. Watchout for binary data

--- a/mgrctl/cmd/api/get.go
+++ b/mgrctl/cmd/api/get.go
@@ -21,7 +21,9 @@ import (
 func runGet(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
 	log.Debug().Msgf("Running GET command %s", args[0])
 	client, err := api.Init(&flags.ConnectionDetails)
-
+	if err == nil && client.Details.User != "" {
+		err = client.Login()
+	}
 	if err != nil {
 		return utils.Errorf(err, L("unable to login to the server"))
 	}

--- a/mgrctl/cmd/api/login.go
+++ b/mgrctl/cmd/api/login.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
@@ -17,10 +19,13 @@ import (
 func runLogin(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
 	log.Debug().Msg("Running login command")
 
+	if api.IsAlreadyLoggedIn() && !flags.ForceLogin {
+		return fmt.Errorf(L("Refusing to overwrite existing login. Use --force to ignore this check."))
+	}
+
 	utils.AskIfMissing(&flags.User, cmd.Flag("api-user").Usage, 0, 0, nil)
 	utils.AskPasswordIfMissing(&flags.Password, cmd.Flag("api-password").Usage, 0, 0)
-	// ToDO add FQDN checker from rebase
-	utils.AskIfMissing(&flags.Server, cmd.Flag("api-server").Usage, 0, 0, nil)
+	utils.AskIfMissing(&flags.Server, cmd.Flag("api-server").Usage, 0, 0, utils.IsWellFormedFQDN)
 
 	if err := api.StoreLoginCreds(&flags.ConnectionDetails); err != nil {
 		return err

--- a/mgrctl/cmd/api/login.go
+++ b/mgrctl/cmd/api/login.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func runLogin(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
+	log.Debug().Msg("Running login command")
+
+	utils.AskIfMissing(&flags.User, cmd.Flag("api-user").Usage, 0, 0, nil)
+	utils.AskPasswordIfMissing(&flags.Password, cmd.Flag("api-password").Usage, 0, 0)
+	// ToDO add FQDN checker from rebase
+	utils.AskIfMissing(&flags.Server, cmd.Flag("api-server").Usage, 0, 0, nil)
+
+	return api.StoreLoginCreds(cmd.Context(), &flags.ConnectionDetails)
+}
+
+func runLogout(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
+	log.Debug().Msg("Running logout command")
+
+	return api.RemoveLoginCreds(cmd.Context())
+}

--- a/mgrctl/cmd/api/login.go
+++ b/mgrctl/cmd/api/login.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/uyuni-project/uyuni-tools/shared/api"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -21,11 +22,19 @@ func runLogin(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Comman
 	// ToDO add FQDN checker from rebase
 	utils.AskIfMissing(&flags.Server, cmd.Flag("api-server").Usage, 0, 0, nil)
 
-	return api.StoreLoginCreds(cmd.Context(), &flags.ConnectionDetails)
+	if err := api.StoreLoginCreds(&flags.ConnectionDetails); err != nil {
+		return err
+	}
+	log.Info().Msg(L("Login credentials verified and stored"))
+	return nil
 }
 
 func runLogout(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
 	log.Debug().Msg("Running logout command")
 
-	return api.RemoveLoginCreds(cmd.Context())
+	if err := api.RemoveLoginCreds(); err != nil {
+		return err
+	}
+	log.Info().Msg(L("Successfully logged out"))
+	return nil
 }

--- a/mgrctl/cmd/api/login.go
+++ b/mgrctl/cmd/api/login.go
@@ -25,20 +25,20 @@ func runLogin(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Comman
 
 	utils.AskIfMissing(&flags.Server, cmd.Flag("api-server").Usage, 0, 0, utils.IsWellFormedFQDN)
 	utils.AskIfMissing(&flags.User, cmd.Flag("api-user").Usage, 0, 0, nil)
-	utils.AskPasswordIfMissing(&flags.Password, cmd.Flag("api-password").Usage, 0, 0)
+	utils.AskPasswordIfMissingOnce(&flags.Password, cmd.Flag("api-password").Usage, 0, 0)
 
 	client, err := api.Init(&flags.ConnectionDetails)
 	if err != nil {
 		return err
 	}
 	if err := client.Login(); err != nil {
-		return utils.Errorf(err, L("Failed to validate credentials. Not storing"))
+		return utils.Errorf(err, L("Failed to validate credentials."))
 	}
 	if err := api.StoreLoginCreds(client); err != nil {
 		return err
 	}
 
-	log.Info().Msg(L("Login credentials verified and stored"))
+	log.Info().Msg(L("Login credentials verified."))
 	return nil
 }
 

--- a/mgrctl/cmd/api/login.go
+++ b/mgrctl/cmd/api/login.go
@@ -25,6 +25,14 @@ func runLogin(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Comman
 	if err := api.StoreLoginCreds(&flags.ConnectionDetails); err != nil {
 		return err
 	}
+	client, err := api.Init(&flags.ConnectionDetails)
+	if err != nil {
+		return err
+	}
+	if !client.ValidateCreds() {
+		err := api.RemoveLoginCreds()
+		return utils.Errorf(err, L("Failed to validate credentials. Not storing"))
+	}
 	log.Info().Msg(L("Login credentials verified and stored"))
 	return nil
 }

--- a/mgrctl/cmd/api/post.go
+++ b/mgrctl/cmd/api/post.go
@@ -21,7 +21,9 @@ import (
 func runPost(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command, args []string) error {
 	log.Debug().Msgf("Running POST command %s", args[0])
 	client, err := api.Init(&flags.ConnectionDetails)
-
+	if err == nil {
+		err = client.Login()
+	}
 	if err != nil {
 		return utils.Errorf(err, L("unable to login to the server"))
 	}

--- a/mgrctl/cmd/api/post.go
+++ b/mgrctl/cmd/api/post.go
@@ -48,7 +48,7 @@ func runPost(globalFlags *types.GlobalFlags, flags *apiFlags, cmd *cobra.Command
 
 	res, err := api.Post[interface{}](client, path, data)
 	if err != nil {
-		return utils.Errorf(err, L("error in query %s"), path)
+		return utils.Errorf(err, L("error in query '%s'"), path)
 	}
 
 	if !res.Success {

--- a/mgrctl/cmd/cmd.go
+++ b/mgrctl/cmd/cmd.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewCommand returns a new cobra.Command implementing the root command for kinder.
-func NewUyunictlCommand() (*cobra.Command, error) {
+func NewUyunictlCommand() *cobra.Command {
 	globalFlags := &types.GlobalFlags{}
 	name := path.Base(os.Args[0])
 	rootCmd := &cobra.Command{
@@ -48,10 +48,7 @@ func NewUyunictlCommand() (*cobra.Command, error) {
 		}
 	}
 
-	apiCmd, err := api.NewCommand(globalFlags)
-	if err != nil {
-		log.Err(err).Msg(L("Failed to create api command"))
-	}
+	apiCmd := api.NewCommand(globalFlags)
 	rootCmd.AddCommand(apiCmd)
 	rootCmd.AddCommand(exec.NewCommand(globalFlags))
 	rootCmd.AddCommand(term.NewCommand(globalFlags))
@@ -60,5 +57,5 @@ func NewUyunictlCommand() (*cobra.Command, error) {
 
 	rootCmd.AddCommand(utils.GetConfigHelpCommand())
 
-	return rootCmd, nil
+	return rootCmd
 }

--- a/mgrctl/main.go
+++ b/mgrctl/main.go
@@ -16,10 +16,8 @@ import (
 // Run runs the `mgrctl` root command.
 func Run() error {
 	gettext.BindLocale(gettext.New("mgrctl", utils.LocaleRoot, l10n_utils.New(utils.LocaleRoot)))
-	run, err := cmd.NewUyunictlCommand()
-	if err != nil {
-		return err
-	}
+	run := cmd.NewUyunictlCommand()
+
 	return run.Execute()
 }
 

--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -24,27 +24,12 @@ import (
 )
 
 // AddAPIFlags is a helper to include api details for the provided command tree.
-//
-// If the api support is only optional for the command, set optional parameter to true.
-func AddAPIFlags(cmd *cobra.Command, optional bool) error {
+func AddAPIFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("api-server", "", L("FQDN of the server to connect to"))
 	cmd.PersistentFlags().String("api-user", "", L("API user username"))
 	cmd.PersistentFlags().String("api-password", "", L("Password for the API user"))
 	cmd.PersistentFlags().String("api-cacert", "", L("Path to a cert file of the CA"))
 	cmd.PersistentFlags().Bool("api-insecure", false, L("If set, server certificate will not be checked for validity"))
-
-	if false {
-		if err := cmd.MarkPersistentFlagRequired("api-server"); err != nil {
-			return err
-		}
-		if err := cmd.MarkPersistentFlagRequired("api-user"); err != nil {
-			return err
-		}
-		if err := cmd.MarkPersistentFlagRequired("api-password"); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func prettyPrint(v interface{}) string {

--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -71,9 +71,11 @@ func (c *APIClient) sendRequest(req *http.Request) (*http.Response, error) {
 			body, err := io.ReadAll(res.Body)
 			if err == nil {
 				if err = json.Unmarshal(body, &errResponse); err == nil {
-					return nil, fmt.Errorf(L("%d: %s"), res.StatusCode, errResponse["message"])
+					error_message := fmt.Sprintf("%d: '%s'", res.StatusCode, errResponse["message"])
+					return nil, fmt.Errorf(error_message)
 				} else {
-					return nil, fmt.Errorf(L("%d: %s"), res.StatusCode, string(body))
+					error_message := fmt.Sprintf("%d: '%s'", res.StatusCode, string(body))
+					return nil, fmt.Errorf(error_message)
 				}
 			}
 		}

--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -172,6 +172,12 @@ func (c *APIClient) login() error {
 	return nil
 }
 
+// Check if login credentials are valid.
+func (c *APIClient) ValidateCreds() bool {
+	err := c.Login()
+	return err == nil
+}
+
 // Post issues a POST HTTP request to the API target
 //
 // `path` specifies an API endpoint

--- a/shared/api/credentials.go
+++ b/shared/api/credentials.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -21,7 +20,7 @@ import (
 )
 
 // Store API credentials for future API use.
-func StoreLoginCreds(ctx context.Context, connection *ConnectionDetails) error {
+func StoreLoginCreds(connection *ConnectionDetails) error {
 	// check login is valid
 	if !checkCredentials(connection) {
 		return fmt.Errorf(L("Failed to validate credentials"))
@@ -59,22 +58,19 @@ func StoreLoginCreds(ctx context.Context, connection *ConnectionDetails) error {
 		log.Error().Msgf(L("Unable to write credentials store"))
 		return err
 	}
-
-	log.Info().Msg(L("Login credentials verified and stored"))
 	return nil
 }
 
 // Remove stored API credentials.
-func RemoveLoginCreds(ctx context.Context) error {
+func RemoveLoginCreds() error {
 	if err := os.Remove(getAPICredsFile()); err != nil {
 		return err
 	}
-	log.Info().Msg(L("Successfully logged out"))
 	return nil
 }
 
 // Read and decrypt stored login credentials.
-func LoadLoginCreds(ctx context.Context, connection *ConnectionDetails) error {
+func LoadLoginCreds(connection *ConnectionDetails) error {
 	data, err := os.ReadFile(getAPICredsFile())
 	if err != nil {
 		return utils.Errorf(err, L("Unable to read credentials file"))

--- a/shared/api/credentials.go
+++ b/shared/api/credentials.go
@@ -11,7 +11,6 @@ import (
 	"path"
 
 	"github.com/rs/zerolog/log"
-
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
@@ -26,7 +25,7 @@ func StoreLoginCreds(client *APIClient) error {
 		{
 			Session: client.AuthCookie.Value,
 			Server:  client.Details.Server,
-			CACert:  client.Details.CAcert,
+			CApath:  client.Details.CApath,
 		},
 	}
 
@@ -105,8 +104,8 @@ func loadLoginCreds(connection *ConnectionDetails) error {
 		return fmt.Errorf(L("specified api server does not match with stored credentials"))
 	}
 	connection.Server = authData.Server
-	if authData.CACert != "" {
-		connection.CAcert = authData.CACert
+	if authData.CApath != "" {
+		connection.CApath = authData.CApath
 	}
 
 	connection.Cookie = authData.Session

--- a/shared/api/credentials.go
+++ b/shared/api/credentials.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/rs/zerolog/log"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// Store API credentials for future API use.
+func StoreLoginCreds(ctx context.Context, connection *ConnectionDetails) error {
+	// check login is valid
+	if !checkCredentials(connection) {
+		return fmt.Errorf(L("Failed to validate credentials"))
+	}
+
+	// encrypt login data
+	urldata := getFixedServerString(connection.Server)
+	encodedURL := make([]byte, base64.URLEncoding.EncodedLen(len(urldata)))
+	base64.URLEncoding.Encode(encodedURL, urldata)
+
+	encUser, err := encryptMsg(connection.User, [32]byte(encodedURL))
+	if err != nil {
+		return err
+	}
+	encPassword, err := encryptMsg(connection.Password, [32]byte(encodedURL))
+	if err != nil {
+		return err
+	}
+
+	// store encrypted credentials into separate credentials config storage
+	auth := authStorage{
+		User:     encUser,
+		Password: encPassword,
+		Server:   connection.Server,
+	}
+
+	authData, err := json.Marshal(auth)
+	if err != nil {
+		log.Error().Msgf(L("Unable to create credentials json"))
+		return err
+	}
+
+	err = os.WriteFile(getAPICredsFile(), authData, 0)
+	if err != nil {
+		log.Error().Msgf(L("Unable to write credentials store"))
+		return err
+	}
+
+	log.Info().Msg(L("Login credentials verified and stored"))
+	return nil
+}
+
+// Remove stored API credentials.
+func RemoveLoginCreds(ctx context.Context) error {
+	if err := os.Remove(getAPICredsFile()); err != nil {
+		return err
+	}
+	log.Info().Msg(L("Successfully logged out"))
+	return nil
+}
+
+// Read and decrypt stored login credentials.
+func LoadLoginCreds(ctx context.Context, connection *ConnectionDetails) error {
+	data, err := os.ReadFile(getAPICredsFile())
+	if err != nil {
+		return utils.Errorf(err, L("Unable to read credentials file"))
+	}
+	authData := authStorage{}
+	err = json.Unmarshal(data, &authData)
+	if err != nil {
+		return utils.Errorf(err, L("Unable to decode credentials file"))
+	}
+	connection.Server = authData.Server
+
+	urldata := getFixedServerString(connection.Server)
+	encodedURL := make([]byte, base64.URLEncoding.EncodedLen(len(urldata)))
+	base64.URLEncoding.Encode(encodedURL, urldata)
+
+	decUser, err := decryptMsg(authData.User, [32]byte(encodedURL))
+	if err != nil {
+		return err
+	}
+	decPassword, err := decryptMsg(authData.Password, [32]byte(encodedURL))
+	if err != nil {
+		return err
+	}
+	connection.Password = string(decPassword)
+	connection.User = string(decUser)
+	return nil
+}
+
+func checkCredentials(connection *ConnectionDetails) bool {
+	_, err := Init(connection)
+	return err == nil
+}
+
+func getAPICredsFile() string {
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			xdgConfigHome = path.Join(home, ".config")
+		}
+	}
+	return path.Join(xdgConfigHome, api_credentials_store)
+}
+
+func getFixedServerString(server string) []byte {
+	res := make([]byte, 32)
+	for i := range res {
+		res[i] = '_'
+	}
+	if len(server) > 32 {
+		copy(res, server[:32])
+	} else {
+		copy(res, server)
+	}
+	return res
+}
+
+func encryptMsg(message string, secret [32]byte) ([]byte, error) {
+	var nonce [24]byte
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return nil, err
+	}
+
+	return secretbox.Seal(nonce[:], []byte(message), &nonce, &secret), nil
+}
+
+func decryptMsg(message []byte, secret [32]byte) (string, error) {
+	var decryptNonce [24]byte
+	copy(decryptNonce[:], message[:24])
+	decrypted, err := secretbox.Open(nil, message[24:], &decryptNonce, &secret)
+	if !err {
+		return "", fmt.Errorf(L("Decoding of secret failed"))
+	}
+	return string(decrypted), nil
+}

--- a/shared/api/credentials_test.go
+++ b/shared/api/credentials_test.go
@@ -99,8 +99,8 @@ func TestAutocleanup(t *testing.T) {
 	connection := ConnectionDetails{
 		Server: server,
 	}
-	err = getLoginCredentials(&connection)
-	if err == nil || connection.InSession {
+	getStoredConnectionDetails(&connection)
+	if connection.InSession {
 		t.Fail()
 	}
 	_, err = os.Stat(getAPICredsFile())

--- a/shared/api/mocks/mocks.go
+++ b/shared/api/mocks/mocks.go
@@ -7,12 +7,11 @@ package mocks
 import "net/http"
 
 // Mocked api.HTTPClient.
-type MockClient struct{}
-
-// To override Do function.
-var GetDoFunc func(req *http.Request) (*http.Response, error)
+type MockClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
 
 // To fulfil api.HTTPClient interface.
 func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
-	return GetDoFunc(req)
+	return m.DoFunc(req)
 }

--- a/shared/api/mocks/mocks.go
+++ b/shared/api/mocks/mocks.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import "net/http"
+
+// Mocked api.HTTPClient.
+type MockClient struct{}
+
+// To override Do function.
+var GetDoFunc func(req *http.Request) (*http.Response, error)
+
+// To fulfil api.HTTPClient interface.
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	return GetDoFunc(req)
+}

--- a/shared/api/org/createFirst.go
+++ b/shared/api/org/createFirst.go
@@ -17,6 +17,9 @@ import (
 // orgName is the name of the first organization to create and admin the user to create.
 func CreateFirst(cnxDetails *api.ConnectionDetails, orgName string, admin *types.User) (*types.Organization, error) {
 	client, err := api.Init(cnxDetails)
+	if err == nil {
+		err = client.Login()
+	}
 	if err != nil {
 		return nil, utils.Errorf(err, L("failed to connect to the server"))
 	}

--- a/shared/api/types.go
+++ b/shared/api/types.go
@@ -9,17 +9,25 @@ import "net/http"
 const root_path_apiv1 = "/rhn/manager/api"
 const api_credentials_store = ".uyuni-api.json"
 
-// HTTP Client is an API entrypoint.
-type HTTPClient struct {
+// API Client is the API entrypoint.
+type APIClient struct {
 
 	// URL to the API endpoint of the target host
 	BaseURL string
 
 	// net/http client
-	Client *http.Client
+	Client HTTPClient
 
 	// Authentication cookie storage
 	AuthCookie *http.Cookie
+
+	// Connection details
+	Details *ConnectionDetails
+}
+
+// Minimal HTTPClient interface. Primarily for unit testing.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // Connection details for initial API connection.
@@ -40,6 +48,9 @@ type ConnectionDetails struct {
 
 	// Disable certificate validation, unsecure and not recommended.
 	Insecure bool
+
+	// Indicates if details we loaded from cache
+	Cached bool
 }
 
 // API response where T is the type of the result.

--- a/shared/api/types.go
+++ b/shared/api/types.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import "net/http"
+
+const root_path_apiv1 = "/rhn/manager/api"
+const api_credentials_store = ".uyuni-api.json"
+
+// HTTP Client is an API entrypoint.
+type HTTPClient struct {
+
+	// URL to the API endpoint of the target host
+	BaseURL string
+
+	// net/http client
+	Client *http.Client
+
+	// Authentication cookie storage
+	AuthCookie *http.Cookie
+}
+
+// Connection details for initial API connection.
+type ConnectionDetails struct {
+
+	// FQDN of the target host.
+	Server string
+
+	// User to login under.
+	User string
+
+	// Password for the user.
+	Password string
+
+	// CA certificate used for target host validation.
+	// Provided certificate is used together with system certificates.
+	CAcert string
+
+	// Disable certificate validation, unsecure and not recommended.
+	Insecure bool
+}
+
+// API response where T is the type of the result.
+type ApiResponse[T interface{}] struct {
+	Result  T
+	Success bool
+	Message string
+}
+
+// Authentication storage.
+type authStorage struct {
+	User     []byte
+	Password []byte
+	Server   string
+}

--- a/shared/api/types.go
+++ b/shared/api/types.go
@@ -50,7 +50,10 @@ type ConnectionDetails struct {
 	Insecure bool
 
 	// Indicates if details we loaded from cache
-	Cached bool
+	InSession bool
+
+	// PXE cookie
+	Cookie string
 }
 
 // API response where T is the type of the result.
@@ -62,7 +65,7 @@ type ApiResponse[T interface{}] struct {
 
 // Authentication storage.
 type authStorage struct {
-	User     []byte
-	Password []byte
-	Server   string
+	Session string
+	Server  string
+	CACert  string
 }

--- a/shared/api/types.go
+++ b/shared/api/types.go
@@ -42,9 +42,9 @@ type ConnectionDetails struct {
 	// Password for the user.
 	Password string
 
-	// CA certificate used for target host validation.
+	// Path to CA certificate file used for target host validation.
 	// Provided certificate is used together with system certificates.
-	CAcert string
+	CApath string
 
 	// Disable certificate validation, unsecure and not recommended.
 	Insecure bool
@@ -67,5 +67,5 @@ type ApiResponse[T interface{}] struct {
 type authStorage struct {
 	Session string
 	Server  string
-	CACert  string
+	CApath  string
 }

--- a/shared/utils/config.go
+++ b/shared/utils/config.go
@@ -41,6 +41,21 @@ func addConfigurationFile(v *viper.Viper, cmd *cobra.Command, configFilename str
 	return nil
 }
 
+// Returns user configuration directory.
+// Can be $XDG_CONFIG_HOME or `homedir/.config`.
+func GetUserConfigDir() string {
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Warn().Err(err).Msg(L("Failed to find home directory"))
+		} else {
+			xdgConfigHome = path.Join(home, ".config")
+		}
+	}
+	return xdgConfigHome
+}
+
 // ReadConfig parse configuration file and env variables a return parameters.
 func ReadConfig(cmd *cobra.Command, configPaths ...string) (*viper.Viper, error) {
 	v := viper.New()
@@ -55,15 +70,7 @@ func ReadConfig(cmd *cobra.Command, configPaths ...string) (*viper.Viper, error)
 	v.SetConfigType("yaml")
 	v.SetConfigName(configFilename)
 
-	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfigHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			log.Err(err).Msg(L("Failed to find home directory"))
-		} else {
-			xdgConfigHome = path.Join(home, ".config")
-		}
-	}
+	xdgConfigHome := GetUserConfigDir()
 	if xdgConfigHome != "" {
 		v.AddConfigPath(path.Join(xdgConfigHome, appName))
 	}

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -96,6 +96,12 @@ func CheckValidPassword(value *string, prompt string, min int, max int) string {
 // AskPasswordIfMissing asks for password if missing.
 // Don't perform any check if min and max are set to 0.
 func AskPasswordIfMissing(value *string, prompt string, min int, max int) {
+	if *value == "" && !term.IsTerminal(int(os.Stdin.Fd())) {
+		//return fmt.Errorf(L("not an interactive device"))
+		log.Warn().Msgf(L("not an interactive device, not asking for missing value"))
+		return
+	}
+
 	for *value == "" {
 		firstRound := CheckValidPassword(value, prompt, min, max)
 		if firstRound == "" {
@@ -114,12 +120,18 @@ func AskPasswordIfMissing(value *string, prompt string, min int, max int) {
 // AskIfMissing asks for a value if missing.
 // Don't perform any check if min and max are set to 0.
 func AskIfMissing(value *string, prompt string, min int, max int, checker func(string) bool) {
+	if *value == "" && !term.IsTerminal(int(os.Stdin.Fd())) {
+		log.Warn().Msgf(L("not an interactive device, not asking for missing value"))
+		return
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 	for *value == "" {
 		fmt.Print(prompt + prompt_end)
 		newValue, err := reader.ReadString('\n')
 		if err != nil {
-			log.Fatal().Err(err).Msgf(L("Failed to read input"))
+			//return utils.Errorf(err, L("failed to read input"))
+			log.Fatal().Err(err).Msg(L("failed to read input"))
 		}
 		tmpValue := strings.TrimSpace(newValue)
 		if checkValueSize(tmpValue, min, max) && (checker == nil || checker(tmpValue)) {

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -410,8 +410,8 @@ func GetFqdn(args []string) (string, error) {
 
 // IsValidFDQN returns an error if the argument is not a valid FQDN.
 func IsValidFQDN(fqdn string) error {
-	if err := IsWellFormedFQDN(fqdn); err != nil {
-		return err
+	if !IsWellFormedFQDN(fqdn) {
+		return fmt.Errorf(L("%s is not a valid FQDN"), fqdn)
 	}
 	_, err := net.LookupHost(fqdn)
 	if err != nil {
@@ -420,12 +420,9 @@ func IsValidFQDN(fqdn string) error {
 	return nil
 }
 
-// IsWellFormedFQDN returns an error if the argument is not a well formed FQDN.
-func IsWellFormedFQDN(fqdn string) error {
-	if !fqdnValid.MatchString(fqdn) {
-		return fmt.Errorf(L("%s is not a valid FQDN"), fqdn)
-	}
-	return nil
+// IsWellFormedFQDN returns an false if the argument is not a well formed FQDN.
+func IsWellFormedFQDN(fqdn string) bool {
+	return fqdnValid.MatchString(fqdn)
 }
 
 // Check if a given command exists in PATH.

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -117,6 +117,20 @@ func AskPasswordIfMissing(value *string, prompt string, min int, max int) {
 	}
 }
 
+// AskPasswordIfMissingOnce asks for password if missing only once
+// Don't perform any check if min and max are set to 0.
+func AskPasswordIfMissingOnce(value *string, prompt string, min int, max int) {
+	if *value == "" && !term.IsTerminal(int(os.Stdin.Fd())) {
+		//return fmt.Errorf(L("not an interactive device"))
+		log.Warn().Msgf(L("not an interactive device, not asking for missing value"))
+		return
+	}
+
+	for *value == "" {
+		*value = CheckValidPassword(value, prompt, min, max)
+	}
+}
+
 // AskIfMissing asks for a value if missing.
 // Don't perform any check if min and max are set to 0.
 func AskIfMissing(value *string, prompt string, min int, max int, checker func(string) bool) {

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -259,8 +259,8 @@ func TestIsWellFormedFQDN(t *testing.T) {
 	}
 
 	for i, testCase := range data {
-		if err := IsWellFormedFQDN(testCase); err != nil {
-			t.Errorf("Testcase %d: Unexpected error while validating FQDN with %s", i, testCase)
+		if !IsWellFormedFQDN(testCase) {
+			t.Errorf("Testcase %d: Unexpected failure while validating FQDN with %s", i, testCase)
 		}
 	}
 	wrongData := []string{
@@ -271,8 +271,8 @@ func TestIsWellFormedFQDN(t *testing.T) {
 	}
 
 	for i, testCase := range wrongData {
-		if err := IsWellFormedFQDN(testCase); err == nil {
-			t.Errorf("Testcase %d: expected error while validating FQDN with %s", i, testCase)
+		if IsWellFormedFQDN(testCase) {
+			t.Errorf("Testcase %d: Unexpected success while validating FQDN with %s", i, testCase)
 		}
 	}
 }

--- a/uyuni-tools.changes.oholecek.persistent_login
+++ b/uyuni-tools.changes.oholecek.persistent_login
@@ -1,0 +1,1 @@
+- add api login and logout calls to allow persistent login


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Add support for login and logout api options.

Login will store session cookie together with server to the ~/.config/.uyuni-api file.
Next api calls will try to load session from this file and use it.

If session is detected to be expired (by issuing get user/listAssignableRoles), if mgrctl api is run in terminal it asks for user and password. If not, call is aborted.

Logout command removes the file with stored session and also calls auth/logout.

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/239
Port: https://github.com/SUSE/uyuni-tools/pull/14

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

