### PR TITLE
On Ubuntu build with Go1.21

### DIFF
--- a/uyuni-tools.changes.deneb-alpha.use_go121_on_ubuntu
+++ b/uyuni-tools.changes.deneb-alpha.use_go121_on_ubuntu
@@ -1,0 +1,1 @@
+- On Ubuntu build with go1.21 instead of go1.20

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -72,7 +72,7 @@ BuildRequires:  golang(API) >= 1.20
 # 0%{?suse_version}
 
 %if 0%{?ubuntu}
-%define go_version      1.20
+%define go_version      1.21
 BuildRequires:  golang-%{go_version}
 %endif
 # 0%{?ubuntu}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Build with Go1.21 instead of Go1.20. 
**This enables the build also on Ubuntu 24.04 and Ubuntu 22.04 still builds correctly**

## Test coverage
- Tests: built on OBS https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master:ContainerUtils/uyuni-tools

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/23918 and https://github.com/SUSE/spacewalk/issues/23880

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

