### PR TITLE
Kubernetes fixes

### DIFF
--- a/mgradm/shared/kubernetes/certificates.go
+++ b/mgradm/shared/kubernetes/certificates.go
@@ -112,7 +112,7 @@ func installCertManager(helmFlags *cmd_utils.HelmFlags, kubeconfig string, image
 		namespace := helmFlags.CertManager.Namespace
 
 		args := []string{
-			"--set", "installCRDs=true",
+			"--set", "crds.enabled=true",
 			"--set-json", "global.commonLabels={\"installedby\": \"mgradm\"}",
 			"--set", "images.pullPolicy=" + kubernetes.GetPullPolicy(imagePullPolicy),
 		}

--- a/shared/utils/exec.go
+++ b/shared/utils/exec.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -46,12 +45,12 @@ func RunCmd(command string, args ...string) error {
 
 // RunCmdStdMapping execute a shell command mapping the stdout and stderr.
 func RunCmdStdMapping(logLevel zerolog.Level, command string, args ...string) error {
-	localLogger := log.Level(logLevel)
+	localLogger := log.Logger.Level(logLevel)
 	localLogger.Debug().Msgf("Running: %s %s", command, strings.Join(args, " "))
 
 	runCmd := exec.Command(command, args...)
-	runCmd.Stdout = os.Stdout
-	runCmd.Stderr = os.Stderr
+	runCmd.Stdout = localLogger
+	runCmd.Stderr = localLogger
 	err := runCmd.Run()
 	return err
 }

--- a/uyuni-tools.changes.cbosdo.traefik-uninstall
+++ b/uyuni-tools.changes.cbosdo.traefik-uninstall
@@ -1,0 +1,1 @@
+- Server on kubernetes uninstallation fixes


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fixes:

* cert-manager deprecated CRDs installation parameter
* uninstallation of traefik to properly reload without our config
* Output more command outputs to the log file
* Fix uninstallation of the server on kubernetes looking for the proxy helm release.

## Test coverage
- No tests: could only be covered with end to end tests

- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

