### PR TITLE
Skip updating tomcat remote debug if conf file is not present

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -120,7 +120,7 @@ sed 's/address=[^:]*:/address=*:/' -i /etc/rhn/taskomatic.conf;
 echo "Altering tomcat configuration..."
 sed 's/--add-modules java.annotation,com.sun.xml.bind://' -i /etc/tomcat/conf.d/*
 sed 's/-XX:-UseConcMarkSweepGC//' -i /etc/tomcat/conf.d/*
-sed 's/address=[^:]*:/address=*:/' -i /etc/tomcat/conf.d/remote_debug.conf
+test -f /etc/tomcat/conf.d/remote_debug.conf && sed 's/address=[^:]*:/address=*:/' -i /etc/tomcat/conf.d/remote_debug.conf
 
 {{ if .Kubernetes }}
 echo 'server.no_ssl = 1' >> /etc/rhn/rhn.conf;

--- a/uyuni-tools.changes.oholecek.skip_remote_debug_if_notpresent
+++ b/uyuni-tools.changes.oholecek.skip_remote_debug_if_notpresent
@@ -1,0 +1,1 @@
+- skip updating tomcat remote debug if conf file is not present


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

If `/etc/tomcat/conf.d/remote_debug.conf` does not exists on the migration target system, skip trying to update it.

This is a follow-up fix from https://github.com/uyuni-project/uyuni-tools/pull/411

## Test coverage
- No tests: Something for integration testing

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

