### PR TITLE
Improve compatibility for updating host trusted certificates

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -425,4 +426,10 @@ func IsWellFormedFQDN(fqdn string) error {
 		return fmt.Errorf(L("%s is not a valid FQDN"), fqdn)
 	}
 	return nil
+}
+
+// Check if a given command exists in PATH.
+func CommandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
 }

--- a/uyuni-tools.changes.santeri3700.improve_copycacertificate_compatibility
+++ b/uyuni-tools.changes.santeri3700.improve_copycacertificate_compatibility
@@ -1,0 +1,1 @@
+- improve compatibility for updating host trusted certificates


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

These changes aim to improve compatibility with other distributions as the container host operating system. \
The `CopyCaCertificate` function fails to copy and/or update the host's trusted certificates on certain distributions such as AlmaLinux 9 (RHEL9) and Arch Linux without these changes.

I've tested the changes with Podman on openSUSE Leap Micro 5.5, AlmaLinux 9 and Arch Linux.

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

