### PR TITLE
Handle setup script returns 1 when already registered

### DIFF
--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -41,7 +41,7 @@ func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[
 	}
 
 	err := adm_utils.ExecCommand(zerolog.InfoLevel, cnx, "/tmp/setup.sh")
-	if err != nil {
+	if err != nil && !preconfigured {
 		return utils.Errorf(err, L("error running the setup script"))
 	}
 

--- a/uyuni-tools.changes.oholecek.fix-autoreinstallation
+++ b/uyuni-tools.changes.oholecek.fix-autoreinstallation
@@ -1,0 +1,1 @@
+- fix error code handling on reinstallation (bsc#1230139)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This commit ignores error return when already setup. This may potentially hide actual errors, but check if server is already setup happens right after variables checks.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

