### PR TITLE
share volumes between containers (bsc#1223142)

### DIFF
--- a/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
+++ b/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
@@ -37,7 +37,7 @@ ExecStart=/usr/bin/podman run \
         -p {{ .Exposed }}:{{ .Port }}{{if .Protocol}}/{{ .Protocol }}{{end}} \
         {{- end }}
         {{- range .Volumes }}
-        -v {{ .Name }}:{{ .MountPath }} \
+        -v {{ .Name }}:{{ .MountPath }}:z \
         {{- end }}
 	-e HUB_API_URL \
 	-e HUB_CONNECT_TIMEOUT \

--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -43,7 +43,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
         {{- end }}
 	{{- end }}
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }} \
+	-v {{ .Name }}:{{ .MountPath }}:z \
 	{{- end }}
 	-e TZ=${TZ} \
 	--network {{ .Network }} \

--- a/mgrpxy/shared/templates/httpd.go
+++ b/mgrpxy/shared/templates/httpd.go
@@ -37,7 +37,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--replace -dt \
 	-v /etc/uyuni/proxy:/etc/uyuni:ro \
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }} \
+	-v {{ .Name }}:{{ .MountPath }}:z \
 	{{- end }}
 	${HTTPD_EXTRA_CONF} --name uyuni-proxy-httpd \
 	${UYUNI_IMAGE}'

--- a/mgrpxy/shared/templates/squid.go
+++ b/mgrpxy/shared/templates/squid.go
@@ -37,7 +37,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--replace -dt \
 	-v /etc/uyuni/proxy:/etc/uyuni:ro \
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }} \
+	-v {{ .Name }}:{{ .MountPath }}:z \
 	{{- end }}
 	${SQUID_EXTRA_CONF} --name uyuni-proxy-squid \
 	${UYUNI_IMAGE}'

--- a/mgrpxy/shared/templates/tftpd.go
+++ b/mgrpxy/shared/templates/tftpd.go
@@ -37,7 +37,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--replace -dt \
 	-v /etc/uyuni/proxy:/etc/uyuni:ro \
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }} \
+	-v {{ .Name }}:{{ .MountPath }}:z \
 	{{- end }}
 	--name uyuni-proxy-tftpd \
 	${UYUNI_IMAGE}'

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -66,7 +66,7 @@ func RunContainer(name string, image string, volumes []types.VolumeMount, extraA
 	podmanArgs := append([]string{"run", "--name", name}, GetCommonParams()...)
 	podmanArgs = append(podmanArgs, extraArgs...)
 	for _, volume := range volumes {
-		podmanArgs = append(podmanArgs, "-v", volume.Name+":"+volume.MountPath)
+		podmanArgs = append(podmanArgs, "-v", volume.Name+":"+volume.MountPath+":z")
 	}
 	podmanArgs = append(podmanArgs, image)
 	podmanArgs = append(podmanArgs, cmd...)

--- a/uyuni-tools.changes.mbussolotto.shared_volume
+++ b/uyuni-tools.changes.mbussolotto.shared_volume
@@ -1,0 +1,1 @@
+- share volumes between containers (bsc#1223142)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

TBH I'm not sure if it'd fix the problem bsc#1223142, but I couldn't find any way to reproduce it and it looks too sporadic, I'd give it a try with it

from podman doc:
```
Labeling systems like SELinux require that proper labels are placed on volume content mounted into a 
<<container|pod>>. 
Without a label, the security system might prevent the processes running inside the 
<<container|pod>> from using the content. 

By default, Podman does not change the labels set by the OS.
To change a label in the <<container|pod>> context, add either of two suffixes :z or :Z to the volume mount. 
These suffixes tell Podman to relabel file objects on the shared volumes. 
The z option tells Podman that two or more <<containers|pods>> share the volume content. 
As a result, Podman labels the content with a shared content label. 
Shared volume labels allow all containers to read/write content. 
The Z option tells Podman to label the content with a private unshared label Only the current <<container|pod>> can use a private volume. 
Relabeling walks the file system under the volume and changes the label on each file, if the volume has thousands of inodes, this process takes a long time, delaying the start of the <<container|pod>>. 
If the volume was previously relabeled with the z option, Podman is optimized to not relabel a second time. 
If files are moved into the volume, then the labels can be manually change with the chcon -R container_file_t PATH command.
```
## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24144

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

