### PR TITLE
Fix namespace usage on mgrctl cp command

### DIFF
--- a/shared/connection.go
+++ b/shared/connection.go
@@ -343,7 +343,10 @@ func (c *Connection) Copy(src string, dst string, user string, group string) err
 	}
 
 	if user != "" && strings.HasPrefix(dst, "server:") {
-		execArgs := []string{"exec", podName, "-n", namespace}
+		execArgs := []string{"exec", podName}
+		if command == "kubectl" {
+			execArgs = append(execArgs, "-n", namespace)
+		}
 		execArgs = append(execArgs, extraArgs...)
 		owner := user
 		if group != "" {

--- a/uyuni-tools.changes.rjpmestre.mgrctl-cp-fix-namespace
+++ b/uyuni-tools.changes.rjpmestre.mgrctl-cp-fix-namespace
@@ -1,0 +1,1 @@
+- Fix namespace usage on mgrctl cp command


### PR DESCRIPTION
## What does this PR change?

Fix namespace usage on mgrctl cp command

## Test coverage
- No tests: not in scope

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

