### PR TITLE
Fix creating first organization and user

### DIFF
--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -59,7 +59,11 @@ func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[
 		}
 
 		// Check if there is already admin user with given password and organization with same name
-		if _, err := api.Init(&apiCnx); err == nil {
+		client, err := api.Init(&apiCnx)
+		if err != nil {
+			log.Error().Err(err).Msgf(L("unable to prepare API client"))
+		}
+		if err = client.Login(); err == nil {
 			if _, err := org.GetOrganizationDetails(&apiCnx, flags.Organization); err == nil {
 				log.Info().Msgf(L("Server organization already exists, reusing"))
 			} else {
@@ -72,11 +76,7 @@ func RunSetup(cnx *shared.Connection, flags *InstallFlags, fqdn string, env map[
 				// We were not able to connect to the server at all
 				return err
 			}
-			// We do not have any user existing, do not try to login
-			apiCnx = api.ConnectionDetails{
-				Server:   fqdn,
-				Insecure: false,
-			}
+			// We do not have any user existing, create one. CreateFirst skip user login
 			_, err := org.CreateFirst(&apiCnx, flags.Organization, &flags.Admin)
 			if err != nil {
 				if preconfigured {

--- a/shared/api/org/createFirst.go
+++ b/shared/api/org/createFirst.go
@@ -17,11 +17,8 @@ import (
 // orgName is the name of the first organization to create and admin the user to create.
 func CreateFirst(cnxDetails *api.ConnectionDetails, orgName string, admin *types.User) (*types.Organization, error) {
 	client, err := api.Init(cnxDetails)
-	if err == nil {
-		err = client.Login()
-	}
 	if err != nil {
-		return nil, utils.Errorf(err, L("failed to connect to the server"))
+		return nil, utils.Errorf(err, L("unable to prepare API client"))
 	}
 
 	data := map[string]interface{}{

--- a/shared/api/org/getDetails.go
+++ b/shared/api/org/getDetails.go
@@ -17,6 +17,9 @@ import (
 // Get details of organization based on organization name.
 func GetOrganizationDetails(cnxDetails *api.ConnectionDetails, orgName string) (*types.Organization, error) {
 	client, err := api.Init(cnxDetails)
+	if err == nil {
+		err = client.Login()
+	}
 	if err != nil {
 		return nil, utils.Errorf(err, L("failed to connect to the server"))
 	}

--- a/uyuni-tools.changes.oholecek.fix-firstuser-call
+++ b/uyuni-tools.changes.oholecek.fix-firstuser-call
@@ -1,0 +1,1 @@
+- fix creating first user and organization


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Recent API refactorings does not automatically call login when API client object is created. This was not reflected in code handling first user creation.

This commit add (and removes when not needed) API login calls.

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): https://github.com/SUSE/uyuni-tools/pull/19

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

