### PR TITLE
Fix the images handling in `mgradm support ptf`

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -33,5 +33,5 @@ jobs:
 
       - id: govulncheck
         name: Run govulncheck
-        run: govulncheck -tags ptf ./... 
+        run: govulncheck -tags ptf ./...
         shell: bash

--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -7,6 +7,7 @@ package podman
 
 import (
 	"github.com/spf13/cobra"
+	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
@@ -18,6 +19,8 @@ type podmanPTFFlags struct {
 	TestID     string           `mapstructure:"test"`
 	CustomerID string           `mapstructure:"user"`
 	SCC        types.SCCCredentials
+	Coco       adm_utils.CocoFlags
+	Hubxmlrpc  adm_utils.HubXmlrpcFlags
 }
 
 func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[podmanPTFFlags]) *cobra.Command {

--- a/mgradm/cmd/support/ptf/podman/utils.go
+++ b/mgradm/cmd/support/ptf/podman/utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/podman"
-	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	podman_shared "github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
@@ -26,15 +25,7 @@ func ptfForPodman(
 	cmd *cobra.Command,
 	args []string,
 ) error {
-	// we don't want to perform a postgres version upgrade when installing a PTF.
-	// in that case, we can use the upgrade command.
-	dummyImage := types.ImageFlags{}
-	dummyCoco := adm_utils.CocoFlags{}
-	dummyHubXmlrpc := adm_utils.HubXmlrpcFlags{}
-	if err := flags.checkParameters(); err != nil {
-		return err
-	}
-
+	// Login first to be able to search the registry for PTF images
 	hostData, err := podman_shared.InspectHost()
 	if err != nil {
 		return err
@@ -46,8 +37,19 @@ func ptfForPodman(
 	}
 	defer cleaner()
 
-	return podman.Upgrade(systemd, authFile, "", flags.Image, dummyImage, dummyCoco, dummyHubXmlrpc)
+	//we don't want to perform a postgres version upgrade when installing a PTF.
+	//in that case, we can use the upgrade command.
+	dummyImage := types.ImageFlags{}
+	if err := flags.checkParameters(); err != nil {
+		return err
+	}
+
+	return podman.Upgrade(systemd, authFile, "", flags.Image, dummyImage, flags.Coco, flags.Hubxmlrpc)
 }
+
+// variables for unit testing.
+var getServiceImage = podman_shared.GetServiceImage
+var hasRemoteImage = podman_shared.HasRemoteImage
 
 func (flags *podmanPTFFlags) checkParameters() error {
 	if flags.TestID != "" && flags.PTFId != "" {
@@ -59,10 +61,6 @@ func (flags *podmanPTFFlags) checkParameters() error {
 	if flags.CustomerID == "" {
 		return errors.New(L("user flag cannot be empty"))
 	}
-	serverImage, err := podman_shared.GetRunningImage(podman_shared.ServerContainerName)
-	if err != nil {
-		return err
-	}
 
 	suffix := "ptf"
 	projectID := flags.PTFId
@@ -70,10 +68,43 @@ func (flags *podmanPTFFlags) checkParameters() error {
 		suffix = "test"
 		projectID = flags.TestID
 	}
+
+	serverImage := getServiceImage(podman_shared.ServerService)
+	if serverImage == "" {
+		return errors.New(L("failed to find server image"))
+	}
+
+	var err error
+
 	flags.Image.Name, err = utils.ComputePTF(flags.CustomerID, projectID, serverImage, suffix)
 	if err != nil {
 		return err
 	}
-	log.Info().Msgf(L("The image computed is: %s"), flags.Image.Name)
+	log.Info().Msgf(L("The computed image is %s"), flags.Image.Name)
+
+	if cocoImage := getServiceImage(podman_shared.ServerAttestationService + "@"); cocoImage != "" {
+		// If no coco image was found then skip it during the upgrade.
+		cocoImage, err = utils.ComputePTF(flags.CustomerID, projectID, cocoImage, suffix)
+		if err != nil {
+			return err
+		}
+		if hasRemoteImage(cocoImage) {
+			flags.Coco.Image.Name = cocoImage
+			log.Info().Msgf(L("The computed confidential computing image is %s"), flags.Coco.Image.Name)
+		}
+	}
+
+	if hubImage := getServiceImage(podman_shared.HubXmlrpcService); hubImage != "" {
+		// If no hub xmlrpc api image was found then skip it during the upgrade.
+		hubImage, err = utils.ComputePTF(flags.CustomerID, projectID, hubImage, suffix)
+		if err != nil {
+			return err
+		}
+		if hasRemoteImage(hubImage) {
+			flags.Hubxmlrpc.Image.Name = hubImage
+			log.Info().Msgf(L("The computed hub XML-RPC API image is %s"), flags.Hubxmlrpc.Image.Name)
+		}
+	}
+
 	return nil
 }

--- a/mgradm/cmd/support/ptf/podman/utils_test.go
+++ b/mgradm/cmd/support/ptf/podman/utils_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+//go:build ptf
+
+package podman
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+func TestCheckParameters(t *testing.T) {
+	createServiceImages := func(image string, cocoImage string, hubImage string) map[string]string {
+		return map[string]string{
+			podman.ServerService:                  image,
+			podman.ServerAttestationService + "@": cocoImage,
+			podman.HubXmlrpcService:               hubImage,
+		}
+	}
+	type testData struct {
+		serviceImages     map[string]string
+		hasRemoteImages   map[string]bool
+		expectedImage     string
+		expectedCocoImage string
+		expectedHubImage  string
+		expectedError     string
+	}
+
+	data := []testData{
+		{
+			createServiceImages("registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0", "", ""),
+			map[string]bool{},
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678",
+			"",
+			"",
+			"",
+		},
+		{
+			createServiceImages(
+				"registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-attestation:5.0.0",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:5.0.0",
+			),
+			map[string]bool{
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-attestation:latest-ptf-5678":    true,
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678": true,
+			},
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678",
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-attestation:latest-ptf-5678",
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678",
+			"",
+		},
+		{
+			createServiceImages(
+				"registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-attestation:5.0.0",
+				"",
+			),
+			map[string]bool{
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678":             true,
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-attestation:latest-ptf-5678": false,
+			},
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678",
+			"",
+			"",
+			"",
+		},
+		{
+			createServiceImages(
+				"",
+				"",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:5.0.0",
+			),
+			map[string]bool{
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678": true,
+			},
+			"",
+			"",
+			"",
+			"failed to find server image",
+		},
+	}
+
+	for i, test := range data {
+		getServiceImage = func(service string) string {
+			return test.serviceImages[service]
+		}
+		hasRemoteImage = func(image string) bool {
+			return test.hasRemoteImages[image]
+		}
+
+		flags := podmanPTFFlags{
+			PTFId:      "5678",
+			CustomerID: "1234",
+		}
+		testCase := fmt.Sprintf("case #%d - ", i+1)
+		actualError := flags.checkParameters()
+		errMessage := ""
+		if actualError != nil {
+			errMessage = actualError.Error()
+		}
+		testutils.AssertEquals(t, testCase+"error didn't match the expected behavior",
+			test.expectedError, errMessage,
+		)
+		testutils.AssertEquals(t, testCase+"unexpected image", test.expectedImage, flags.Image.Name)
+		testutils.AssertEquals(t, testCase+"unexpected coco image", test.expectedCocoImage, flags.Coco.Image.Name)
+		testutils.AssertEquals(t, testCase+"unexpected hub image", test.expectedHubImage, flags.Hubxmlrpc.Image.Name)
+	}
+}

--- a/mgradm/shared/coco/coco.go
+++ b/mgradm/shared/coco/coco.go
@@ -28,6 +28,11 @@ func Upgrade(
 	dbUser string,
 	dbPassword string,
 ) error {
+	if cocoFlags.Image.Name == "" {
+		// Don't touch the coco service in ptf if not already present.
+		return nil
+	}
+
 	if err := writeCocoServiceFiles(
 		systemd, authFile, registry, cocoFlags, baseImage, dbName, dbPort, dbUser, dbPassword,
 	); err != nil {

--- a/mgradm/shared/hub/xmlrpcapi.go
+++ b/mgradm/shared/hub/xmlrpcapi.go
@@ -87,6 +87,10 @@ func Upgrade(
 	tag string,
 	hubXmlrpcFlags cmd_utils.HubXmlrpcFlags,
 ) error {
+	if hubXmlrpcFlags.Image.Name == "" {
+		// Don't touch the hub service in ptf if not already present.
+		return nil
+	}
 	if err := SetupHubXmlrpc(systemd, authFile, registry, pullPolicy, tag, hubXmlrpcFlags); err != nil {
 		return err
 	}

--- a/shared/podman/images.go
+++ b/shared/podman/images.go
@@ -258,3 +258,17 @@ func GetRunningImage(container string) (string, error) {
 	image := strings.TrimSpace(string(out))
 	return image, nil
 }
+
+// HasRemoteImage returns true if the image is available remotely.
+//
+// The image has to be a full image with registry, path and tag.
+func HasRemoteImage(image string) bool {
+	out, err := runCmdOutput(zerolog.DebugLevel,
+		"podman", "search", "--list-tags", "--format", "{{.Name}}:{{.Tag}}", image,
+	)
+	if err != nil {
+		return false
+	}
+	imageFinder := regexp.MustCompile("(?Um)^" + image + "$")
+	return imageFinder.Match(out)
+}

--- a/shared/podman/images_test.go
+++ b/shared/podman/images_test.go
@@ -5,7 +5,11 @@
 package podman
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
 )
 
 func TestGetRpmImageName(t *testing.T) {
@@ -98,5 +102,48 @@ func TestMatchingMetadata(t *testing.T) {
 	_, err := BuildRpmImagePath(jsonDataInvalidWithTypo, "", "")
 	if err == nil {
 		t.Error("typo in json: this should fail")
+	}
+}
+
+func TestHasRemoteImage(t *testing.T) {
+	type testData struct {
+		out      string
+		err      error
+		expected bool
+	}
+
+	data := []testData{
+		{
+			`Error: 1 error occurred:
+	* getting repository tags: fetching tags list: repository name not known to registry
+`,
+			errors.New("exit code 125"),
+			false,
+		},
+		{
+			`myregistry.org/path/image:1.2.2
+myregistry.org/path/image:1.2.3
+myregistry.org/path/image:1.2.3.4
+myregistry.org/path/image:1.2
+myregistry.org/path/image:latest`,
+			nil,
+			true,
+		},
+		{
+			`myregistry.org/path/image:1.2.1
+myregistry.org/path/image:1.2.1.2
+myregistry.org/path/image:1.2
+myregistry.org/path/image:latest`,
+			nil,
+			false,
+		},
+	}
+
+	for _, test := range data {
+		runCmdOutput = func(_ zerolog.Level, _ string, _ ...string) ([]byte, error) {
+			return []byte(test.out), test.err
+		}
+		searchedImage := "myregistry.org/path/image:1.2.3"
+		testutils.AssertEquals(t, "Unexpected result", test.expected, HasRemoteImage(searchedImage))
 	}
 }

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -19,6 +20,9 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
+
+// runCmdOutput is a function pointer to use for easies unit testing.
+var runCmdOutput = utils.RunCmdOutput
 
 const commonArgs = "--rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw"
 
@@ -107,21 +111,19 @@ func DeleteContainer(name string, dryRun bool) {
 
 // GetServiceImage returns the value of the UYUNI_IMAGE variable for a systemd service.
 func GetServiceImage(service string) string {
-	serviceConfPath := GetServiceConfPath(service)
-	if !utils.FileExists(serviceConfPath) {
+	out, err := runCmdOutput(zerolog.DebugLevel, "systemd", "cat", service)
+	if err != nil {
+		log.Warn().Err(err).Msgf(L("failed to get %s systemd service definition"), service)
 		return ""
 	}
 
-	content := string(utils.ReadFile(serviceConfPath))
-	lines := strings.Split(content, "\n")
-	const imagePrefix = "Environment=UYUNI_IMAGE="
-	for _, line := range lines {
-		if strings.HasPrefix(line, imagePrefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, imagePrefix))
-		}
+	imageFinder := regexp.MustCompile(`UYUNI_IMAGE=(.*)`)
+	matches := imageFinder.FindStringSubmatch(string(out))
+	if len(matches) < 2 {
+		log.Warn().Msgf(L("no UYUNI_IMAGE defined in %s systemd service"), service)
+		return ""
 	}
-
-	return ""
+	return matches[1]
 }
 
 // DeleteImage deletes a podman image based on its name.

--- a/shared/podman/utils_test.go
+++ b/shared/podman/utils_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+func TestGetServiceImage(t *testing.T) {
+	type dataType struct {
+		catOut   string
+		catErr   error
+		expected string
+	}
+	data := []dataType{
+		{"", errors.New("service not existing"), ""},
+		{"content with no image defined", nil, ""},
+		{`# /etc/systemd/system/uyuni-server-attestation@.service
+[Unit]
+Description=Uyuni server attestation container service
+Wants=network.target
+After=network-online.target
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+[Install]
+WantedBy=multi-user.target default.target
+
+# /etc/systemd/system/uyuni-server-attestation@.service.d/generated.conf
+
+[Service]
+Environment=UYUNI_IMAGE=myregistry.org/silly/image:tag
+`, nil, "myregistry.org/silly/image:tag"},
+	}
+
+	for _, testData := range data {
+		runCmdOutput = func(_ zerolog.Level, _ string, _ ...string) ([]byte, error) {
+			return []byte(testData.catOut), testData.catErr
+		}
+
+		testutils.AssertEquals(t, "Wrong image found", testData.expected, GetServiceImage("myservice"))
+	}
+}

--- a/uyuni-tools.changes.cbosdo.ptf-fix
+++ b/uyuni-tools.changes.cbosdo.ptf-fix
@@ -1,0 +1,2 @@
+- Ignore coco and hub images when applying PTF if they are not
+  available (bsc#1229079)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The mgradm support ptf command has been designed with only the server image in mind, leave the coco and hub container untouched in such a case.

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

