### PR TITLE
Persist the search indexes in a volume

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -44,18 +45,14 @@ func GetExposedPorts(debug bool) []types.PortMap {
 	return ports
 }
 
-// GenerateSystemdService creates a serverY systemd file.
-func GenerateSystemdService(tz string, image string, debug bool, mirrorPath string, podmanArgs []string) error {
-	ipv6Enabled, err := podman.SetupNetwork(false)
-	if err != nil {
-		return utils.Errorf(err, L("cannot setup network"))
-	}
+// GenerateServerSystemdService creates the server systemd service file.
+func GenerateServerSystemdService(mirrorPath string, debug bool) error {
+	ipv6Enabled := podman.HasIpv6Enabled(podman.UyuniNetwork)
 
-	log.Info().Msg(L("Enabling system service"))
 	args := podman.GetCommonParams()
 
 	if mirrorPath != "" {
-		args = append(args, "-v", mirrorPath+":/mirror")
+		args = append(args, "-v", mirrorPath+":/mirror:z")
 	}
 
 	ports := GetExposedPorts(debug)
@@ -72,8 +69,23 @@ func GenerateSystemdService(tz string, image string, debug bool, mirrorPath stri
 		Network:     podman.UyuniNetwork,
 		IPV6Enabled: ipv6Enabled,
 	}
-	if err := utils.WriteTemplateToFile(data, podman.GetServicePath("uyuni-server"), 0555, false); err != nil {
+	if err := utils.WriteTemplateToFile(data, podman.GetServicePath("uyuni-server"), 0555, true); err != nil {
 		return utils.Errorf(err, L("failed to generate systemd service unit file"))
+	}
+
+	return nil
+}
+
+// GenerateSystemdService creates a server systemd file.
+func GenerateSystemdService(tz string, image string, debug bool, mirrorPath string, podmanArgs []string) error {
+	err := podman.SetupNetwork(false)
+	if err != nil {
+		return utils.Errorf(err, L("cannot setup network"))
+	}
+
+	log.Info().Msg(L("Enabling system service"))
+	if err := GenerateServerSystemdService(mirrorPath, debug); err != nil {
+		return err
 	}
 
 	if err := podman.GenerateSystemdConfFile("uyuni-server", "generated.conf",
@@ -403,6 +415,10 @@ func Upgrade(
 	); err != nil {
 		return err
 	}
+
+	if err := updateServerSystemdService(); err != nil {
+		return err
+	}
 	log.Info().Msg(L("Waiting for the server to start…"))
 
 	err = coco.Upgrade(authFile, registry, cocoFlags, image,
@@ -418,6 +434,31 @@ func Upgrade(
 	}
 
 	return podman.ReloadDaemon(false)
+}
+
+var runCmdOutput = utils.RunCmdOutput
+
+func hasDebugPorts(definition []byte) bool {
+	return regexp.MustCompile(`-p 8003:8003`).Match(definition)
+}
+
+func getMirrorPath(definition []byte) string {
+	mirrorPath := ""
+	finder := regexp.MustCompile(`-v +([^:]+):/mirror(?::z)?[[:space:]]`)
+	submatches := finder.FindStringSubmatch(string(definition))
+	if len(submatches) == 2 {
+		mirrorPath = submatches[1]
+	}
+	return mirrorPath
+}
+
+func updateServerSystemdService() error {
+	out, err := runCmdOutput(zerolog.DebugLevel, "systemctl", "cat", podman.ServerService)
+	if err != nil {
+		return utils.Errorf(err, "failed to get %s systemd service definition", podman.ServerService)
+	}
+
+	return GenerateServerSystemdService(getMirrorPath(out), hasDebugPorts(out))
 }
 
 // Inspect check values on a given image and deploy.

--- a/mgradm/shared/podman/podman_test.go
+++ b/mgradm/shared/podman/podman_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/test_utils"
+)
+
+func TestHasDebugPorts(t *testing.T) {
+	data := map[string]bool{
+		`[Service]
+ExecStart=/bin/sh -c '/usr/bin/podman run \
+        --name uyuni-server \
+        --hostname uyuni-server.mgr.internal \
+        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        -p 80:80 \
+        -p [::]:80:80 \
+        -p 8003:8003 \
+        -p [::]:8003:8003 \
+        -p 4505:4505 \
+        -p [::]:4505:4505`: true,
+		`[Service]
+ExecStart=/bin/sh -c '/usr/bin/podman run \
+        --name uyuni-server \
+        --hostname uyuni-server.mgr.internal \
+        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        -p 80:80 \
+        -p [::]:80:80 \
+        -p [::]:8003:8003 \
+        -p 4505:4505 \
+        -p [::]:4505:4505`: false,
+	}
+
+	for definition, expected := range data {
+		actual := hasDebugPorts([]byte(definition))
+		test_utils.AssertEquals(t, "Unexpected result for "+definition, expected, actual)
+	}
+}
+
+func TestGetMirrorPath(t *testing.T) {
+	data := map[string]string{
+		`[Service]
+ExecStart=/bin/sh -c '/usr/bin/podman run \
+        --name uyuni-server \
+        --hostname uyuni-server.mgr.internal \
+        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        -p 80:80 \
+        -p 4505:4505 \
+        -p [::]:4505:4505`: "",
+		`[Service]
+ExecStart=/bin/sh -c '/usr/bin/podman run \
+        --name uyuni-server \
+        --hostname uyuni-server.mgr.internal \
+        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+		-v   /path/to/mirror:/mirror:z \
+        -p 80:80 \
+        -p 4505:4505 \
+        -p [::]:4505:4505`: "/path/to/mirror",
+		`[Service]
+ExecStart=/bin/sh -c '/usr/bin/podman run \
+        --name uyuni-server \
+        --hostname uyuni-server.mgr.internal \
+		--rm --cap-add NET_RAW -v /path/to/mirror:/mirror --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        -p 80:80 \
+        -p 4505:4505 \
+        -p [::]:4505:4505`: "/path/to/mirror",
+	}
+
+	for definition, expected := range data {
+		actual := getMirrorPath([]byte(definition))
+		test_utils.AssertEquals(t, "Unexpected result for "+definition, expected, actual)
+	}
+}

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -32,10 +32,12 @@ type PodmanProxyFlags struct {
 // GenerateSystemdService generates all the systemd files required by proxy.
 func GenerateSystemdService(httpdImage string, saltBrokerImage string, squidImage string, sshImage string,
 	tftpdImage string, flags *PodmanProxyFlags) error {
-	ipv6Enabled, err := podman.SetupNetwork(true)
+	err := podman.SetupNetwork(true)
 	if err != nil {
 		return shared_utils.Errorf(err, L("cannot setup network"))
 	}
+
+	ipv6Enabled := podman.HasIpv6Enabled(podman.UyuniNetwork)
 
 	log.Info().Msg(L("Generating systemd services"))
 	httpProxyConfig := getHttpProxyConfig()

--- a/shared/utils/volumes.go
+++ b/shared/utils/volumes.go
@@ -64,6 +64,7 @@ var etcAndPgsqlVolumes = append(PgsqlRequiredVolumes, EtcServerVolumes[:]...)
 // the helm chart and the systemctl services definitions.
 var ServerVolumeMounts = append([]types.VolumeMount{
 	{MountPath: "/var/lib/cobbler", Name: "var-cobbler"},
+	{MountPath: "/var/lib/rhn/search", Name: "var-search"},
 	{MountPath: "/var/lib/salt", Name: "var-salt"},
 	{MountPath: "/var/cache", Name: "var-cache"},
 	{MountPath: "/var/spacewalk", Name: "var-spacewalk"},

--- a/uyuni-tools.changes.cbosdo.search-indexes
+++ b/uyuni-tools.changes.cbosdo.search-indexes
@@ -1,0 +1,1 @@
+- Persist search server indexes (bsc#1231759)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Add a volume for the search indexes. The systemd service will be fixed with a `mgradm upgrade podman`, but sadly there is no way to keep the existing indexes: `rhn-search cleanindex` needs to be called inside the container after the upgrade.

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25572

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

