### PR TITLE
cert-manager has no images.pullPolicy value

### DIFF
--- a/mgradm/shared/kubernetes/certificates.go
+++ b/mgradm/shared/kubernetes/certificates.go
@@ -115,7 +115,7 @@ func installCertManager(helmFlags *cmd_utils.HelmFlags, kubeconfig string, image
 		args := []string{
 			"--set", "crds.enabled=true",
 			"--set-json", "global.commonLabels={\"installedby\": \"mgradm\"}",
-			"--set", "images.pullPolicy=" + kubernetes.GetPullPolicy(imagePullPolicy),
+			"--set", "image.pullPolicy=" + kubernetes.GetPullPolicy(imagePullPolicy),
 		}
 		extraValues := helmFlags.CertManager.Values
 		if extraValues != "" {

--- a/uyuni-tools.changes.cbosdo.helm-fixes
+++ b/uyuni-tools.changes.cbosdo.helm-fixes
@@ -1,0 +1,1 @@
+- Fix cert-manager image.pullPolicy helm chart value (bsc#1231734)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

There is a typo preventing to install cert-manager in some cases. the value has to be image.pullPolicy without the 's'.

## Test coverage
- No tests: covered by the k3s CI

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25597

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

