### PR TITLE
Fix 1d87d60a: podman host path mounts can't have :z option

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -52,7 +52,7 @@ func GenerateServerSystemdService(mirrorPath string, debug bool) error {
 	args := podman.GetCommonParams()
 
 	if mirrorPath != "" {
-		args = append(args, "-v", mirrorPath+":/mirror:z")
+		args = append(args, "-v", mirrorPath+":/mirror")
 	}
 
 	ports := GetExposedPorts(debug)
@@ -452,7 +452,7 @@ func hasDebugPorts(definition []byte) bool {
 
 func getMirrorPath(definition []byte) string {
 	mirrorPath := ""
-	finder := regexp.MustCompile(`-v +([^:]+):/mirror(?::z)?[[:space:]]`)
+	finder := regexp.MustCompile(`-v +([^:]+):/mirror[[:space:]]`)
 	submatches := finder.FindStringSubmatch(string(definition))
 	if len(submatches) == 2 {
 		mirrorPath = submatches[1]

--- a/mgradm/shared/podman/podman_test.go
+++ b/mgradm/shared/podman/podman_test.go
@@ -56,7 +56,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
         --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
-		-v   /path/to/mirror:/mirror:z \
+		-v   /path/to/mirror:/mirror \
         -p 80:80 \
         -p 4505:4505 \
         -p [::]:4505:4505`: "/path/to/mirror",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Remove the :z option to the mirror flag as it breaks podman run.

Fixes PR https://github.com/uyuni-project/uyuni-tools/pull/470

## Test coverage
- Unit tests were adjusted

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25572

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

