### PR TITLE
Don't migrate systemd enabled services, recreate them

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -51,7 +51,8 @@ rpm -qa --qf '[%{fileflags},%{filenames}\n]' |grep ",/etc/" | while IFS="," read
     fi
 done
 
-echo "-/ .repo_gpgcheck" >> exclude_list
+# No need to migrate zypper's cache
+echo "-/ /var/cache/zypp/**" >> exclude_list
 
 # exclude mgr-sync configuration file, in this way it would be re-generated (bsc#1228685)
 echo "-/ /root/.mgr-sync" >> exclude_list
@@ -67,15 +68,30 @@ echo "-/ /etc/sysconfig/rhn/schema-upgrade" >> exclude_list
 # exclude lastlog - it is not needed and can be too large
 echo "-/ /var/log/lastlog" >> exclude_list
 
+# exclude systemd units as they will be recreated later
+echo "-/ /etc/systemd/**" >> exclude_list
+
 for folder in {{ range .Volumes }}{{ .MountPath }} {{ end }};
 do
+  RSYNC_ARGS=-l
+  # Those folders used to have symlinks in the cloud images.
+  if test "$folder" = "/var/cache" -o "$folder" = "/var/spacewalk" -o \
+          "$folder" = "/var/lib/pgsql"; then
+    RSYNC_ARGS=-L
+  fi
   if $SSH {{ .SourceFqdn }} test -e $folder; then
     echo "Copying $folder..."
-    rsync -e "$SSH" --rsync-path='sudo rsync' -avzL --trust-sender -f 'merge exclude_list' {{ .SourceFqdn }}:$folder/ $folder;
+    rsync -e "$SSH" --rsync-path='sudo rsync' -avz $RSYNC_ARGS --trust-sender -f 'merge exclude_list' {{ .SourceFqdn }}:$folder/ $folder;
   else
     echo "Skipping missing $folder..."
   fi
 done;
+
+spacewalk-service enable
+if $SSH {{ .SourceFqdn }} systemctl is-enabled tftp.socket; then
+  echo "Enabling tftp socket..."
+  systemctl enable tftp.socket
+fi
 
 sed -i -e 's|appBase="webapps"|appBase="/usr/share/susemanager/www/tomcat/webapps"|' /etc/tomcat/server.xml
 sed -i -e 's|DocumentRoot\s*"/srv/www/htdocs"|DocumentRoot "/usr/share/susemanager/www/htdocs"|' /etc/apache2/vhosts.d/vhost-ssl.conf

--- a/uyuni-tools.changes.cbosdo.migration_systemd
+++ b/uyuni-tools.changes.cbosdo.migration_systemd
@@ -1,0 +1,1 @@
+- Don't migrate enabled systemd services, recreate them (bsc#1232575)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Migrating systemd enabled services has some issues:
  - with rsync using -L the symlinks are converted into files and the services are not enabled / started after the migration
  - some dropped services symlinks could be copied

This is worked around by not synchronizing the files in /etc/systemd/system/multi-user.target.wants and enabling the spacewalk services after the migration.

## Test coverage
- No tests: migration tests require E2E tests.

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25672

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

