### PR TITLE
Ignore all zypper caches during migration

### DIFF
--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -60,6 +60,12 @@ func migrateToPodman(
 		return err
 	}
 
+	// Prepare Uyuni network, migration container needs to run in the same network as resulting image
+	err = podman_utils.SetupNetwork(false)
+	if err != nil {
+		return utils.Errorf(err, L("cannot setup network"))
+	}
+
 	// Find the SSH Socket and paths for the migration
 	sshAuthSocket := migration_shared.GetSSHAuthSocket()
 	sshConfigPath, sshKnownhostsPath := migration_shared.GetSSHPaths()

--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -54,6 +54,9 @@ done
 # No need to migrate zypper's cache
 echo "-/ /var/cache/zypp/**" >> exclude_list
 
+# Migrating the reposync cache files doesn't bring value and contains dangling symlinks (bsc#1231769)
+echo "-/ /var/cache/rhn/reposync/**" >> exclude_list
+
 # exclude mgr-sync configuration file, in this way it would be re-generated (bsc#1228685)
 echo "-/ /root/.mgr-sync" >> exclude_list
 

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -68,6 +68,7 @@ func RunContainer(name string, image string, volumes []types.VolumeMount, extraA
 	for _, volume := range volumes {
 		podmanArgs = append(podmanArgs, "-v", volume.Name+":"+volume.MountPath+":z")
 	}
+	podmanArgs = append(podmanArgs, "--network", UyuniNetwork)
 	podmanArgs = append(podmanArgs, image)
 	podmanArgs = append(podmanArgs, cmd...)
 

--- a/uyuni-tools.changes.cbosdo.5.0.2-gpgcheck
+++ b/uyuni-tools.changes.cbosdo.5.0.2-gpgcheck
@@ -1,0 +1,1 @@
+- Ignore all zypper caches during migration (bsc#1232769)

--- a/uyuni-tools.changes.cbosdo.uyuni-network
+++ b/uyuni-tools.changes.cbosdo.uyuni-network
@@ -1,0 +1,1 @@
+- Use the uyuni network for all podman container (bsc#1232817)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

forward port of https://github.com/SUSE/uyuni-tools/pull/33

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25694 https://bugzilla.suse.com/show_bug.cgi?id=1232817

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
