### PR TITLE
podman upgrade fixes

### DIFF
--- a/mgradm/shared/coco/coco.go
+++ b/mgradm/shared/coco/coco.go
@@ -39,6 +39,9 @@ func Upgrade(
 		return err
 	}
 
+	if !cocoFlags.IsChanged {
+		return systemd.RestartInstantiated(podman.ServerAttestationService)
+	}
 	return systemd.ScaleService(cocoFlags.Replicas, podman.ServerAttestationService)
 }
 

--- a/mgradm/shared/hub/xmlrpcapi.go
+++ b/mgradm/shared/hub/xmlrpcapi.go
@@ -72,8 +72,6 @@ func EnableHubXmlrpc(systemd podman.Systemd, replicas int) error {
 		if err := systemd.ScaleService(replicas, podman.HubXmlrpcService); err != nil {
 			return utils.Errorf(err, L("cannot enable service"))
 		}
-	} else {
-		log.Info().Msg(L("Not starting Hub XML-RPC API service"))
 	}
 	return nil
 }
@@ -99,7 +97,10 @@ func Upgrade(
 		return err
 	}
 
-	return systemd.RestartInstantiated(podman.HubXmlrpcService)
+	if !hubXmlrpcFlags.IsChanged {
+		return systemd.RestartInstantiated(podman.HubXmlrpcService)
+	}
+	return systemd.ScaleService(hubXmlrpcFlags.Replicas, podman.HubXmlrpcService)
 }
 
 // generateHubXmlrpcSystemdService creates the Hub XMLRPC systemd files.

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -434,6 +434,10 @@ func Upgrade(
 		return err
 	}
 
+	if err := systemd.ReloadDaemon(false); err != nil {
+		return err
+	}
+
 	if err := updateServerSystemdService(); err != nil {
 		return err
 	}

--- a/uyuni-tools.changes.cbosdo.upgrade-fix
+++ b/uyuni-tools.changes.cbosdo.upgrade-fix
@@ -1,1 +1,2 @@
+- Run systemctl daemon-reload after changing the container image config (bsc#1233279)
 - coco-replicas-upgrade

--- a/uyuni-tools.changes.cbosdo.upgrade-fix
+++ b/uyuni-tools.changes.cbosdo.upgrade-fix
@@ -1,0 +1,1 @@
+- coco-replicas-upgrade


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

* Fixes the way the coco and hub services are restarted after upgrade with and without providing the replicas numbers.
* Adds a missing `systemctl daemon-reload`

## Test coverage
- No tests: still needs some more mockable layers to be working.

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25770 https://github.com/SUSE/spacewalk/issues/25771

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
