### PR TITLE
Add SCC and SSL to the list of checked initialisms

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters-settings:
       - DB
       # Added
       - SCC
+      - SSL
   gofmt:
     simplify: true
   gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,43 @@ linters-settings:
   stylecheck:
     dot-import-whitelist:
       - github.com/uyuni-project/uyuni-tools/shared/l10n
+    initialisms:
+      # Default
+      - ACL
+      - API
+      - ASCII
+      - CPU
+      - DNS
+      - EOF
+      - GUID
+      - HTML
+      - HTTP
+      - HTTPS
+      - ID
+      - IP
+      - JSON
+      - RPC
+      - SLA
+      - SMTP
+      - SQL
+      - SSH
+      - TCP
+      - TLS
+      - TTL
+      - UDP
+      - UI
+      - GID
+      - UID
+      - UUID
+      - URI
+      - URL
+      - UTF8
+      - VM
+      - XML
+      - RTP
+      - DB
+      # Added
+      - SCC
   gofmt:
     simplify: true
   gocyclo:

--- a/mgradm/cmd/inspect/inspect_test.go
+++ b/mgradm/cmd/inspect/inspect_test.go
@@ -21,14 +21,14 @@ func TestParamsParsing(t *testing.T) {
 	}
 
 	args = append(args, flagstests.ImageFlagsTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 
 	// Test function asserting that the args are properly parsed
 	tester := func(globalFlags *types.GlobalFlags, flags *inspectFlags,
 		cmd *cobra.Command, args []string,
 	) error {
 		flagstests.AssertImageFlag(t, cmd, &flags.Image)
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		if utils.KubernetesBuilt {
 			testutils.AssertEquals(t, "Error parsing --backend", "kubectl", flags.Backend)
 		}

--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -59,8 +59,8 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	}
 
 	// Deploy the SSL CA or server certificate
-	ca := types.SslPair{}
-	sslArgs, err := kubernetes.DeployCertificate(&flags.Helm, &flags.Ssl, "", &ca, clusterInfos.GetKubeconfig(), fqdn,
+	ca := types.SSLPair{}
+	sslArgs, err := kubernetes.DeployCertificate(&flags.Helm, &flags.SSL, "", &ca, clusterInfos.GetKubeconfig(), fqdn,
 		flags.Image.PullPolicy)
 	if err != nil {
 		return shared_utils.Errorf(err, L("cannot deploy certificate"))
@@ -74,7 +74,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	}
 
 	// Deploy Uyuni and wait for it to be up
-	if err := kubernetes.Deploy(cnx, flags.Image.Registry, &flags.Image, &flags.Helm, &flags.Ssl,
+	if err := kubernetes.Deploy(cnx, flags.Image.Registry, &flags.Image, &flags.Helm, &flags.SSL,
 		clusterInfos, fqdn, flags.Debug.Java, false, helmArgs...,
 	); err != nil {
 		return shared_utils.Errorf(err, L("cannot deploy uyuni"))

--- a/mgradm/cmd/install/kubernetes/utils.go
+++ b/mgradm/cmd/install/kubernetes/utils.go
@@ -68,7 +68,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	helmArgs = append(helmArgs, sslArgs...)
 
 	// Create a secret using SCC credentials if any are provided
-	helmArgs, err = shared_kubernetes.AddSccSecret(helmArgs, flags.Helm.Uyuni.Namespace, &flags.Scc)
+	helmArgs, err = shared_kubernetes.AddSCCSecret(helmArgs, flags.Helm.Uyuni.Namespace, &flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -93,20 +93,20 @@ func installForPodman(
 		return utils.Errorf(err, L("cannot wait for system start"))
 	}
 
-	caPassword := flags.Ssl.Password
-	if flags.Ssl.UseExisting() {
+	caPassword := flags.SSL.Password
+	if flags.SSL.UseExisting() {
 		// We need to have a password for the generated CA, even though it will be thrown away after install
 		caPassword = "dummy"
 	}
 
 	env := map[string]string{
-		"CERT_O":       flags.Ssl.Org,
-		"CERT_OU":      flags.Ssl.OU,
-		"CERT_CITY":    flags.Ssl.City,
-		"CERT_STATE":   flags.Ssl.State,
-		"CERT_COUNTRY": flags.Ssl.Country,
-		"CERT_EMAIL":   flags.Ssl.Email,
-		"CERT_CNAMES":  strings.Join(append([]string{fqdn}, flags.Ssl.Cnames...), ","),
+		"CERT_O":       flags.SSL.Org,
+		"CERT_OU":      flags.SSL.OU,
+		"CERT_CITY":    flags.SSL.City,
+		"CERT_STATE":   flags.SSL.State,
+		"CERT_COUNTRY": flags.SSL.Country,
+		"CERT_EMAIL":   flags.SSL.Email,
+		"CERT_CNAMES":  strings.Join(append([]string{fqdn}, flags.SSL.Cnames...), ","),
 		"CERT_PASS":    caPassword,
 	}
 
@@ -144,8 +144,8 @@ func installForPodman(
 		}
 	}
 
-	if flags.Ssl.UseExisting() {
-		if err := podman.UpdateSslCertificate(cnx, &flags.Ssl.Ca, &flags.Ssl.Server); err != nil {
+	if flags.SSL.UseExisting() {
+		if err := podman.UpdateSSLCertificate(cnx, &flags.SSL.Ca, &flags.SSL.Server); err != nil {
 			return utils.Errorf(err, L("cannot update SSL certificate"))
 		}
 	}

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -55,7 +55,7 @@ func installForPodman(
 		return err
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Scc)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.SCC)
 	if err != nil {
 		return utils.Errorf(err, L("failed to login to registry.suse.com"))
 	}

--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -49,7 +49,7 @@ type InstallFlags struct {
 	Tftp         bool
 	DB           DBFlags
 	ReportDB     DBFlags
-	Ssl          cmd_utils.InstallSSLFlags
+	SSL          cmd_utils.InstallSSLFlags
 	SCC          types.SCCCredentials
 	Debug        DebugFlags
 	Image        types.ImageFlags `mapstructure:",squash"`
@@ -90,11 +90,11 @@ func (flags *InstallFlags) CheckParameters(cmd *cobra.Command, command string) {
 	}
 
 	// Make sure we have all the required 3rd party flags or none
-	flags.Ssl.CheckParameters()
+	flags.SSL.CheckParameters()
 
 	// Since we use cert-manager for self-signed certificates on kubernetes we don't need password for it
-	if !flags.Ssl.UseExisting() && command == "podman" {
-		utils.AskPasswordIfMissing(&flags.Ssl.Password, cmd.Flag("ssl-password").Usage, 0, 0)
+	if !flags.SSL.UseExisting() && command == "podman" {
+		utils.AskPasswordIfMissing(&flags.SSL.Password, cmd.Flag("ssl-password").Usage, 0, 0)
 	}
 
 	// Use the host timezone if the user didn't define one
@@ -109,7 +109,7 @@ func (flags *InstallFlags) CheckParameters(cmd *cobra.Command, command string) {
 	utils.AskPasswordIfMissing(&flags.Admin.Password, cmd.Flag("admin-password").Usage, 5, 48)
 	utils.AskIfMissing(&flags.Organization, cmd.Flag("organization").Usage, 3, 128, nil)
 
-	flags.Ssl.Email = flags.Email
+	flags.SSL.Email = flags.Email
 	flags.Admin.Email = flags.Email
 }
 

--- a/mgradm/cmd/install/shared/flags.go
+++ b/mgradm/cmd/install/shared/flags.go
@@ -50,7 +50,7 @@ type InstallFlags struct {
 	DB           DBFlags
 	ReportDB     DBFlags
 	Ssl          cmd_utils.InstallSSLFlags
-	Scc          types.SCCCredentials
+	SCC          types.SCCCredentials
 	Debug        DebugFlags
 	Image        types.ImageFlags `mapstructure:",squash"`
 	Coco         cmd_utils.CocoFlags

--- a/mgradm/cmd/install/shared/shared.go
+++ b/mgradm/cmd/install/shared/shared.go
@@ -140,8 +140,8 @@ func generateSetupScript(flags *InstallFlags, fqdn string, extraEnv map[string]s
 		"EXTERNALDB_PROVIDER":   flags.DB.Provider,
 		"ISS_PARENT":            flags.IssParent,
 		"ACTIVATE_SLP":          "N", // Deprecated, will be removed soon
-		"SCC_USER":              flags.Scc.User,
-		"SCC_PASS":              flags.Scc.Password,
+		"SCC_USER":              flags.SCC.User,
+		"SCC_PASS":              flags.SCC.Password,
 	}
 	if flags.Mirror != "" {
 		env["MIRROR_PATH"] = "/mirror"

--- a/mgradm/cmd/migrate/kubernetes/kubernetes.go
+++ b/mgradm/cmd/migrate/kubernetes/kubernetes.go
@@ -20,7 +20,7 @@ type kubernetesMigrateFlags struct {
 	shared.MigrateFlags `mapstructure:",squash"`
 	Helm                cmd_utils.HelmFlags
 	SCC                 types.SCCCredentials
-	Ssl                 types.SslCertGenerationFlags
+	SSL                 types.SSLCertGenerationFlags
 }
 
 func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[kubernetesMigrateFlags]) *cobra.Command {

--- a/mgradm/cmd/migrate/kubernetes/kubernetes_test.go
+++ b/mgradm/cmd/migrate/kubernetes/kubernetes_test.go
@@ -24,7 +24,7 @@ func TestParamsParsing(t *testing.T) {
 	}
 
 	args = append(args, flagstests.MirrorFlagTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.ImageFlagsTestArgs...)
 	args = append(args, flagstests.DBUpdateImageFlagTestArgs...)
 	args = append(args, flagstests.CocoFlagsTestArgs...)
@@ -37,7 +37,7 @@ func TestParamsParsing(t *testing.T) {
 	) error {
 		testutils.AssertTrue(t, "Prepare not set", flags.Prepare)
 		flagstests.AssertMirrorFlag(t, cmd, flags.Mirror)
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		flagstests.AssertImageFlag(t, cmd, &flags.Image)
 		flagstests.AssertDBUpgradeImageFlag(t, cmd, &flags.DBUpgradeImage)
 		flagstests.AssertCocoFlag(t, cmd, &flags.Coco)

--- a/mgradm/cmd/migrate/kubernetes/kubernetes_test.go
+++ b/mgradm/cmd/migrate/kubernetes/kubernetes_test.go
@@ -44,7 +44,7 @@ func TestParamsParsing(t *testing.T) {
 		flagstests.AssertHubXmlrpcFlag(t, cmd, &flags.HubXmlrpc)
 		testutils.AssertEquals(t, "Error parsing --user", "sudoer", flags.User)
 		flagstests.AssertServerHelmFlags(t, cmd, &flags.Helm)
-		testutils.AssertEquals(t, "Error parsing --ssl-password", "sslsecret", flags.Ssl.Password)
+		testutils.AssertEquals(t, "Error parsing --ssl-password", "sslsecret", flags.SSL.Password)
 		testutils.AssertEquals(t, "Wrong FQDN", "source.fq.dn", args[0])
 		return nil
 	}

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -130,7 +130,7 @@ func migrateToKubernetes(
 		}
 	}()
 
-	setupSslArray, err := setupSsl(&flags.Helm, kubeconfig, scriptDir, flags.Ssl.Password, flags.Image.PullPolicy)
+	setupSSLArray, err := setupSSL(&flags.Helm, kubeconfig, scriptDir, flags.SSL.Password, flags.Image.PullPolicy)
 	if err != nil {
 		return utils.Errorf(err, L("cannot setup SSL"))
 	}
@@ -144,7 +144,7 @@ func migrateToKubernetes(
 		// TODO Handle claims for multi-node clusters
 		helmArgs = append(helmArgs, "--set", "mirror.hostPath="+flags.Mirror)
 	}
-	helmArgs = append(helmArgs, setupSslArray...)
+	helmArgs = append(helmArgs, setupSSLArray...)
 
 	// Run uyuni upgrade using the new ssl certificate
 	if err = kubernetes.UyuniUpgrade(
@@ -202,7 +202,7 @@ func migrateToKubernetes(
 
 // updateIssuer replaces the temporary SSL certificate issuer with the source server CA.
 // Return additional helm args to use the SSL certificates.
-func setupSsl(
+func setupSSL(
 	helm *adm_utils.HelmFlags,
 	kubeconfig string,
 	scriptDir string,
@@ -222,7 +222,7 @@ func setupSsl(
 			return []string{}, utils.Errorf(err, L("failed to strip text part from CA certificate"))
 		}
 		cert := base64.StdEncoding.EncodeToString(out)
-		ca := types.SslPair{Cert: cert, Key: key}
+		ca := types.SSLPair{Cert: cert, Key: key}
 
 		// An empty struct means no third party certificate
 		sslFlags := adm_utils.InstallSSLFlags{}
@@ -235,7 +235,7 @@ func setupSsl(
 		// Handle third party certificates and CA
 		sslFlags := adm_utils.InstallSSLFlags{
 			Ca: types.CaChain{Root: caCert},
-			Server: types.SslPair{
+			Server: types.SSLPair{
 				Key:  path.Join(scriptDir, "spacewalk.key"),
 				Cert: path.Join(scriptDir, "spacewalk.crt"),
 			},

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -78,7 +78,7 @@ func migrateToKubernetes(
 	helmArgs := []string{}
 
 	// Create a secret using SCC credentials if any are provided
-	helmArgs, err = shared_kubernetes.AddSccSecret(helmArgs, flags.Helm.Uyuni.Namespace, &flags.Scc)
+	helmArgs, err = shared_kubernetes.AddSCCSecret(helmArgs, flags.Helm.Uyuni.Namespace, &flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/migrate/podman/podman_test.go
+++ b/mgradm/cmd/migrate/podman/podman_test.go
@@ -21,7 +21,7 @@ func TestParamsParsing(t *testing.T) {
 	}
 
 	args = append(args, flagstests.MirrorFlagTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.ImageFlagsTestArgs...)
 	args = append(args, flagstests.DBUpdateImageFlagTestArgs...)
 	args = append(args, flagstests.CocoFlagsTestArgs...)
@@ -34,7 +34,7 @@ func TestParamsParsing(t *testing.T) {
 	) error {
 		testutils.AssertTrue(t, "Prepare not set", flags.Prepare)
 		flagstests.AssertMirrorFlag(t, cmd, flags.Mirror)
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		flagstests.AssertImageFlag(t, cmd, &flags.Image)
 		flagstests.AssertDBUpgradeImageFlag(t, cmd, &flags.DBUpgradeImage)
 		flagstests.AssertCocoFlag(t, cmd, &flags.Coco)

--- a/mgradm/cmd/migrate/shared/flags.go
+++ b/mgradm/cmd/migrate/shared/flags.go
@@ -20,7 +20,7 @@ type MigrateFlags struct {
 	User           string
 	Mirror         string
 	HubXmlrpc      utils.HubXmlrpcFlags
-	Scc            types.SCCCredentials
+	SCC            types.SCCCredentials
 }
 
 // AddMigrateFlags add migration flags to a command.

--- a/mgradm/cmd/upgrade/kubernetes/kubernetes_test.go
+++ b/mgradm/cmd/upgrade/kubernetes/kubernetes_test.go
@@ -22,7 +22,7 @@ func TestParamsParsing(t *testing.T) {
 	args = append(args, flagstests.DBUpdateImageFlagTestArgs...)
 	args = append(args, flagstests.CocoFlagsTestArgs...)
 	args = append(args, flagstests.HubXmlrpcFlagsTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.ServerHelmFlagsTestArgs...)
 
 	// Test function asserting that the args are properly parsed

--- a/mgradm/cmd/upgrade/podman/podman_test.go
+++ b/mgradm/cmd/upgrade/podman/podman_test.go
@@ -20,7 +20,7 @@ func TestParamsParsing(t *testing.T) {
 	args = append(args, flagstests.DBUpdateImageFlagTestArgs...)
 	args = append(args, flagstests.CocoFlagsTestArgs...)
 	args = append(args, flagstests.HubXmlrpcFlagsTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.PodmanFlagsTestArgs...)
 
 	// Test function asserting that the args are properly parsed
@@ -31,7 +31,7 @@ func TestParamsParsing(t *testing.T) {
 		flagstests.AssertDBUpgradeImageFlag(t, cmd, &flags.DBUpgradeImage)
 		flagstests.AssertCocoFlag(t, cmd, &flags.Coco)
 		flagstests.AssertHubXmlrpcFlag(t, cmd, &flags.HubXmlrpc)
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		flagstests.AssertPodmanInstallFlags(t, cmd, &flags.Podman)
 		return nil
 	}

--- a/mgradm/shared/kubernetes/certificates.go
+++ b/mgradm/shared/kubernetes/certificates.go
@@ -51,8 +51,8 @@ func installTLSSecret(namespace string, serverCrt []byte, serverKey []byte, root
 // Install cert-manager and its CRDs using helm in the cert-manager namespace if needed
 // and then create a self-signed CA and issuers.
 // Returns helm arguments to be added to use the issuer.
-func installSslIssuers(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.InstallSSLFlags, rootCa string,
-	tlsCert *types.SslPair, kubeconfig, fqdn string, imagePullPolicy string) ([]string, error) {
+func installSSLIssuers(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.InstallSSLFlags, rootCa string,
+	tlsCert *types.SSLPair, kubeconfig, fqdn string, imagePullPolicy string) ([]string, error) {
 	// Install cert-manager if needed
 	if err := installCertManager(helmFlags, kubeconfig, imagePullPolicy); err != nil {
 		return []string{}, utils.Errorf(err, L("cannot install cert manager"))
@@ -95,7 +95,7 @@ func installSslIssuers(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.Insta
 		out, err := utils.RunCmdOutput(zerolog.DebugLevel, "kubectl", "get", "-o=jsonpath={.status.conditions[*].type}",
 			"issuer", "uyuni-ca-issuer", "-n", issuerData.Namespace)
 		if err == nil && string(out) == "Ready" {
-			return []string{"--set-json", "ingressSslAnnotations={\"cert-manager.io/issuer\": \"uyuni-ca-issuer\"}"}, nil
+			return []string{"--set-json", "ingressSSLAnnotations={\"cert-manager.io/issuer\": \"uyuni-ca-issuer\"}"}, nil
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/mgradm/shared/kubernetes/install.go
+++ b/mgradm/shared/kubernetes/install.go
@@ -69,7 +69,7 @@ func Deploy(
 
 // DeployCertificate executre a deploy a new certificate given an helm.
 func DeployCertificate(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.InstallSSLFlags, rootCa string,
-	ca *types.SslPair, kubeconfig string, fqdn string, imagePullPolicy string) ([]string, error) {
+	ca *types.SSLPair, kubeconfig string, fqdn string, imagePullPolicy string) ([]string, error) {
 	helmArgs := []string{}
 	if sslFlags.UseExisting() {
 		if err := DeployExistingCertificate(helmFlags, sslFlags, kubeconfig); err != nil {
@@ -77,7 +77,7 @@ func DeployCertificate(helmFlags *cmd_utils.HelmFlags, sslFlags *cmd_utils.Insta
 		}
 	} else {
 		// Install cert-manager and a self-signed issuer ready for use
-		issuerArgs, err := installSslIssuers(helmFlags, sslFlags, rootCa, ca, kubeconfig, fqdn, imagePullPolicy)
+		issuerArgs, err := installSSLIssuers(helmFlags, sslFlags, rootCa, ca, kubeconfig, fqdn, imagePullPolicy)
 		if err != nil {
 			return []string{}, utils.Errorf(err, L("cannot install cert-manager and self-sign issuer"))
 		}

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -110,8 +110,8 @@ Environment="PODMAN_EXTRA_ARGS=%s"
 	return systemd.ReloadDaemon(false)
 }
 
-// UpdateSslCertificate update SSL certificate.
-func UpdateSslCertificate(cnx *shared.Connection, chain *types.CaChain, serverPair *types.SslPair) error {
+// UpdateSSLCertificate update SSL certificate.
+func UpdateSSLCertificate(cnx *shared.Connection, chain *types.CaChain, serverPair *types.SSLPair) error {
 	ssl.CheckPaths(chain, serverPair)
 
 	// Copy the CAs, certificate and key to the container

--- a/mgradm/shared/utils/types.go
+++ b/mgradm/shared/utils/types.go
@@ -10,9 +10,9 @@ import (
 
 // InstallSSLFlags holds all the flags values related to SSL for installation.
 type InstallSSLFlags struct {
-	types.SslCertGenerationFlags `mapstructure:",squash"`
+	types.SSLCertGenerationFlags `mapstructure:",squash"`
 	Ca                           types.CaChain
-	Server                       types.SslPair
+	Server                       types.SSLPair
 }
 
 // HelmFlags stores Uyuni and Cert Manager Helm information.

--- a/mgrctl/cmd/proxy/config.go
+++ b/mgrctl/cmd/proxy/config.go
@@ -39,14 +39,14 @@ type proxyFlags struct {
 }
 
 type caFlags struct {
-	types.SslPair `mapstructure:",squash"`
+	types.SSLPair `mapstructure:",squash"`
 	Password      string
 	Intermediate  []string
 }
 
-type proxyConfigSslFlags struct {
-	types.SslCertGenerationFlags `mapstructure:",squash"`
-	Proxy                        types.SslPair
+type proxyConfigSSLFlags struct {
+	types.SSLCertGenerationFlags `mapstructure:",squash"`
+	Proxy                        types.SSLPair
 	Ca                           caFlags
 }
 
@@ -55,7 +55,7 @@ type proxyCreateConfigFlags struct {
 	ConnectionDetails api.ConnectionDetails `mapstructure:"api"`
 	Proxy             proxyFlags
 	Output            string
-	Ssl               proxyConfigSslFlags
+	SSL               proxyConfigSSLFlags
 }
 
 // proxyCreateConfigRequiredFields is a set of required fields for validation.

--- a/mgrctl/cmd/proxy/config_do.go
+++ b/mgrctl/cmd/proxy/config_do.go
@@ -42,11 +42,11 @@ func proxyCreateConfig(
 	}
 
 	// handle CA certificate path
-	caCertificate := string(utils.ReadFile(flags.Ssl.Ca.Cert))
+	caCertificate := string(utils.ReadFile(flags.SSL.Ca.Cert))
 
 	// Check if ProxyCrt is provided to decide which configuration to run
 	var data *[]int8
-	if flags.Ssl.Proxy.Cert != "" {
+	if flags.SSL.Proxy.Cert != "" {
 		data, err = handleProxyConfig(client, flags, caCertificate, proxyConfig)
 	} else {
 		data, err = handleProxyConfigGenerate(client, flags, caCertificate, proxyConfigGenerate)
@@ -73,17 +73,17 @@ func handleProxyConfig(
 	proxyConfig func(client *api.APIClient, request proxy.ProxyConfigRequest) (*[]int8, error),
 ) (*[]int8, error) {
 	// Custom validations
-	if flags.Ssl.Proxy.Key == "" {
+	if flags.SSL.Proxy.Key == "" {
 		return nil, errors.New(L("flag proxyKey is required when flag proxyCrt is provided"))
 	}
 
 	// Read file paths for certificates and keys
-	proxyCrt := string(utils.ReadFile(flags.Ssl.Proxy.Cert))
-	proxyKey := string(utils.ReadFile(flags.Ssl.Proxy.Key))
+	proxyCrt := string(utils.ReadFile(flags.SSL.Proxy.Cert))
+	proxyKey := string(utils.ReadFile(flags.SSL.Proxy.Key))
 
 	// Handle intermediate CAs
 	var intermediateCAs []string
-	for _, path := range flags.Ssl.Ca.Intermediate {
+	for _, path := range flags.SSL.Ca.Intermediate {
 		intermediateCAs = append(intermediateCAs, string(utils.ReadFile(path)))
 	}
 
@@ -111,13 +111,13 @@ func handleProxyConfigGenerate(
 	proxyConfigGenerate func(client *api.APIClient, request proxy.ProxyConfigGenerateRequest) (*[]int8, error),
 ) (*[]int8, error) {
 	// CA key and password
-	caKey := string(utils.ReadFile(flags.Ssl.Ca.Key))
+	caKey := string(utils.ReadFile(flags.SSL.Ca.Key))
 
 	var caPasswordRead string
-	if flags.Ssl.Ca.Password == "" {
+	if flags.SSL.Ca.Password == "" {
 		utils.AskPasswordIfMissingOnce(&caPasswordRead, L("Please enter SSL CA password"), 0, 0)
 	} else {
-		caPasswordRead = flags.Ssl.Ca.Password
+		caPasswordRead = flags.SSL.Ca.Password
 	}
 
 	// Prepare the request object & call the proxyConfigGenerate function
@@ -130,13 +130,13 @@ func handleProxyConfigGenerate(
 		CaCrt:      caCertificate,
 		CaKey:      caKey,
 		CaPassword: caPasswordRead,
-		Cnames:     flags.Ssl.Cnames,
-		Country:    flags.Ssl.Country,
-		State:      flags.Ssl.State,
-		City:       flags.Ssl.City,
-		Org:        flags.Ssl.Org,
-		OrgUnit:    flags.Ssl.OU,
-		SslEmail:   flags.Ssl.Email,
+		Cnames:     flags.SSL.Cnames,
+		Country:    flags.SSL.Country,
+		State:      flags.SSL.State,
+		City:       flags.SSL.City,
+		Org:        flags.SSL.Org,
+		OrgUnit:    flags.SSL.OU,
+		SSLEmail:   flags.SSL.Email,
 	}
 
 	return proxyConfigGenerate(client, request)

--- a/mgrctl/cmd/proxy/config_do_test.go
+++ b/mgrctl/cmd/proxy/config_do_test.go
@@ -131,11 +131,11 @@ func TestFailProxyCreateConfigWhenProxyCrtIsProvidedButProxyKeyIsMissing(t *test
 	testFiles := setupTestFiles(t, testDir)
 	flags := &proxyCreateConfigFlags{
 		ConnectionDetails: connectionDetails,
-		Ssl: proxyConfigSslFlags{
+		SSL: proxyConfigSSLFlags{
 			Ca: caFlags{
-				SslPair: types.SslPair{Cert: testFiles.ProxyCrtFilePath},
+				SSLPair: types.SSLPair{Cert: testFiles.ProxyCrtFilePath},
 			},
-			Proxy: types.SslPair{Cert: testFiles.ProxyCrtFilePath},
+			Proxy: types.SSLPair{Cert: testFiles.ProxyCrtFilePath},
 		},
 	}
 	expectedErrorMessage := "flag proxyKey is required when flag proxyCrt is provided"
@@ -157,11 +157,11 @@ func TestFailProxyCreateConfigWhenProxyConfigApiRequestFails(t *testing.T) {
 	testFiles := setupTestFiles(t, testDir)
 	mockContainerConfigflags := &proxyCreateConfigFlags{
 		ConnectionDetails: connectionDetails,
-		Ssl: proxyConfigSslFlags{
+		SSL: proxyConfigSSLFlags{
 			Ca: caFlags{
-				SslPair: types.SslPair{Cert: testFiles.CaCrtFilePath},
+				SSLPair: types.SSLPair{Cert: testFiles.CaCrtFilePath},
 			},
-			Proxy: types.SslPair{
+			Proxy: types.SSLPair{
 				Cert: testFiles.ProxyCrtFilePath,
 				Key:  testFiles.ProxyKeyFilePath,
 			},
@@ -169,9 +169,9 @@ func TestFailProxyCreateConfigWhenProxyConfigApiRequestFails(t *testing.T) {
 	}
 	mockContainerConfigGenerateflags := &proxyCreateConfigFlags{
 		ConnectionDetails: connectionDetails,
-		Ssl: proxyConfigSslFlags{
+		SSL: proxyConfigSSLFlags{
 			Ca: caFlags{
-				SslPair: types.SslPair{
+				SSLPair: types.SSLPair{
 					Cert: testFiles.CaCrtFilePath,
 					Key:  testFiles.CaKeyFilePath,
 				},
@@ -231,12 +231,12 @@ func TestSuccessProxyCreateConfigWhenAllParamsProvidedSuccess(t *testing.T) {
 			Email:    "example@email.com",
 		},
 		Output: output,
-		Ssl: proxyConfigSslFlags{
+		SSL: proxyConfigSSLFlags{
 			Ca: caFlags{
-				SslPair:      types.SslPair{Cert: testFiles.CaCrtFilePath},
+				SSLPair:      types.SSLPair{Cert: testFiles.CaCrtFilePath},
 				Intermediate: []string{testFiles.IntermediateCA1FilePath, testFiles.IntermediateCA2FilePath},
 			},
-			Proxy: types.SslPair{
+			Proxy: types.SSLPair{
 				Cert: testFiles.ProxyCrtFilePath,
 				Key:  testFiles.ProxyKeyFilePath,
 			},
@@ -293,8 +293,8 @@ func TestSuccessProxyCreateConfigGenerateWhenAllParamsProvidedSuccess(t *testing
 			Email:    "example@email.com",
 		},
 		Output: output,
-		Ssl: proxyConfigSslFlags{
-			SslCertGenerationFlags: types.SslCertGenerationFlags{
+		SSL: proxyConfigSSLFlags{
+			SSLCertGenerationFlags: types.SSLCertGenerationFlags{
 				Cnames:  []string{"altNameA.example.com", "altNameB.example.com"},
 				Country: "testCountry",
 				State:   "exampleState",
@@ -304,7 +304,7 @@ func TestSuccessProxyCreateConfigGenerateWhenAllParamsProvidedSuccess(t *testing
 				Email:   "sslEmail@example.com",
 			},
 			Ca: caFlags{
-				SslPair: types.SslPair{
+				SSLPair: types.SSLPair{
 					Cert: testFiles.CaCrtFilePath,
 					Key:  testFiles.CaKeyFilePath,
 				},
@@ -323,13 +323,13 @@ func TestSuccessProxyCreateConfigGenerateWhenAllParamsProvidedSuccess(t *testing
 		testutils.AssertEquals(t, "Unexpected caCrt", dummyCaCrtContents, request.CaCrt)
 		testutils.AssertEquals(t, "Unexpected caKey", dummyCaKeyContents, request.CaKey)
 		testutils.AssertEquals(t, "Unexpected caPassword", dummyCaPasswordContents, request.CaPassword)
-		testutils.AssertEquals(t, "Unexpected cnames", fmt.Sprintf("%v", flags.Ssl.Cnames), fmt.Sprintf("%v", request.Cnames))
-		testutils.AssertEquals(t, "Unexpected country", flags.Ssl.Country, request.Country)
-		testutils.AssertEquals(t, "Unexpected state", flags.Ssl.State, request.State)
-		testutils.AssertEquals(t, "Unexpected city", flags.Ssl.City, request.City)
-		testutils.AssertEquals(t, "Unexpected org", flags.Ssl.Org, request.Org)
-		testutils.AssertEquals(t, "Unexpected orgUnit", flags.Ssl.OU, request.OrgUnit)
-		testutils.AssertEquals(t, "Unexpected sslEmail", flags.Ssl.Email, request.SslEmail)
+		testutils.AssertEquals(t, "Unexpected cnames", fmt.Sprintf("%v", flags.SSL.Cnames), fmt.Sprintf("%v", request.Cnames))
+		testutils.AssertEquals(t, "Unexpected country", flags.SSL.Country, request.Country)
+		testutils.AssertEquals(t, "Unexpected state", flags.SSL.State, request.State)
+		testutils.AssertEquals(t, "Unexpected city", flags.SSL.City, request.City)
+		testutils.AssertEquals(t, "Unexpected org", flags.SSL.Org, request.Org)
+		testutils.AssertEquals(t, "Unexpected orgUnit", flags.SSL.OU, request.OrgUnit)
+		testutils.AssertEquals(t, "Unexpected sslEmail", flags.SSL.Email, request.SSLEmail)
 		return &expectedConfigFileData, nil
 	}
 

--- a/mgrctl/cmd/proxy/config_test.go
+++ b/mgrctl/cmd/proxy/config_test.go
@@ -36,7 +36,7 @@ func assertCommonArgs(t *testing.T, cmd *cobra.Command, flags *proxyCreateConfig
 	testutils.AssertEquals(t, "Unexpected proxy max cache", 123456, flags.Proxy.MaxCache)
 	testutils.AssertEquals(t, "Unexpected proxy email", "admin@proxy.test.com", flags.Proxy.Email)
 	testutils.AssertEquals(t, "Unexpected output path", "path/to/output.tgz", flags.Output)
-	testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.Ssl.Ca.Cert)
+	testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.SSL.Ca.Cert)
 }
 
 func TestParamsParsingGeneratedCert(t *testing.T) {
@@ -60,11 +60,11 @@ func TestParamsParsingGeneratedCert(t *testing.T) {
 		cmd *cobra.Command, args []string,
 	) error {
 		assertCommonArgs(t, cmd, flags)
-		flagstests.AssertSSLGenerationFlags(t, cmd, &flags.Ssl.SslCertGenerationFlags)
-		testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.Ssl.Ca.Cert)
-		testutils.AssertEquals(t, "Unexpected SSL CA key path", "path/to/ca.key", flags.Ssl.Ca.Key)
-		testutils.AssertEquals(t, "Unexpected SSL CA password", "casecret", flags.Ssl.Ca.Password)
-		testutils.AssertEquals(t, "Unexpected SSL email", "ssl@test.com", flags.Ssl.Email)
+		flagstests.AssertSSLGenerationFlags(t, cmd, &flags.SSL.SSLCertGenerationFlags)
+		testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.SSL.Ca.Cert)
+		testutils.AssertEquals(t, "Unexpected SSL CA key path", "path/to/ca.key", flags.SSL.Ca.Key)
+		testutils.AssertEquals(t, "Unexpected SSL CA password", "casecret", flags.SSL.Ca.Password)
+		testutils.AssertEquals(t, "Unexpected SSL email", "ssl@test.com", flags.SSL.Email)
 		return nil
 	}
 
@@ -106,12 +106,12 @@ func TestParamsParsingProvidedCert(t *testing.T) {
 		cmd *cobra.Command, args []string,
 	) error {
 		assertCommonArgs(t, cmd, flags)
-		testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.Ssl.Ca.Cert)
+		testutils.AssertEquals(t, "Unexpected SSL CA cert path", "path/to/ca.crt", flags.SSL.Ca.Cert)
 		testutils.AssertEquals(t, "Unexpected SSL intermediate CA cert paths",
-			[]string{"path/to/ca1.crt", "path/to/ca2.crt"}, flags.Ssl.Ca.Intermediate,
+			[]string{"path/to/ca1.crt", "path/to/ca2.crt"}, flags.SSL.Ca.Intermediate,
 		)
-		testutils.AssertEquals(t, "Unexpected Proxy SSL cert path", "path/to/proxy.crt", flags.Ssl.Proxy.Cert)
-		testutils.AssertEquals(t, "Unexpected Proxy SSL key path", "path/to/proxy.key", flags.Ssl.Proxy.Key)
+		testutils.AssertEquals(t, "Unexpected Proxy SSL cert path", "path/to/proxy.crt", flags.SSL.Proxy.Cert)
+		testutils.AssertEquals(t, "Unexpected Proxy SSL key path", "path/to/proxy.key", flags.SSL.Proxy.Key)
 		return nil
 	}
 

--- a/mgrpxy/cmd/install/kubernetes/kubernetes.go
+++ b/mgrpxy/cmd/install/kubernetes/kubernetes.go
@@ -16,7 +16,7 @@ import (
 type kubernetesProxyInstallFlags struct {
 	pxy_utils.ProxyImageFlags `mapstructure:",squash"`
 	Helm                      kubernetes.HelmFlags
-	Scc                       types.SCCCredentials
+	SCC                       types.SCCCredentials
 }
 
 func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[kubernetesProxyInstallFlags]) *cobra.Command {

--- a/mgrpxy/cmd/install/kubernetes/kubernetes_test.go
+++ b/mgrpxy/cmd/install/kubernetes/kubernetes_test.go
@@ -20,7 +20,7 @@ func TestParamsParsing(t *testing.T) {
 
 	args = append(args, flagstests.ImageProxyFlagsTestArgs...)
 	args = append(args, flagstests.ProxyHelmFlagsTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 
 	// Test function asserting that the args are properly parsed
 	tester := func(globalFlags *types.GlobalFlags, flags *kubernetesProxyInstallFlags,
@@ -28,7 +28,7 @@ func TestParamsParsing(t *testing.T) {
 	) error {
 		flagstests.AssertProxyImageFlags(t, cmd, &flags.ProxyImageFlags)
 		flagstests.AssertProxyHelmFlags(t, cmd, &flags.Helm)
-		flagstests.AssertSccFlag(t, cmd, &flags.Scc)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		return nil
 	}
 

--- a/mgrpxy/cmd/install/kubernetes/utils.go
+++ b/mgrpxy/cmd/install/kubernetes/utils.go
@@ -57,7 +57,7 @@ func installForKubernetes(globalFlags *types.GlobalFlags,
 	}
 
 	helmArgs := []string{"--set", "ingress=" + clusterInfos.Ingress}
-	helmArgs, err = shared_kubernetes.AddSccSecret(helmArgs, flags.Helm.Proxy.Namespace, &flags.Scc)
+	helmArgs, err = shared_kubernetes.AddSCCSecret(helmArgs, flags.Helm.Proxy.Namespace, &flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/cmd/install/podman/podman_test.go
+++ b/mgrpxy/cmd/install/podman/podman_test.go
@@ -21,7 +21,7 @@ func TestParamsParsing(t *testing.T) {
 	}
 	args = append(args, flagstests.ImageProxyFlagsTestArgs...)
 	args = append(args, flagstests.PodmanFlagsTestArgs...)
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 
 	// Test function asserting that the args are properly parsed
 	tester := func(globalFlags *types.GlobalFlags, flags *podman.PodmanProxyFlags,
@@ -29,7 +29,7 @@ func TestParamsParsing(t *testing.T) {
 	) error {
 		flagstests.AssertProxyImageFlags(t, cmd, &flags.ProxyImageFlags)
 		flagstests.AssertPodmanInstallFlags(t, cmd, &flags.Podman)
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		return nil
 	}
 

--- a/mgrpxy/cmd/support/ptf/podman/podman_test.go
+++ b/mgrpxy/cmd/support/ptf/podman/podman_test.go
@@ -21,14 +21,14 @@ func TestParamsParsing(t *testing.T) {
 		"--user", "sccuser",
 	}
 
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.ImageProxyFlagsTestArgs...)
 
 	// Test function asserting that the args are properly parsed
 	tester := func(globalFlags *types.GlobalFlags, flags *podmanPTFFlags,
 		cmd *cobra.Command, args []string,
 	) error {
-		flagstests.AssertSccFlag(t, cmd, &flags.UpgradeFlags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.UpgradeFlags.SCC)
 		flagstests.AssertProxyImageFlags(t, cmd, &flags.UpgradeFlags.ProxyImageFlags)
 		testutils.AssertEquals(t, "Error parsing --ptf", "ptf123", flags.PTFId)
 		testutils.AssertEquals(t, "Error parsing --test", "test123", flags.TestID)

--- a/mgrpxy/cmd/upgrade/podman/podman_test.go
+++ b/mgrpxy/cmd/upgrade/podman/podman_test.go
@@ -18,7 +18,7 @@ import (
 func TestParamsParsing(t *testing.T) {
 	args := []string{}
 
-	args = append(args, flagstests.SccFlagTestArgs...)
+	args = append(args, flagstests.SCCFlagTestArgs...)
 	args = append(args, flagstests.ImageProxyFlagsTestArgs...)
 	args = append(args, flagstests.PodmanFlagsTestArgs...)
 
@@ -26,7 +26,7 @@ func TestParamsParsing(t *testing.T) {
 	tester := func(globalFlags *types.GlobalFlags, flags *podman.PodmanProxyFlags,
 		cmd *cobra.Command, args []string,
 	) error {
-		flagstests.AssertSccFlag(t, cmd, &flags.SCC)
+		flagstests.AssertSCCFlag(t, cmd, &flags.SCC)
 		flagstests.AssertPodmanInstallFlags(t, cmd, &flags.Podman)
 		flagstests.AssertProxyImageFlags(t, cmd, &flags.ProxyImageFlags)
 		return nil

--- a/shared/api/proxy/containerConfig_test.go
+++ b/shared/api/proxy/containerConfig_test.go
@@ -36,7 +36,7 @@ type ProxyConfigGenerateRequestBodyData struct {
 	City       string
 	Org        string
 	OrgUnit    string
-	SslEmail   string
+	SSLEmail   string
 }
 
 // ProxyConfigRequestBodyData is the data structure for the request body of the ContainerConfig API request.
@@ -75,7 +75,7 @@ const expectedState = "exampleState"
 const expectedCity = "exampleCity"
 const expectedOrg = "exampleOrg"
 const expectedOrgUnit = "exampleOrgUnit"
-const expectedSslEmail = "sslEmail@example.com"
+const expectedSSLEmail = "sslEmail@example.com"
 
 var expectedCnames = []string{"altNameA.example.com", "altNameB.example.com"}
 
@@ -113,7 +113,7 @@ var proxyConfigGenerateRequest = proxy.ProxyConfigGenerateRequest{
 	City:       expectedCity,
 	Org:        expectedOrg,
 	OrgUnit:    expectedOrgUnit,
-	SslEmail:   expectedSslEmail,
+	SSLEmail:   expectedSSLEmail,
 }
 
 // Tests ContainerConfig when the post request fails.
@@ -298,7 +298,7 @@ func TestSuccessfulContainerConfigGenerateWhenAllParametersAreProvided(t *testin
 			testutils.AssertEquals(globalT, "City doesn't match", expectedCity, data.City)
 			testutils.AssertEquals(globalT, "Org doesn't match", expectedOrg, data.Org)
 			testutils.AssertEquals(globalT, "OrgUnit doesn't match", expectedOrgUnit, data.OrgUnit)
-			testutils.AssertEquals(globalT, "SslEmail doesn't match", expectedSslEmail, data.SslEmail)
+			testutils.AssertEquals(globalT, "SSLEmail doesn't match", expectedSSLEmail, data.SSLEmail)
 
 			// mock response
 			return testutils.GetResponse(200, `{"success": true, "result": [1, 2, 3, 4, 5]}`)

--- a/shared/api/proxy/mapping.go
+++ b/shared/api/proxy/mapping.go
@@ -38,6 +38,6 @@ func ProxyConfigGenerateRequestToMap(request ProxyConfigGenerateRequest) map[str
 		"city":       request.City,
 		"org":        request.Org,
 		"orgUnit":    request.OrgUnit,
-		"sslEmail":   request.SslEmail,
+		"sslEmail":   request.SSLEmail,
 	}
 }

--- a/shared/api/proxy/model.go
+++ b/shared/api/proxy/model.go
@@ -37,5 +37,5 @@ type ProxyConfigGenerateRequest struct {
 	City       string
 	Org        string
 	OrgUnit    string
-	SslEmail   string
+	SSLEmail   string
 }

--- a/shared/kubernetes/kubernetes.go
+++ b/shared/kubernetes/kubernetes.go
@@ -192,8 +192,8 @@ data:
 	return nil
 }
 
-// AddSccSecret creates a secret holding the SCC credentials and adds it to the helm args.
-func AddSccSecret(helmArgs []string, namespace string, scc *types.SCCCredentials) ([]string, error) {
+// AddSCCSecret creates a secret holding the SCC credentials and adds it to the helm args.
+func AddSCCSecret(helmArgs []string, namespace string, scc *types.SCCCredentials) ([]string, error) {
 	if scc.User != "" && scc.Password != "" {
 		secretName := "scc-credentials"
 		if err := createDockerSecret(

--- a/shared/podman/hostinspector.go
+++ b/shared/podman/hostinspector.go
@@ -40,8 +40,8 @@ func NewHostInspector(scriptDir string) HostInspector {
 
 // HostInspectData are the data returned by the host inspector.
 type HostInspectData struct {
-	SccUsername    string `mapstructure:"scc_username"`
-	SccPassword    string `mapstructure:"scc_password"`
+	SCCUsername    string `mapstructure:"scc_username"`
+	SCCPassword    string `mapstructure:"scc_password"`
 	HasUyuniServer bool   `mapstructure:"has_uyuni_server"`
 }
 

--- a/shared/podman/hostinspector_test.go
+++ b/shared/podman/hostinspector_test.go
@@ -52,7 +52,7 @@ has_uyuni_server=true
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	testutils.AssertEquals(t, "Invalid SCC username", "myuser", actual.SccUsername)
-	testutils.AssertEquals(t, "Invalid SCC password", "mysecret", actual.SccPassword)
+	testutils.AssertEquals(t, "Invalid SCC username", "myuser", actual.SCCUsername)
+	testutils.AssertEquals(t, "Invalid SCC password", "mysecret", actual.SCCPassword)
 	testutils.AssertTrue(t, "HasUyuniServer should be true", actual.HasUyuniServer)
 }

--- a/shared/podman/login.go
+++ b/shared/podman/login.go
@@ -19,8 +19,8 @@ import (
 //
 // It returns an authentication file, a cleanup function and an error.
 func PodmanLogin(hostData *HostInspectData, scc types.SCCCredentials) (string, func(), error) {
-	sccUser := hostData.SccUsername
-	sccPassword := hostData.SccPassword
+	sccUser := hostData.SCCUsername
+	sccPassword := hostData.SCCPassword
 	if scc.User != "" && scc.Password != "" {
 		log.Info().Msg(L("SCC credentials parameters will be used. SCC credentials from host will be ignored."))
 		sccUser = scc.User

--- a/shared/ssl/ssl.go
+++ b/shared/ssl/ssl.go
@@ -21,7 +21,7 @@ import (
 // OrderCas generates the server certificate with the CA chain.
 //
 // Returns the certificate chain and the root CA.
-func OrderCas(chain *types.CaChain, serverPair *types.SslPair) ([]byte, []byte) {
+func OrderCas(chain *types.CaChain, serverPair *types.SSLPair) ([]byte, []byte) {
 	CheckPaths(chain, serverPair)
 
 	// Extract all certificates and their data
@@ -218,7 +218,7 @@ func sortCertificates(mapBySubjectHash map[string]certificate, serverCertHash st
 }
 
 // CheckPaths ensures that all the passed path exists and the required files are available.
-func CheckPaths(chain *types.CaChain, serverPair *types.SslPair) {
+func CheckPaths(chain *types.CaChain, serverPair *types.SSLPair) {
 	mandatoryFile(chain.Root, "root CA")
 	for _, ca := range chain.Intermediate {
 		optionalFile(ca)

--- a/shared/ssl/ssl_test.go
+++ b/shared/ssl/ssl_test.go
@@ -83,7 +83,7 @@ func TestOrderCas(t *testing.T) {
 		Root:         "testdata/chain1/root-ca.crt",
 		Intermediate: []string{"testdata/chain1/intermediate-ca.crt"},
 	}
-	server := types.SslPair{Cert: "testdata/chain1/server.crt", Key: "testdata/chain1/server.key"}
+	server := types.SSLPair{Cert: "testdata/chain1/server.crt", Key: "testdata/chain1/server.key"}
 
 	certs, rootCa := OrderCas(&chain, &server)
 	ordered := strings.Split(string(certs), "-----BEGIN CERTIFICATE-----\n")
@@ -137,7 +137,7 @@ func TestFindServerCertificate(t *testing.T) {
 // Test a CA chain with all the chain in the server certificate file.
 func TestOrderCasChain2(t *testing.T) {
 	chain := types.CaChain{Root: "testdata/chain2/RHN-ORG-TRUSTED-SSL-CERT", Intermediate: []string{}}
-	server := types.SslPair{Cert: "testdata/chain2/spacewalk.crt", Key: "testdata/chain2/spacewalk.key"}
+	server := types.SSLPair{Cert: "testdata/chain2/spacewalk.crt", Key: "testdata/chain2/spacewalk.key"}
 
 	certs, rootCa := OrderCas(&chain, &server)
 	ordered := strings.Split(string(certs), "-----BEGIN CERTIFICATE-----\n")

--- a/shared/testutils/flagstests/mgradm_install.go
+++ b/shared/testutils/flagstests/mgradm_install.go
@@ -49,7 +49,7 @@ var InstallFlagsTestArgs = func() []string {
 	}
 
 	args = append(args, MirrorFlagTestArgs...)
-	args = append(args, SccFlagTestArgs...)
+	args = append(args, SCCFlagTestArgs...)
 	args = append(args, ImageFlagsTestArgs...)
 	args = append(args, CocoFlagsTestArgs...)
 	args = append(args, HubXmlrpcFlagsTestArgs...)
@@ -94,7 +94,7 @@ func AssertInstallFlags(t *testing.T, cmd *cobra.Command, flags *shared.InstallF
 	testutils.AssertEquals(t, "Error parsing --admin-lastName", "adminlast", flags.Admin.LastName)
 	testutils.AssertEquals(t, "Error parsing --organization", "someorg", flags.Organization)
 	AssertMirrorFlag(t, cmd, flags.Mirror)
-	AssertSccFlag(t, cmd, &flags.Scc)
+	AssertSCCFlag(t, cmd, &flags.SCC)
 	AssertImageFlag(t, cmd, &flags.Image)
 	AssertCocoFlag(t, cmd, &flags.Coco)
 	AssertHubXmlrpcFlag(t, cmd, &flags.HubXmlrpc)

--- a/shared/testutils/flagstests/mgradm_install.go
+++ b/shared/testutils/flagstests/mgradm_install.go
@@ -79,14 +79,14 @@ func AssertInstallFlags(t *testing.T, cmd *cobra.Command, flags *shared.InstallF
 	testutils.AssertEquals(t, "Error parsing --reportdb-name", "reportdbname", flags.ReportDB.Name)
 	testutils.AssertEquals(t, "Error parsing --reportdb-host", "reportdbhost", flags.ReportDB.Host)
 	testutils.AssertEquals(t, "Error parsing --reportdb-port", 5678, flags.ReportDB.Port)
-	AssertSSLGenerationFlags(t, cmd, &flags.Ssl.SslCertGenerationFlags)
-	testutils.AssertEquals(t, "Error parsing --ssl-password", "sslsecret", flags.Ssl.Password)
+	AssertSSLGenerationFlags(t, cmd, &flags.SSL.SSLCertGenerationFlags)
+	testutils.AssertEquals(t, "Error parsing --ssl-password", "sslsecret", flags.SSL.Password)
 	testutils.AssertEquals(t, "Error parsing --ssl-ca-intermediate",
-		[]string{"path/inter1.crt", "path/inter2.crt"}, flags.Ssl.Ca.Intermediate,
+		[]string{"path/inter1.crt", "path/inter2.crt"}, flags.SSL.Ca.Intermediate,
 	)
-	testutils.AssertEquals(t, "Error parsing --ssl-ca-root", "path/root.crt", flags.Ssl.Ca.Root)
-	testutils.AssertEquals(t, "Error parsing --ssl-server-cert", "path/srv.crt", flags.Ssl.Server.Cert)
-	testutils.AssertEquals(t, "Error parsing --ssl-server-key", "path/srv.key", flags.Ssl.Server.Key)
+	testutils.AssertEquals(t, "Error parsing --ssl-ca-root", "path/root.crt", flags.SSL.Ca.Root)
+	testutils.AssertEquals(t, "Error parsing --ssl-server-cert", "path/srv.crt", flags.SSL.Server.Cert)
+	testutils.AssertEquals(t, "Error parsing --ssl-server-key", "path/srv.key", flags.SSL.Server.Key)
 	testutils.AssertTrue(t, "Error parsing --debug-java", flags.Debug.Java)
 	testutils.AssertEquals(t, "Error parsing --admin-login", "adminuser", flags.Admin.Login)
 	testutils.AssertEquals(t, "Error parsing --admin-password", "adminpass", flags.Admin.Password)

--- a/shared/testutils/flagstests/scc.go
+++ b/shared/testutils/flagstests/scc.go
@@ -12,14 +12,14 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-// SccFlagTestArgs is the expected values for AssertSccFlag.
-var SccFlagTestArgs = []string{
+// SCCFlagTestArgs is the expected values for AssertSccFlag.
+var SCCFlagTestArgs = []string{
 	"--scc-user", "mysccuser",
 	"--scc-password", "mysccpass",
 }
 
-// AssertSccFlag checks that all SCC flags are parsed correctly.
-func AssertSccFlag(t *testing.T, cmd *cobra.Command, flags *types.SCCCredentials) {
+// AssertSCCFlag checks that all SCC flags are parsed correctly.
+func AssertSCCFlag(t *testing.T, cmd *cobra.Command, flags *types.SCCCredentials) {
 	testutils.AssertEquals(t, "Error parsing --scc-user", "mysccuser", flags.User)
 	testutils.AssertEquals(t, "Error parsing --scc-password", "mysccpass", flags.Password)
 }

--- a/shared/testutils/flagstests/ssl.go
+++ b/shared/testutils/flagstests/ssl.go
@@ -24,7 +24,7 @@ var SSLGenerationFlagsTestArgs = []string{
 }
 
 // AssertSSLGenerationFlags checks that all the SSL certificate generation flags are parsed correctly.
-func AssertSSLGenerationFlags(t *testing.T, cmd *cobra.Command, flags *types.SslCertGenerationFlags) {
+func AssertSSLGenerationFlags(t *testing.T, cmd *cobra.Command, flags *types.SSLCertGenerationFlags) {
 	testutils.AssertEquals(t, "Error parsing --ssl-cname", []string{"cname1", "cname2"}, flags.Cnames)
 	testutils.AssertEquals(t, "Error parsing --ssl-country", "OS", flags.Country)
 	testutils.AssertEquals(t, "Error parsing --ssl-state", "sslstate", flags.State)

--- a/shared/types/ssl.go
+++ b/shared/types/ssl.go
@@ -4,8 +4,8 @@
 
 package types
 
-// SslCertGenerationFlags stores informations to generate an SSL Certificate.
-type SslCertGenerationFlags struct {
+// SSLCertGenerationFlags stores informations to generate an SSL Certificate.
+type SSLCertGenerationFlags struct {
 	Cnames   []string `mapstructure:"cname"`
 	Country  string
 	State    string
@@ -22,8 +22,8 @@ type CaChain struct {
 	Intermediate []string
 }
 
-// SslPair is a type for SSL Cert and Key.
-type SslPair struct {
+// SSLPair is a type for SSL Cert and Key.
+type SSLPair struct {
 	Cert string
 	Key  string
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

SCC and SSL are initialisms and should be either lowercase or uppercase, not a mix of them. This PR adds them to the golangci-lint checks in order to harmonize how those are written throughout the code base.

## Test coverage
- No tests: case change

- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
