### PR TITLE
Fix wrong systemd command

### DIFF
--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -111,7 +111,7 @@ func DeleteContainer(name string, dryRun bool) {
 
 // GetServiceImage returns the value of the UYUNI_IMAGE variable for a systemd service.
 func GetServiceImage(service string) string {
-	out, err := runCmdOutput(zerolog.DebugLevel, "systemd", "cat", service)
+	out, err := runCmdOutput(zerolog.DebugLevel, "systemctl", "cat", service)
 	if err != nil {
 		log.Warn().Err(err).Msgf(L("failed to get %s systemd service definition"), service)
 		return ""


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Typo got `systemd cat` instead of `systemctl cat` resulting in runtime errors.

## Test coverage
- No tests: systemctl commands are not tested yet.

- [X] **DONE**

## Links

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
