### PR TITLE
cloudguestregistryauth is only expected to work for PAYG

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -526,11 +526,22 @@ func CallCloudGuestRegistryAuth() error {
 
 	path, err := exec.LookPath(cloudguestregistryauth)
 	if err == nil {
-		// the binary is installed
-		return utils.RunCmdStdMapping(zerolog.DebugLevel, path)
+		if err := utils.RunCmdStdMapping(zerolog.DebugLevel, path); err != nil && isPAYG() {
+			// Not being registered against the cloud registry is  not an error on BYOS.
+			return err
+		}
 	}
 	// silently ignore error if it is missing
 	return nil
+}
+
+func isPAYG() bool {
+	flavorCheckPath := "/usr/bin/instance-flavor-check"
+	if utils.FileExists(flavorCheckPath) {
+		out, _ := utils.RunCmdOutput(zerolog.DebugLevel, flavorCheckPath)
+		return strings.TrimSpace(string(out)) == "PAYG"
+	}
+	return false
 }
 
 // GetMountPoint return folder where a given volume is mounted.

--- a/uyuni-tools.changes.cbosdo.byos-fix
+++ b/uyuni-tools.changes.cbosdo.byos-fix
@@ -1,0 +1,1 @@
+- Only raise an error if cloudguestregistryauth fails for PAYG (bsc#1233630)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The tool is also installed for BYOS images, and users can register the system against the cloud registry, but this is not mandatory, so ignore the errors in such a case. (bsc#1233630)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: testing with expected files is no ready yet

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1233630

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
