### PR TITLE
Fix the mirror PV handling

### DIFF
--- a/mgradm/shared/kubernetes/deployment.go
+++ b/mgradm/shared/kubernetes/deployment.go
@@ -80,12 +80,18 @@ func getServerDeployment(
 	}
 
 	if mirrorPvName != "" {
-		// Add a mount for the mirror
+		// Add a volume for the mirror
 		mounts = append(mounts, types.VolumeMount{MountPath: "/mirror", Name: mirrorPvName})
 
 		// Add the environment variable for the deployment to use the mirror
 		// This doesn't makes sense for migration as the setup script is not executed
 		envs = append(envs, core.EnvVar{Name: "MIRROR_PATH", Value: "/mirror"})
+
+		// Add the volume mount now since we don't want it in the init container ones.
+		volumeMounts = append(volumeMounts, core.VolumeMount{
+			Name:      mirrorPvName,
+			MountPath: "/mirror",
+		})
 	}
 
 	volumes := kubernetes.CreateVolumes(mounts)

--- a/uyuni-tools.changes.cbosdo.k8s-mirror-fix
+++ b/uyuni-tools.changes.cbosdo.k8s-mirror-fix
@@ -1,0 +1,1 @@
+- Fix mirror pv check when the pv isn't claimed


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

If the PV has no claimRef, the generated JSON fragment will miss a value and won't be valid. Output the whole PV as JSON and parse it using the Kubernetes API type.

The volume mount for the mirror is also missing in the container.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: not sure we could add meaningful tests here

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9542

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
