### PR TITLE
Revert use of :z flag on volumes

### DIFF
--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -181,7 +181,7 @@ func runSetup(image string, flags *adm_utils.ServerFlags, fqdn string, sslArgs [
 	}
 	command = append(command, sslArgs...)
 	for _, volume := range utils.ServerVolumeMounts {
-		command = append(command, "-v", fmt.Sprintf("%s:%s:z", volume.Name, volume.MountPath))
+		command = append(command, "-v", fmt.Sprintf("%s:%s", volume.Name, volume.MountPath))
 	}
 	command = append(command, envNames...)
 	command = append(command, image)

--- a/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
+++ b/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
@@ -37,7 +37,7 @@ ExecStart=/usr/bin/podman run \
         -p {{ .Exposed }}:{{ .Port }}{{if .Protocol}}/{{ .Protocol }}{{end}} \
         {{- end }}
         {{- range .Volumes }}
-        -v {{ .Name }}:{{ .MountPath }}:z \
+        -v {{ .Name }}:{{ .MountPath }} \
         {{- end }}
 	-e HUB_API_URL \
 	-e HUB_CONNECT_TIMEOUT \

--- a/mgradm/shared/templates/salineServiceTemplate.go
+++ b/mgradm/shared/templates/salineServiceTemplate.go
@@ -41,7 +41,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	-p [::]:{{ .SalinePort }}:8216 \
 	{{- end }}
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }}:z \
+	-v {{ .Name }}:{{ .MountPath }} \
 	{{- end }}
 	-e TZ=${TZ} \
 	-e NOSSL=${NOSSL} \

--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -43,7 +43,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
         {{- end }}
 	{{- end }}
 	{{- range .Volumes }}
-	-v {{ .Name }}:{{ .MountPath }}:z \
+	-v {{ .Name }}:{{ .MountPath }} \
 	{{- end }}
 	-e TZ=${TZ} \
 	--network {{ .Network }} \

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -69,9 +69,6 @@ func GenerateSystemdService(
 
 	// Httpd
 	volumeOptions := ""
-	if podman.IsSELinuxEnabled() {
-		volumeOptions = ",z"
-	}
 
 	{
 		dataHttpd := templates.HttpdTemplateData{

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -70,7 +70,7 @@ func RunContainer(name string, image string, volumes []types.VolumeMount, extraA
 	podmanArgs := append([]string{"run", "--name", name}, GetCommonParams()...)
 	podmanArgs = append(podmanArgs, extraArgs...)
 	for _, volume := range volumes {
-		podmanArgs = append(podmanArgs, "-v", volume.Name+":"+volume.MountPath+":z")
+		podmanArgs = append(podmanArgs, "-v", volume.Name+":"+volume.MountPath)
 	}
 	podmanArgs = append(podmanArgs, "--network", UyuniNetwork)
 	podmanArgs = append(podmanArgs, image)

--- a/shared/utils/volumes.go
+++ b/shared/utils/volumes.go
@@ -73,16 +73,16 @@ var SalineVolumeMounts = []types.VolumeMount{
 
 // ProxyHttpdVolumes volumes used by HTTPD in proxy.
 var ProxyHttpdVolumes = []types.VolumeMount{
-	{Name: "uyuni-proxy-rhn-cache", MountPath: "/var/cache/rhn:z"},
-	{Name: "uyuni-proxy-tftpboot", MountPath: "/srv/tftpboot:z"},
+	{Name: "uyuni-proxy-rhn-cache", MountPath: "/var/cache/rhn"},
+	{Name: "uyuni-proxy-tftpboot", MountPath: "/srv/tftpboot"},
 }
 
 // ProxySquidVolumes volumes used by Squid in  proxy.
 var ProxySquidVolumes = []types.VolumeMount{
-	{Name: "uyuni-proxy-squid-cache", MountPath: "/var/cache/squid:z"},
+	{Name: "uyuni-proxy-squid-cache", MountPath: "/var/cache/squid"},
 }
 
 // ProxyTftpdVolumes used by TFTP in proxy.
 var ProxyTftpdVolumes = []types.VolumeMount{
-	{Name: "uyuni-proxy-tftpboot", MountPath: "/srv/tftpboot:ro,z"},
+	{Name: "uyuni-proxy-tftpboot", MountPath: "/srv/tftpboot:ro"},
 }

--- a/uyuni-tools.changes.nadvornik.revert_z
+++ b/uyuni-tools.changes.nadvornik.revert_z
@@ -1,0 +1,1 @@
+- Revert use of :z flag on server volumes (bsc#1235861)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR reverts use of `:z` flag on volumes.

The flag is still used in `mgradm/cmd/install/podman/ssl.go` to set the labels of temp directory for ssl certificates.

Forward port of https://github.com/SUSE/uyuni-tools/pull/58

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

https://github.com/SUSE/uyuni-tools/pull/58
https://github.com/SUSE/spacewalk/issues/26170
https://github.com/SUSE/spacewalk/issues/26219
https://bugzilla.suse.com/show_bug.cgi?id=1235861


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
