### PR TITLE
Prevent fix-up commits from being merged

### DIFF
--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Bradley Erickson
+# SPDX-FileCopyrightText: 2019 Brad Erickson
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2021 Bradley Erickson
+#
+# SPDX-License-Identifier: MIT
+
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Brad Erickson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Prevent fix-up commits from being merged.

Port of https://github.com/uyuni-project/uyuni/pull/9773 from the `uyuni` repository.

After this PR is merged, I will force the test to pass for the `main` branch.

## Test coverage
- No tests: None, this is adding an action

- [x] **DONE**

## Links

Issue(s): None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
