### PR TITLE
Revert to go 1.21 for RHEL-based builds

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uyuni-project/uyuni-tools
 
-go 1.22
+go 1.21
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2

--- a/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
+++ b/mgradm/shared/templates/hubXmlrpcServiceTemplate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/mgradm/shared/templates/salineServiceTemplate.go
+++ b/mgradm/shared/templates/salineServiceTemplate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/shared/utils/volumes.go
+++ b/shared/utils/volumes.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -96,7 +96,7 @@ BuildRequires:  golang >= 1.19
 # 0%{?debian}
 
 %if 0%{?fedora} || 0%{?rhel}
-BuildRequires:  golang >= 1.22
+BuildRequires:  golang >= 1.21
 %endif
 # 0%{?fedora} || 0%{?rhel}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

There are issues getting go 1.22 on AlmaLinux 8 SUSE Multi-Linux Manager client tools. Reverting to go 1.21 to pass the builds.

Still require go 1.22 where possible.

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
