### PR TITLE
Pin all GitHub actions to a commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version: '1.22'
 
@@ -65,7 +65,7 @@ jobs:
         run: go test ./...
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1
         with:
           name: binaries
           path: ./bin/*

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -19,12 +19,12 @@ jobs:
     name: Test changelog entries
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 1
     - id: master
       name: Get modified master changelog files
-      uses: Ana06/get-changed-files@v2.3.0
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c #v2.3.0
       with:
         filter: '*.changes'
     - name: Fail if the master changelog files are modified
@@ -42,7 +42,7 @@ jobs:
     - id: changelogs
       name: Get modified changelog files
       if: "!contains(github.event.pull_request.body, '[x] No changelog needed')"
-      uses: Ana06/get-changed-files@v2.3.0
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c #v2.3.0
       with:
         filter: '*.changes.*'
     - name: Fail if no changelog entries are added
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Remind the author with a comment
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: |

--- a/.github/workflows/check_l10n.yml
+++ b/.github/workflows/check_l10n.yml
@@ -17,11 +17,11 @@ jobs:
     name: localizable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Check localizable strings
         shell: bash -x {0}
         run: ./check_localizable
-      - uses: cbosdo/gettext-go-lint@gettext-go-lint-0.1.1-0
+      - uses: cbosdo/gettext-go-lint@118d756ec8dc7b45cd5e560dcaaecf45fd17d891 # gettext-go-lint-0.1.1-0
         name: Localizable strings linter
         with:
           keywords: L,NL,PL

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,13 +19,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version: '1.22'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea #v6.5.1
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/prebuilt_devcontainer.yml
+++ b/.github/workflows/prebuilt_devcontainer.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Compute tag for devcontainer image
         id: meta
@@ -27,7 +27,7 @@ jobs:
          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,6 +18,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v5
+      uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 #v5.0.0

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version: '1.22'
           check-latest: true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

# Description

One of the recommendations of the [Good security practices for using GitHub Actions features](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started).

For each action I went to the repository and used the last released version for the major version we were using, and specified the exact version with a comment.

## Codespace
Not needed

## Test coverage
- No tests: Adjusting Git Workflows

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
