### PR TITLE
Add gpg list command

### DIFF
--- a/mgradm/cmd/gpg/gpg.go
+++ b/mgradm/cmd/gpg/gpg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +7,7 @@ package gpg
 import (
 	"github.com/spf13/cobra"
 	gpgadd "github.com/uyuni-project/uyuni-tools/mgradm/cmd/gpg/add"
+	gpglist "github.com/uyuni-project/uyuni-tools/mgradm/cmd/gpg/list"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
@@ -21,6 +22,7 @@ func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	}
 
 	gpgKeyCmd.AddCommand(gpgadd.NewCommand(globalFlags))
+	gpgKeyCmd.AddCommand(gpglist.NewCommand(globalFlags))
 
 	return gpgKeyCmd
 }

--- a/mgradm/cmd/gpg/list/gpg.go
+++ b/mgradm/cmd/gpg/list/gpg.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpglist
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+const customKeyringPath = "/var/spacewalk/gpg/customer-build-keys.gpg"
+const systemKeyringPath = "/usr/lib/susemanager/susemanager-build-keys.gpg"
+
+type gpgListFlags struct {
+	Backend string
+	System  bool
+}
+
+func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[gpgListFlags]) *cobra.Command {
+	gpgListKeyCmd := &cobra.Command{
+		Use:   "list",
+		Short: L("List GPG keys"),
+		Long:  L("List GPG keys from custom keyring (default) or system keyring"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags gpgListFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
+		},
+	}
+
+	gpgListKeyCmd.Flags().BoolP("system", "s", false, L("List keys from system keyring"))
+	utils.AddBackendFlag(gpgListKeyCmd)
+	return gpgListKeyCmd
+}
+
+// NewCommand lists imported gpg keys.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	return newCmd(globalFlags, gpgListKeys)
+}
+
+func gpgListKeys(_ *types.GlobalFlags, flags *gpgListFlags, _ *cobra.Command, _ []string) error {
+	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
+
+	gpgListCmd := []string{"gpg", "--no-default-keyring", "--keyring"}
+
+	if flags.System {
+		gpgListCmd = append(gpgListCmd, systemKeyringPath, "--list-keys")
+	} else {
+		gpgListCmd = append(gpgListCmd, customKeyringPath, "--list-keys")
+	}
+
+	log.Info().Msgf(L("Running %s"), strings.Join(gpgListCmd, " "))
+	if err := adm_utils.ExecCommand(
+		zerolog.InfoLevel, cnx, gpgListCmd...,
+	); err != nil {
+		return utils.Errorf(err, L("failed to list keys in selected keyring"))
+	}
+
+	return nil
+}

--- a/mgradm/cmd/gpg/list/gpg_test.go
+++ b/mgradm/cmd/gpg/list/gpg_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpglist
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+func TestParamsParsing(t *testing.T) {
+	args := []string{
+		"--system",
+		"--backend", "kubectl",
+	}
+
+	// Test function asserting that the args are properly parsed
+	tester := func(_ *types.GlobalFlags, flags *gpgListFlags, _ *cobra.Command, _ []string) error {
+		testutils.AssertTrue(t, "Error parsing --system", flags.System)
+		testutils.AssertEquals(t, "Error parsing --backend", "kubectl", flags.Backend)
+		return nil
+	}
+
+	globalFlags := types.GlobalFlags{}
+	cmd := newCmd(&globalFlags, tester)
+
+	testutils.AssertHasAllFlags(t, cmd, args)
+
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("command failed with error: %s", err)
+	}
+}

--- a/uyuni-tools.changes.symorglass.gpg-list-command
+++ b/uyuni-tools.changes.symorglass.gpg-list-command
@@ -1,0 +1,1 @@
+- add gpg list command to mgradm


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

 This PR adds list command to gpg. The list command allows user to:

- list gpg keys from the custom keyring (default)
- list gpg keys from the system keyring with the `--system` flag

I will be working on the rm command shortly. 

## Test coverage

- Unit test to make sure the flags work as expected
- Integration test in the container environment, what I did:
  - generated a test gpg key and exported it
  - used mgradm add to add the key to the custom keyring
  - verified the list command works with all flag combinations

This is the test output:
Note: I don't have system keys now, so it is not listing any keys.


<img width="766" alt="Integration_test_v2" src="https://github.com/user-attachments/assets/6dfd02a8-59ae-479b-859f-7836acd20c35" />

- [X] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/269

- [ ] **DONE** (partially done)

## Changelogs

Changelog added

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
