### PR TITLE
Remove the dependency to slices package

### DIFF
--- a/mgradm/shared/podman/startstop.go
+++ b/mgradm/shared/podman/startstop.go
@@ -5,13 +5,12 @@
 package podman
 
 import (
-	"errors"
-
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 func StartServices() error {
-	return errors.Join(
+	return utils.JoinErrors(
 		systemd.StartService(podman.DBService),
 		systemd.StartInstantiated(podman.ServerAttestationService),
 		systemd.StartInstantiated(podman.HubXmlrpcService),
@@ -20,7 +19,7 @@ func StartServices() error {
 }
 
 func StopServices() error {
-	return errors.Join(
+	return utils.JoinErrors(
 		systemd.StopInstantiated(podman.ServerAttestationService),
 		systemd.StopInstantiated(podman.HubXmlrpcService),
 		systemd.StopService(podman.ServerService),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Debian 12 only ships go 1.19 in it's official repositories and the slices package came with go 1.21. Since removing this dependency is easy, let's get the Debian 12 build go green again.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
