### PR TITLE
Bump the default tag to 5.1.0-beta2

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -24,7 +24,7 @@ if [ "${OSCAPI}" == "https://api.suse.de" ]; then
   esac
 
 # Define the default tag to use
-  sed 's/^tag=%{!?_default_tag:latest}/tag=5.1.0-beta1/' -i ${SRPM_PKG_DIR}/uyuni-tools.spec
+  sed 's/^tag=%{!?_default_tag:latest}/tag=5.1.0-beta2/' -i ${SRPM_PKG_DIR}/uyuni-tools.spec
 
   sed "s/namespace='%{_default_namespace}'/namespace='%{_default_namespace}\/%{_arch}'/" -i ${SRPM_PKG_DIR}/uyuni-tools.spec
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

* Bump the default tag to 5.1.0-beta2
* No changelog needed. No need  to  pollute the  changelog  with this  info.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: this is the internal script that defines the default tag.  it doesn't have  additional tests.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26778

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
