### PR TITLE
Fix the distro path in cobbler files after migration

### DIFF
--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -153,8 +153,7 @@ func installForPodman(
 
 	if flags.Saline.Replicas > 0 {
 		if err := saline.SetupSalineContainer(
-			systemd, authFile, flags.Image.Registry, flags.Saline, flags.Image,
-			flags.Installation.TZ, flags.Podman.Args,
+			systemd, authFile, flags.Image.Registry, flags.Saline, flags.Image, flags.Installation.TZ,
 		); err != nil {
 			return err
 		}

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -602,7 +602,7 @@ func Migrate(
 	}
 
 	if err := saline.Upgrade(systemd, authFile, registry, salineFlags, image,
-		utils.GetLocalTimezone(), viper.GetStringSlice("podman.arg"),
+		utils.GetLocalTimezone(), podmanArgs.Args,
 	); err != nil {
 		return utils.Errorf(err, L("error upgrading saline service."))
 	}

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/coco"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/hub"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/pgsql"
@@ -439,9 +438,7 @@ func Upgrade(
 		return err
 	}
 
-	if err := saline.Upgrade(systemd, authFile, registry, salineFlags, image,
-		utils.GetLocalTimezone(), viper.GetStringSlice("podman.arg"),
-	); err != nil {
+	if err := saline.Upgrade(systemd, authFile, registry, salineFlags, image, utils.GetLocalTimezone()); err != nil {
 		return utils.Errorf(err, L("error upgrading saline service."))
 	}
 
@@ -601,9 +598,7 @@ func Migrate(
 		return err
 	}
 
-	if err := saline.Upgrade(systemd, authFile, registry, salineFlags, image,
-		utils.GetLocalTimezone(), podmanArgs.Args,
-	); err != nil {
+	if err := saline.Upgrade(systemd, authFile, registry, salineFlags, image, utils.GetLocalTimezone()); err != nil {
 		return utils.Errorf(err, L("error upgrading saline service."))
 	}
 

--- a/mgradm/shared/saline/saline.go
+++ b/mgradm/shared/saline/saline.go
@@ -25,10 +25,9 @@ func Upgrade(
 	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
 	tz string,
-	podmanArgs []string,
 ) error {
 	if err := writeSalineServiceFiles(
-		systemd, authFile, registry, salineFlags, baseImage, tz, podmanArgs,
+		systemd, authFile, registry, salineFlags, baseImage, tz,
 	); err != nil {
 		return err
 	}
@@ -49,7 +48,6 @@ func writeSalineServiceFiles(
 	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
 	tz string,
-	podmanArgs []string,
 ) error {
 	image := salineFlags.Image
 
@@ -106,8 +104,7 @@ func writeSalineServiceFiles(
 	}
 
 	config := fmt.Sprintf(`Environment=TZ=%s
-Environment="PODMAN_EXTRA_ARGS=%s"
-`, strings.TrimSpace(tz), strings.Join(podmanArgs, " "))
+`, strings.TrimSpace(tz))
 
 	if err := podman.GenerateSystemdConfFile(podman.SalineService, "custom.conf",
 		config, false); err != nil {
@@ -128,11 +125,8 @@ func SetupSalineContainer(
 	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
 	tz string,
-	podmanArgs []string,
 ) error {
-	if err := writeSalineServiceFiles(
-		systemd, authFile, registry, salineFlags, baseImage, tz, podmanArgs,
-	); err != nil {
+	if err := writeSalineServiceFiles(systemd, authFile, registry, salineFlags, baseImage, tz); err != nil {
 		return err
 	}
 	return systemd.EnableService(podman.SalineService)

--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -112,6 +112,10 @@ while IFS="," read -r target path ; do
     echo "Copying distribution $target from $path"
     mkdir -p "/srv/www/distributions/$target"
     rsync --delete -e "$SSH" --rsync-path='sudo rsync' -avz "{{ .SourceFqdn }}:$path/" "/srv/www/distributions/$target"
+	# Adjust cobbler distro configuration
+	for config in $(grep "$path/" -r /var/lib/cobbler/collections/distros/ -l); do
+		sed "s|$path/|/srv/www/distributions/$target/|g" -i $config
+	done
   else
     echo "Skipping missing distribution $path..."
   fi

--- a/uyuni-tools.changes.cbosdo.cobbler-distro-path-fix
+++ b/uyuni-tools.changes.cbosdo.cobbler-distro-path-fix
@@ -1,0 +1,2 @@
+- Adjust the distro path in cobbler files after migration
+  (bsc#1238929)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

During the migration, the autoinstallation distro path are standardized. However the path needs to be changed in the cobbler distro configuration file too. Otherwise cobbler will fail to load the distro and then the profiles and some of the data would be lost after a cobbler-sync task run. (bsc#1238929)

## Test coverage
- No tests: migration script cannot be unit tested

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26675
Port(s): https://github.com/SUSE/uyuni-tools/pull/70

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
