### PR TITLE
Add --pullPolicy to mgradm support ptf podman command

### DIFF
--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -41,6 +41,7 @@ NOTE: for now installing on a remote podman is not supported!
 		},
 	}
 
+	adm_utils.AddSCCFlag(podmanCmd)
 	utils.AddPTFFlag(podmanCmd)
 	utils.AddPullPolicyFlag(podmanCmd)
 

--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -42,6 +42,7 @@ NOTE: for now installing on a remote podman is not supported!
 	}
 
 	utils.AddPTFFlag(podmanCmd)
+	utils.AddPullPolicyFlag(podmanCmd)
 
 	return podmanCmd
 }

--- a/mgradm/cmd/support/ptf/podman/podman_test.go
+++ b/mgradm/cmd/support/ptf/podman/podman_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 //go:build ptf
@@ -18,6 +18,7 @@ func TestParamsParsing(t *testing.T) {
 		"--ptf", "ptf123",
 		"--test", "test123",
 		"--user", "sccuser",
+		"--pullPolicy", "never",
 	}
 
 	// Test function asserting that the args are properly parsed
@@ -25,6 +26,7 @@ func TestParamsParsing(t *testing.T) {
 		testutils.AssertEquals(t, "Error parsing --ptf", "ptf123", flags.PTFId)
 		testutils.AssertEquals(t, "Error parsing --test", "test123", flags.TestID)
 		testutils.AssertEquals(t, "Error parsing --user", "sccuser", flags.CustomerID)
+		testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.Image.PullPolicy)
 		return nil
 	}
 

--- a/mgradm/cmd/support/ptf/podman/podman_test.go
+++ b/mgradm/cmd/support/ptf/podman/podman_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils/flagstests"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
@@ -20,6 +21,7 @@ func TestParamsParsing(t *testing.T) {
 		"--user", "sccuser",
 		"--pullPolicy", "never",
 	}
+	args = append(args, flagstests.SCCFlagTestArgs...)
 
 	// Test function asserting that the args are properly parsed
 	tester := func(_ *types.GlobalFlags, flags *podmanPTFFlags, _ *cobra.Command, _ []string) error {
@@ -27,6 +29,7 @@ func TestParamsParsing(t *testing.T) {
 		testutils.AssertEquals(t, "Error parsing --test", "test123", flags.TestID)
 		testutils.AssertEquals(t, "Error parsing --user", "sccuser", flags.CustomerID)
 		testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.Image.PullPolicy)
+		flagstests.AssertSCCFlag(t, &flags.ServerFlags.Installation.SCC)
 		return nil
 	}
 

--- a/uyuni-tools.changes.cbosdo.ptf-pull-policy
+++ b/uyuni-tools.changes.cbosdo.ptf-pull-policy
@@ -1,0 +1,1 @@
+- Add mgradm support ptf podman --pullPolicy flag. (bsc#1236877)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Setting the pull policy to always or never could be useful when installing PTFs. (bsc#1236877)

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
