### PR TITLE
--no-rpm parameter doesn't exist anymore in rhn-ssl-tool

### DIFF
--- a/mgradm/shared/podman/ssl.go
+++ b/mgradm/shared/podman/ssl.go
@@ -358,7 +358,7 @@ const sslSetupServerScript = `
 
 	echo "Generating the self-signed SSL CA..."
 	mkdir -p /root/ssl-build
-	rhn-ssl-tool --gen-ca --no-rpm --force --dir /root/ssl-build \
+	rhn-ssl-tool --gen-ca --force --dir /root/ssl-build \
 		--password "$CERT_PASS" \
 		--set-country "$CERT_COUNTRY" --set-state "$CERT_STATE" --set-city "$CERT_CITY" \
 	    --set-org "$CERT_O" --set-org-unit "$CERT_OU" \
@@ -371,7 +371,7 @@ const sslSetupServerScript = `
 		cert_args="$cert_args --set-cname $CERT_CNAME"
 	done
 
-	rhn-ssl-tool --gen-server --no-rpm --cert-expiration 3650 \
+	rhn-ssl-tool --gen-server --cert-expiration 3650 \
 		--dir /root/ssl-build --password "$CERT_PASS" \
 		--set-country "$CERT_COUNTRY" --set-state "$CERT_STATE" --set-city "$CERT_CITY" \
 	    --set-org "$CERT_O" --set-org-unit "$CERT_OU" \
@@ -388,7 +388,7 @@ const sslSetupServerScript = `
 // this will need to be updated to include check for ca cert and build if needed.
 const sslSetupDatabaseScript = `
 	echo "Generating DB certificate..."
-	rhn-ssl-tool --gen-server --no-rpm --cert-expiration 3650 \
+	rhn-ssl-tool --gen-server --cert-expiration 3650 \
 		--dir /root/ssl-build --password "$CERT_PASS" \
 		--set-country "$CERT_COUNTRY" --set-state "$CERT_STATE" --set-city "$CERT_CITY" \
 	    --set-org "$CERT_O" --set-org-unit "$CERT_OU" \

--- a/uyuni-tools.changes.cbosdo.no-rpm
+++ b/uyuni-tools.changes.cbosdo.no-rpm
@@ -1,0 +1,2 @@
+-  Remove rhn-ssl-tool --gen-server RPM feature and options
+  (bsc#1235696)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

sister PR for https://github.com/uyuni-project/uyuni/pull/9622

## Test coverage
- No tests: covered by integration tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26194

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
