### PR TITLE
Fix build for locales missing the shared.po file

### DIFF
--- a/locale/build.sh
+++ b/locale/build.sh
@@ -16,7 +16,11 @@ for domain in mgrctl mgradm mgrpxy; do
         locale_dir=${PREFIX}${lang}/LC_MESSAGES
         install -vd -m 0755 ${locale_dir}
 
-        msgcat -o ${locale_dir}/${domain}.po ${po_file} ${locales_dir}/shared/${lang}.po
+        if test -e ${locales_dir}/shared/${lang}.po; then
+            msgcat -o ${locale_dir}/${domain}.po ${po_file} ${locales_dir}/shared/${lang}.po
+        else
+            cp ${po_file} ${locale_dir}/${domain}.po
+        fi
         msgfmt -c -o ${locale_dir}/${domain}.mo ${locale_dir}/${domain}.po
         if test $? -ne 0;
         then


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

In some early stages of localization the shared.po file may be missing. Make the build more lenient to not break in such cases.

## Test coverage
- No tests: locale build script change

- [x] **DONE**

## Links

Issue(s): #
Port: https://github.com/SUSE/uyuni-tools/pull/76

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
