### PR TITLE
Add saline and db image support to mgradm support ptf

### DIFF
--- a/mgradm/cmd/support/config/extractor.go
+++ b/mgradm/cmd/support/config/extractor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/mgradm/cmd/support/ptf/podman/utils_test.go
+++ b/mgradm/cmd/support/ptf/podman/utils_test.go
@@ -14,27 +14,35 @@ import (
 )
 
 func TestCheckParameters(t *testing.T) {
-	createServiceImages := func(image string, cocoImage string, hubImage string) map[string]string {
+	createServiceImages := func(
+		image string, cocoImage string, hubImage string, salineImage string, dbImage string,
+	) map[string]string {
 		return map[string]string{
 			podman.ServerService:                  image,
 			podman.ServerAttestationService + "@": cocoImage,
 			podman.HubXmlrpcService:               hubImage,
+			podman.SalineService:                  salineImage,
+			podman.DBService:                      dbImage,
 		}
 	}
 	type testData struct {
-		serviceImages     map[string]string
-		hasRemoteImages   map[string]bool
-		expectedImage     string
-		expectedCocoImage string
-		expectedHubImage  string
-		expectedError     string
+		serviceImages       map[string]string
+		hasRemoteImages     map[string]bool
+		expectedImage       string
+		expectedCocoImage   string
+		expectedHubImage    string
+		expectedSalineImage string
+		expectedDBImage     string
+		expectedError       string
 	}
 
 	data := []testData{
 		{
-			createServiceImages("registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0", "", ""),
+			createServiceImages("registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0", "", "", "", ""),
 			map[string]bool{},
 			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678",
+			"",
+			"",
 			"",
 			"",
 			"",
@@ -44,20 +52,28 @@ func TestCheckParameters(t *testing.T) {
 				"registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0",
 				"registry.suse.com/suse/manager/5.0/x86_64/server-attestation:5.0.0",
 				"registry.suse.com/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:5.0.0",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-saline:5.0.0",
+				"registry.suse.com/suse/manager/5.0/x86_64/server-postgresql:5.0.0",
 			),
 			map[string]bool{
 				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-attestation:latest-ptf-5678":    true,
 				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678": true,
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-saline:latest-ptf-5678":         true,
+				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-postgresql:latest-ptf-5678":     true,
 			},
 			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server:latest-ptf-5678",
 			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-attestation:latest-ptf-5678",
 			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678",
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-saline:latest-ptf-5678",
+			"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-postgresql:latest-ptf-5678",
 			"",
 		},
 		{
 			createServiceImages(
 				"registry.suse.com/suse/manager/5.0/x86_64/server:5.0.0",
 				"registry.suse.com/suse/manager/5.0/x86_64/server-attestation:5.0.0",
+				"",
+				"",
 				"",
 			),
 			map[string]bool{
@@ -68,16 +84,22 @@ func TestCheckParameters(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
+			"",
 		},
 		{
 			createServiceImages(
 				"",
 				"",
 				"registry.suse.com/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:5.0.0",
+				"",
+				"",
 			),
 			map[string]bool{
 				"registry.suse.com/a/1234/5678/suse/manager/5.0/x86_64/server-hub-xmlrpc-api:latest-ptf-5678": true,
 			},
+			"",
+			"",
 			"",
 			"",
 			"",
@@ -109,5 +131,7 @@ func TestCheckParameters(t *testing.T) {
 		testutils.AssertEquals(t, testCase+"unexpected image", test.expectedImage, flags.Image.Name)
 		testutils.AssertEquals(t, testCase+"unexpected coco image", test.expectedCocoImage, flags.Coco.Image.Name)
 		testutils.AssertEquals(t, testCase+"unexpected hub image", test.expectedHubImage, flags.HubXmlrpc.Image.Name)
+		testutils.AssertEquals(t, testCase+"unexpected saline image", test.expectedSalineImage, flags.Saline.Image.Name)
+		testutils.AssertEquals(t, testCase+"unexpected db image", test.expectedDBImage, flags.Pgsql.Image.Name)
 	}
 }

--- a/uyuni-tools.changes.cbosdo.saline-ptf
+++ b/uyuni-tools.changes.cbosdo.saline-ptf
@@ -1,0 +1,1 @@
+- Patch saline and database images if needed mgradm support ptf


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Applying PTF can also happen with the new Saline and DB container images.

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/566

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
