### PR TITLE
Use an openSUSE Tumbleweed as base for the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM mcr.microsoft.com/devcontainers/go:1.21
+FROM opensuse/tumbleweed:latest
+
+RUN set -euo pipefail; \
+    curl -o uyuni-tools.gpg https://build.opensuse.org/projects/systemsmanagement:Uyuni:Utils/signing_keys/download?kind=gpg && \
+    rpm --import uyuni-tools.gpg && \
+    zypper ar https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Utils/openSUSE_Tumbleweed/ uyuni-utils && \
+    zypper -n in go1.21 go1.21-doc golangci-lint git-core curl neovim python313-pre-commit python313 gpg2 \
+        sed grep gettext-tools util-linux less awk uyuni-releng-tools
+
+RUN set -euo pipefail; zypper -n clean -a; \
+    rm -rf {/target,}/var/log/{alternatives.log,lastlog,tallylog,zypper.log,zypp/history,YaST2}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,11 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 {
   "name": "uyuni-tools-devcontainer",
   "build": { "dockerfile": "Dockerfile" },
 
-  // Features to add to the dev container. More info: https://containers.dev/features.
-  "features": {
-    "ghcr.io/guiyomh/features/golangci-lint:0": {},
-    "ghcr.io/stuartleeks/dev-container-features/dev-tunnels:0": {},
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/duduribeiro/devcontainer-features/neovim:1": { "version": "nightly" },
-    "ghcr.io/devcontainers/features/python:1": {
-      "toolsToInstall": "pre-commit"
-    }
-  },
-
   // Configure tool-specific properties.
-  // "customizations": {},
-
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Using debian12 as the base for the dev container was causing issues with recent GPG keyrings. Use openSUSE Tumbleweed and packages from openSUSE to get safer and more up to date container.

## Test coverage
- No tests: dev container changes

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
