### PR TITLE
Fix mgradm start / stop to work with 5.0 for upgrade

### DIFF
--- a/check_localizable
+++ b/check_localizable
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 res=0
-grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir 'testutils' --exclude-dir='vendor' -n \
     -e 'fmt\.Errorf("[^"]\+"' \
     -e 'errors.New("[^"]\+"' \
     -e '\(Fatal\|Error\|Info\|Warn\)()\(\.Err(err)\)\?\.Msgf\?("' \
@@ -35,7 +35,7 @@ if test $res -ne 0; then
     res=1
 fi
 
-grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir 'testutils' --exclude-dir='vendor' -n \
     -e '\(Trace\|Debug\)()\(\.Err(err)\)\?\.Msgf\?(P\?N\?L("' \
 
 if test $? -eq 0; then
@@ -43,7 +43,7 @@ if test $? -eq 0; then
     res=1
 fi
 
-grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir='vendor' -n \
+grep -r . --include '*.go' --exclude '*_test.go' --exclude-dir 'testutils' --exclude-dir='vendor' -n \
     -e '\(Short\|Long\): \+P\?N\?L(["`][a-z]'
 if test $? -eq 0; then
     echo -e "Short and Long messages shouldn't start with a lowercase letter\n"

--- a/mgradm/cmd/backup/create/systemd_utils.go
+++ b/mgradm/cmd/backup/create/systemd_utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func exportSystemdConfiguration(outputDir string, dryRun bool) error {
 	filesToBackup := gatherSystemdItems()

--- a/mgradm/cmd/backup/restore/restore.go
+++ b/mgradm/cmd/backup/restore/restore.go
@@ -24,7 +24,7 @@ import (
 
 var runCmdInput = utils.RunCmdInput
 var runCmd = utils.RunCmd
-var systemd = podman.SystemdImpl{}
+var systemd = podman.NewSystemd()
 
 func Restore(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -26,7 +26,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd shared_podman.Systemd = shared_podman.SystemdImpl{}
+var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
 func installForPodman(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -17,7 +17,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman_utils.Systemd = podman_utils.SystemdImpl{}
+var systemd podman_utils.Systemd = podman_utils.NewSystemd()
 
 func migrateToPodman(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/restart/podman.go
+++ b/mgradm/cmd/restart/podman.go
@@ -11,7 +11,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanRestart(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/scale/podman.go
+++ b/mgradm/cmd/scale/podman.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanScale(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/status/podman.go
+++ b/mgradm/cmd/status/podman.go
@@ -16,7 +16,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanStatus(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/support/config/extractor.go
+++ b/mgradm/cmd/support/config/extractor.go
@@ -17,7 +17,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func filesRemover(files []string) {
 	for _, file := range files {

--- a/mgradm/cmd/support/ptf/podman/utils.go
+++ b/mgradm/cmd/support/ptf/podman/utils.go
@@ -18,7 +18,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman_shared.Systemd = podman_shared.SystemdImpl{}
+var systemd podman_shared.Systemd = podman_shared.NewSystemd()
 
 func ptfForPodman(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/uninstall/podman.go
+++ b/mgradm/cmd/uninstall/podman.go
@@ -13,7 +13,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func uninstallForPodman(
 	_ *types.GlobalFlags,

--- a/mgradm/cmd/upgrade/podman/utils.go
+++ b/mgradm/cmd/upgrade/podman/utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd shared_podman.Systemd = shared_podman.SystemdImpl{}
+var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
 func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.Command, _ []string) error {
 	hostData, err := shared_podman.InspectHost()

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 // GetExposedPorts returns the port exposed.
 func GetExposedPorts(debug bool) []types.PortMap {

--- a/mgradm/shared/podman/startstop.go
+++ b/mgradm/shared/podman/startstop.go
@@ -10,21 +10,39 @@ import (
 )
 
 func StartServices() error {
-	return utils.JoinErrors(
-		systemd.StartService(podman.DBService),
+	var dbErr error
+	if systemd.HasService(podman.DBService) {
+		dbErr = systemd.StartService(podman.DBService)
+	}
+	errs := utils.JoinErrors(
+		dbErr,
 		systemd.StartInstantiated(podman.ServerAttestationService),
 		systemd.StartInstantiated(podman.HubXmlrpcService),
 		systemd.StartInstantiated(podman.SalineService),
 		systemd.StartService(podman.ServerService),
 	)
+
+	if systemd.HasService(podman.SalineService + "@") {
+		errs = utils.JoinErrors(errs, systemd.StartInstantiated(podman.SalineService))
+	}
+
+	return errs
 }
 
 func StopServices() error {
-	return utils.JoinErrors(
+	errs := utils.JoinErrors(
 		systemd.StopInstantiated(podman.ServerAttestationService),
 		systemd.StopInstantiated(podman.HubXmlrpcService),
 		systemd.StopInstantiated(podman.SalineService),
 		systemd.StopService(podman.ServerService),
-		systemd.StopService(podman.DBService),
 	)
+
+	if systemd.HasService(podman.DBService) {
+		errs = utils.JoinErrors(errs, systemd.StopService(podman.DBService))
+	}
+
+	if systemd.HasService(podman.SalineService + "@") {
+		errs = utils.JoinErrors(errs, systemd.StopInstantiated(podman.SalineService))
+	}
+	return errs
 }

--- a/mgradm/shared/podman/startstop_test.go
+++ b/mgradm/shared/podman/startstop_test.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+var allServices = []string{
+	podman.ServerService,
+	podman.DBService,
+	podman.SalineService + "@",
+	podman.ServerAttestationService + "@",
+	podman.HubXmlrpcService + "@",
+}
+
+func TestStartServices(t *testing.T) {
+	cases := []struct {
+		installed          []string
+		enabled            []string
+		expectedStarted    []string
+		expectedNotStarted []string
+		startErrors        map[string]error
+		err                error
+	}{
+		// Regular case with only server and DB containers
+		{
+			installed:       allServices,
+			enabled:         []string{podman.ServerService, podman.DBService},
+			expectedStarted: []string{podman.ServerService, podman.DBService},
+			expectedNotStarted: []string{
+				podman.HubXmlrpcService + "@", podman.ServerAttestationService + "@",
+				podman.SalineService + "@",
+			},
+		},
+		// Regular case with an instance of all services.
+		{
+			installed: allServices,
+			enabled: []string{
+				podman.ServerService, podman.DBService,
+				podman.HubXmlrpcService + "@0", podman.ServerAttestationService + "@0", podman.SalineService + "@0",
+			},
+			expectedStarted: []string{
+				podman.ServerService, podman.DBService,
+				podman.HubXmlrpcService + "@0", podman.ServerAttestationService + "@0", podman.SalineService + "@0",
+			},
+			expectedNotStarted: []string{},
+		},
+		// In a migration from non-split DB to split DB we have no DB container yet
+		{
+			installed: []string{
+				podman.ServerService, podman.HubXmlrpcService + "@", podman.ServerAttestationService + "@",
+			},
+			enabled:         []string{podman.ServerService},
+			expectedStarted: []string{podman.ServerService},
+			expectedNotStarted: []string{
+				podman.HubXmlrpcService + "@", podman.ServerAttestationService + "@", podman.DBService,
+			},
+		},
+		// Error case where both the server and the DB service fail to start
+		{
+			installed: allServices,
+			enabled:   []string{podman.ServerService, podman.DBService},
+			expectedNotStarted: []string{
+				podman.ServerService, podman.DBService, podman.HubXmlrpcService + "@",
+				podman.ServerAttestationService + "@", podman.SalineService + "@",
+			},
+			startErrors: map[string]error{
+				podman.ServerService: errors.New("failed to start server"),
+				podman.DBService:     errors.New("failed to start DB"),
+			},
+			err: errors.New("failed to start DB; failed to start server"),
+		},
+	}
+
+	for i, testCase := range cases {
+		driver := testutils.FakeSystemdDriver{
+			Installed:          testCase.installed,
+			Enabled:            testCase.enabled,
+			StartServiceErrors: testCase.startErrors,
+		}
+
+		systemd = podman.NewSystemdWithDriver(&driver)
+
+		err := StartServices()
+
+		prefix := fmt.Sprintf("case %d - ", i+1)
+		for _, service := range testCase.expectedStarted {
+			testutils.AssertContains(t, fmt.Sprintf("%s%s not started", prefix, service), driver.Running, service)
+		}
+		for _, service := range testCase.expectedNotStarted {
+			testutils.AssertNotContains(t, fmt.Sprintf("%s%s has been started", prefix, service), driver.Running, service)
+		}
+		testutils.AssertEquals(t, prefix+"unexpected error returned", testCase.err, err)
+	}
+}
+
+func TestStopServices(t *testing.T) {
+	cases := []struct {
+		installed          []string
+		enabled            []string
+		started            []string
+		expectedStarted    []string
+		expectedNotStarted []string
+		stopErrors         map[string]error
+		err                error
+	}{
+		// Regular case with only server and DB containers
+		{
+			installed: allServices,
+			enabled:   []string{podman.ServerService, podman.DBService},
+			started:   []string{podman.ServerService, podman.DBService},
+			expectedNotStarted: []string{
+				podman.ServerService, podman.DBService, podman.HubXmlrpcService + "@",
+				podman.ServerAttestationService + "@", podman.SalineService + "@",
+			},
+		},
+		// Regular case with an instance of all services.
+		{
+			installed: allServices,
+			enabled: []string{
+				podman.ServerService, podman.DBService,
+				podman.HubXmlrpcService + "@0", podman.ServerAttestationService + "@0", podman.SalineService + "@0",
+			},
+			started: []string{
+				podman.ServerService, podman.DBService,
+				podman.HubXmlrpcService + "@0", podman.ServerAttestationService + "@0", podman.SalineService + "@0",
+			},
+			expectedNotStarted: []string{
+				podman.ServerService, podman.DBService,
+				podman.HubXmlrpcService + "@0", podman.ServerAttestationService + "@0", podman.SalineService + "@0",
+			},
+		},
+		// In a migration from non-split DB to split DB we have no DB container yet
+		{
+			installed: []string{podman.ServerService, podman.HubXmlrpcService + "@", podman.ServerAttestationService + "@"},
+			enabled:   []string{podman.ServerService},
+			started:   []string{podman.ServerService},
+			expectedNotStarted: []string{
+				podman.ServerService, podman.HubXmlrpcService + "@", podman.ServerAttestationService + "@", podman.DBService,
+			},
+		},
+		// Error case where both the server and the DB service fail to start
+		{
+			installed:       allServices,
+			enabled:         []string{podman.ServerService, podman.DBService},
+			started:         []string{podman.ServerService, podman.DBService},
+			expectedStarted: []string{podman.ServerService, podman.DBService},
+			expectedNotStarted: []string{
+				podman.HubXmlrpcService + "@",
+				podman.ServerAttestationService + "@", podman.SalineService + "@",
+			},
+			stopErrors: map[string]error{
+				podman.ServerService: errors.New("failed to stop server"),
+				podman.DBService:     errors.New("failed to stop DB"),
+			},
+			err: errors.New("failed to stop server; failed to stop DB"),
+		},
+	}
+
+	for i, testCase := range cases {
+		driver := testutils.FakeSystemdDriver{
+			Installed:         testCase.installed,
+			Enabled:           testCase.enabled,
+			Running:           testCase.started,
+			StopServiceErrors: testCase.stopErrors,
+		}
+
+		systemd = podman.NewSystemdWithDriver(&driver)
+
+		err := StopServices()
+
+		prefix := fmt.Sprintf("case %d - ", i+1)
+		for _, service := range testCase.expectedStarted {
+			testutils.AssertContains(t, fmt.Sprintf("%s%s has been stopped", prefix, service), driver.Running, service)
+		}
+		for _, service := range testCase.expectedNotStarted {
+			testutils.AssertNotContains(t, fmt.Sprintf("%s%s has not been stopped", prefix, service), driver.Running, service)
+		}
+		testutils.AssertEquals(t, prefix+"unexpected error returned", testCase.err, err)
+	}
+}

--- a/mgradm/shared/utils/flags.go
+++ b/mgradm/shared/utils/flags.go
@@ -56,7 +56,7 @@ type InstallationFlags struct {
 	Organization string
 }
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 // CheckUpgradeParameters verifies the consistency of the parameters for upgrade and migrate commands.
 func (flags *InstallationFlags) CheckUpgradeParameters(cmd *cobra.Command, command string) {

--- a/mgrpxy/cmd/cache/podman.go
+++ b/mgrpxy/cmd/cache/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanCacheClear(
 	_ *types.GlobalFlags,

--- a/mgrpxy/cmd/install/podman/utils.go
+++ b/mgrpxy/cmd/install/podman/utils.go
@@ -17,7 +17,7 @@ import (
 	shared_utils "github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd shared_podman.Systemd = shared_podman.SystemdImpl{}
+var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
 // Start the proxy services.
 func startPod() error {

--- a/mgrpxy/cmd/logs/logs.go
+++ b/mgrpxy/cmd/logs/logs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +27,7 @@ type logsFlags struct {
 	Since      string
 }
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 // NewCommand to get the logs of the server.
 func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[logsFlags]) *cobra.Command {

--- a/mgrpxy/cmd/restart/podman.go
+++ b/mgrpxy/cmd/restart/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanRestart(
 	_ *types.GlobalFlags,

--- a/mgrpxy/cmd/start/podman.go
+++ b/mgrpxy/cmd/start/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanStart(
 	_ *types.GlobalFlags,

--- a/mgrpxy/cmd/status/status.go
+++ b/mgrpxy/cmd/status/status.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 type statusFlags struct {
 }

--- a/mgrpxy/cmd/stop/podman.go
+++ b/mgrpxy/cmd/stop/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func podmanStop(
 	_ *types.GlobalFlags,

--- a/mgrpxy/cmd/support/config/extractor.go
+++ b/mgrpxy/cmd/support/config/extractor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func extract(_ *types.GlobalFlags, flags *configFlags, _ *cobra.Command, _ []string) error {
 	// Copy the generated file locally

--- a/mgrpxy/cmd/support/ptf/podman/utils.go
+++ b/mgrpxy/cmd/support/ptf/podman/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 //go:build ptf
@@ -17,7 +17,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman_shared.Systemd = podman_shared.SystemdImpl{}
+var systemd podman_shared.Systemd = podman_shared.NewSystemd()
 
 func ptfForPodman(
 	globalFlags *types.GlobalFlags,

--- a/mgrpxy/cmd/uninstall/podman.go
+++ b/mgrpxy/cmd/uninstall/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +15,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func uninstallForPodman(
 	_ *types.GlobalFlags,

--- a/mgrpxy/cmd/upgrade/podman/utils.go
+++ b/mgrpxy/cmd/upgrade/podman/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-var systemd shared_podman.Systemd = shared_podman.SystemdImpl{}
+var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
 func upgradePodman(
 	globalFlags *types.GlobalFlags,

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -42,8 +42,9 @@ type Connection struct {
 // container is the name of a container to look for when detecting the command.
 // kubernetesFilter is a filter parameter to use to match a pod.
 func NewConnection(backend string, container string, kubernetesFilter string) *Connection {
+	systemd := podman.NewSystemd()
 	cnx := Connection{
-		backend: backend, container: container, kubernetesFilter: kubernetesFilter, systemd: new(podman.SystemdImpl),
+		backend: backend, container: container, kubernetesFilter: kubernetesFilter, systemd: systemd,
 	}
 
 	return &cnx

--- a/shared/podman/interfaces.go
+++ b/shared/podman/interfaces.go
@@ -71,9 +71,6 @@ type Systemd interface {
 	// StopInstantiated stops all replicas.
 	StopInstantiated(name string) error
 
-	// GetServicesFromSystemdFiles return the uyuni enabled services as string list.
-	GetServicesFromSystemdFiles(systemdFileList string) []string
-
 	// GetServiceProperty returns the value of a systemd service property.
 	GetServiceProperty(service string, property string) (string, error)
 }

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -37,28 +37,65 @@ const SalineService = "uyuni-saline"
 // ProxyService is the name of the systemd service for the proxy.
 const ProxyService = "uyuni-proxy-pod"
 
-// SystemdImpl implements the Systemd interface.
-type SystemdImpl struct {
+// Interface to perform systemd calls.
+// This is not meant to be used elsewhere than in the SystemdImpl class and the unit tests.
+type SystemdDriver interface {
+	// HasService returns if a systemd service is installed.
+	// name is the name of the service without the '.service' part.
+	HasService(name string) bool
+
+	// ServiceIsEnabled returns if a service is enabled
+	// name is the name of the service without the '.service' part.
+	ServiceIsEnabled(name string) bool
+
+	// DisableService disables a service
+	// name is the name of the service without the '.service' part.
+	DisableService(name string) error
+
+	// ReloadDaemon resets the failed state of services and reload the systemd daemon.
+	// If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
+	ReloadDaemon() error
+
+	// IsServiceRunning returns whether the systemd service is started or not.
+	IsServiceRunning(service string) bool
+
+	// RestartService restarts the systemd service.
+	RestartService(service string) error
+
+	// StartService starts the systemd service.
+	StartService(service string) error
+
+	// StopService starts the systemd service.
+	StopService(service string) error
+
+	// EnableService enables and starts a systemd service.
+	EnableService(service string) error
+
+	// GetServiceProperty returns the value of a systemd service property.
+	GetServiceProperty(service string, property string) (string, error)
+}
+
+type systemdDriverImpl struct {
 }
 
 // HasService returns if a systemd service is installed.
 // name is the name of the service without the '.service' part.
-func (s SystemdImpl) HasService(name string) bool {
+func (d *systemdDriverImpl) HasService(name string) bool {
 	err := utils.RunCmd("systemctl", "list-unit-files", name+".service")
 	return err == nil
 }
 
 // ServiceIsEnabled returns if a service is enabled
 // name is the name of the service without the '.service' part.
-func (s SystemdImpl) ServiceIsEnabled(name string) bool {
+func (d *systemdDriverImpl) ServiceIsEnabled(name string) bool {
 	err := utils.RunCmd("systemctl", "is-enabled", name+".service")
 	return err == nil
 }
 
 // DisableService disables a service
 // name is the name of the service without the '.service' part.
-func (s SystemdImpl) DisableService(name string) error {
-	if !s.ServiceIsEnabled(name) {
+func (d *systemdDriverImpl) DisableService(name string) error {
+	if !d.ServiceIsEnabled(name) {
 		log.Debug().Msgf("%s is already disabled.", name)
 		return nil
 	}
@@ -68,12 +105,66 @@ func (s SystemdImpl) DisableService(name string) error {
 	return nil
 }
 
-// GetServicePath return the path for a given service.
-func GetServicePath(name string) string {
-	return path.Join(servicesPath, name+".service")
+// ReloadDaemon resets the failed state of services and reload the systemd daemon.
+// If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
+func (d *systemdDriverImpl) ReloadDaemon() error {
+	err := utils.RunCmd("systemctl", "reset-failed")
+	if err != nil {
+		return errors.New(L("failed to reset-failed systemd"))
+	}
+	err = utils.RunCmd("systemctl", "daemon-reload")
+	if err != nil {
+		return errors.New(L("failed to reload systemd daemon"))
+	}
+	return nil
 }
 
-func (s SystemdImpl) GetServiceProperty(service string, property string) (string, error) {
+// IsServiceRunning returns whether the systemd service is started or not.
+func (d *systemdDriverImpl) IsServiceRunning(service string) bool {
+	cmd := exec.Command("systemctl", "is-active", "-q", service)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return cmd.ProcessState.ExitCode() == 0
+}
+
+// RestartService restarts the systemd service.
+func (d *systemdDriverImpl) RestartService(service string) error {
+	if err := utils.RunCmd("systemctl", "restart", service); err != nil {
+		return utils.Errorf(err, L("failed to restart systemd %s.service"), service)
+	}
+	return nil
+}
+
+// StartService starts the systemd service.
+func (d *systemdDriverImpl) StartService(service string) error {
+	if err := utils.RunCmd("systemctl", "start", service); err != nil {
+		return utils.Errorf(err, L("failed to start systemd %s.service"), service)
+	}
+	return nil
+}
+
+// StopService starts the systemd service.
+func (d *systemdDriverImpl) StopService(service string) error {
+	if err := utils.RunCmd("systemctl", "stop", service); err != nil {
+		return utils.Errorf(err, L("failed to stop systemd %s.service"), service)
+	}
+	return nil
+}
+
+// EnableService enables and starts a systemd service.
+func (d *systemdDriverImpl) EnableService(service string) error {
+	if d.ServiceIsEnabled(service) {
+		log.Debug().Msgf("%s is already enabled.", service)
+		return nil
+	}
+	if err := utils.RunCmd("systemctl", "enable", "--now", service); err != nil {
+		return utils.Errorf(err, L("failed to enable %s systemd service"), service)
+	}
+	return nil
+}
+
+func (d *systemdDriverImpl) GetServiceProperty(service string, property string) (string, error) {
 	serviceName := service
 	if strings.HasSuffix(service, "@") {
 		serviceName = service + "0"
@@ -83,6 +174,54 @@ func (s SystemdImpl) GetServiceProperty(service string, property string) (string
 		return "", utils.Errorf(err, L("Failed to get the %[1]s property from %[2]s service"), property, service)
 	}
 	return strings.TrimPrefix(strings.TrimSpace(string(out)), property+"="), nil
+}
+
+// NewSystemd returns a new Systemd instance.
+func NewSystemd() Systemd {
+	driver := systemdDriverImpl{}
+	return SystemdImpl{
+		driver: &driver,
+	}
+}
+
+// NewSystemdWithDriver returns a new Systemd instance with a custom driver.
+func NewSystemdWithDriver(driver SystemdDriver) Systemd {
+	return SystemdImpl{
+		driver: driver,
+	}
+}
+
+// SystemdImpl implements the Systemd interface.
+type SystemdImpl struct {
+	// driver actually calls the systemd executable.
+	driver SystemdDriver
+}
+
+// HasService returns if a systemd service is installed.
+// name is the name of the service without the '.service' part.
+func (s SystemdImpl) HasService(name string) bool {
+	return s.driver.HasService(name)
+}
+
+// ServiceIsEnabled returns if a service is enabled
+// name is the name of the service without the '.service' part.
+func (s SystemdImpl) ServiceIsEnabled(name string) bool {
+	return s.driver.ServiceIsEnabled(name)
+}
+
+// DisableService disables a service
+// name is the name of the service without the '.service' part.
+func (s SystemdImpl) DisableService(name string) error {
+	return s.driver.DisableService(name)
+}
+
+// GetServicePath return the path for a given service.
+func GetServicePath(name string) string {
+	return path.Join(servicesPath, name+".service")
+}
+
+func (s SystemdImpl) GetServiceProperty(service string, property string) (string, error) {
+	return s.driver.GetServiceProperty(service, property)
 }
 
 // GetServiceConfFolder return the conf folder for systemd services.
@@ -95,23 +234,6 @@ func GetServiceConfPath(name string) string {
 	return path.Join(GetServiceConfFolder(name), "generated.conf")
 }
 
-// GetServicesFromSystemdFiles return the uyuni enabled services as string list.
-func (s SystemdImpl) GetServicesFromSystemdFiles(systemdFileList string) []string {
-	services := strings.Replace(string(systemdFileList), "/etc/systemd/system/", "", -1)
-	services = strings.Replace(services, ".service", "", -1)
-	servicesList := strings.Split(strings.TrimSpace(services), "\n")
-
-	var trimmedServices []string
-	for _, service := range servicesList {
-		if s.ServiceIsEnabled(service) {
-			trimmedServices = append(trimmedServices, strings.TrimSpace(service))
-		} else {
-			log.Debug().Msgf("service %s is not enabled. Do not run any action on the container.", service)
-		}
-	}
-	return trimmedServices
-}
-
 // UninstallService stops and remove a systemd service.
 // If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
 func (s SystemdImpl) UninstallService(name string, dryRun bool) {
@@ -122,10 +244,9 @@ func (s SystemdImpl) UninstallService(name string, dryRun bool) {
 			log.Info().Msgf(L("Would run %s"), "systemctl disable --now "+name)
 		} else {
 			log.Info().Msgf(L("Disable %s service"), name)
-			// disable server
 			err := s.DisableService(name)
 			if err != nil {
-				log.Error().Err(err).Msgf(L("Failed to disable %s service"), name)
+				log.Error().Err(err).Send()
 			}
 		}
 		uninstallServiceFiles(name, dryRun)
@@ -201,61 +322,34 @@ func (s SystemdImpl) ReloadDaemon(dryRun bool) error {
 		log.Info().Msgf(L("Would run %s"), "systemctl reset-failed")
 		log.Info().Msgf(L("Would run %s"), "systemctl daemon-reload")
 	} else {
-		err := utils.RunCmd("systemctl", "reset-failed")
-		if err != nil {
-			return errors.New(L("failed to reset-failed systemd"))
-		}
-		err = utils.RunCmd("systemctl", "daemon-reload")
-		if err != nil {
-			return errors.New(L("failed to reload systemd daemon"))
-		}
+		return s.driver.ReloadDaemon()
 	}
 	return nil
 }
 
 // IsServiceRunning returns whether the systemd service is started or not.
 func (s SystemdImpl) IsServiceRunning(service string) bool {
-	cmd := exec.Command("systemctl", "is-active", "-q", service)
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-	return cmd.ProcessState.ExitCode() == 0
+	return s.driver.IsServiceRunning(service)
 }
 
 // RestartService restarts the systemd service.
 func (s SystemdImpl) RestartService(service string) error {
-	if err := utils.RunCmd("systemctl", "restart", service); err != nil {
-		return utils.Errorf(err, L("failed to restart systemd %s.service"), service)
-	}
-	return nil
+	return s.driver.RestartService(service)
 }
 
 // StartService starts the systemd service.
 func (s SystemdImpl) StartService(service string) error {
-	if err := utils.RunCmd("systemctl", "start", service); err != nil {
-		return utils.Errorf(err, L("failed to start systemd %s.service"), service)
-	}
-	return nil
+	return s.driver.StartService(service)
 }
 
 // StopService starts the systemd service.
 func (s SystemdImpl) StopService(service string) error {
-	if err := utils.RunCmd("systemctl", "stop", service); err != nil {
-		return utils.Errorf(err, L("failed to stop systemd %s.service"), service)
-	}
-	return nil
+	return s.driver.StopService(service)
 }
 
 // EnableService enables and starts a systemd service.
 func (s SystemdImpl) EnableService(service string) error {
-	if s.ServiceIsEnabled(service) {
-		log.Debug().Msgf("%s is already enabled.", service)
-		return nil
-	}
-	if err := utils.RunCmd("systemctl", "enable", "--now", service); err != nil {
-		return utils.Errorf(err, L("failed to enable %s systemd service"), service)
-	}
-	return nil
+	return s.driver.EnableService(service)
 }
 
 // StartInstantiated starts all replicas.
@@ -286,6 +380,40 @@ func (s SystemdImpl) StopInstantiated(service string) error {
 		errList = append(errList, err)
 	}
 	return utils.JoinErrors(errList...)
+}
+
+// CurrentReplicaCount returns the current enabled replica count for a template service
+// name is the name of the service without the '.service' part.
+func (s SystemdImpl) CurrentReplicaCount(name string) int {
+	count := 0
+	for s.ServiceIsEnabled(fmt.Sprintf("%s@%d", name, count)) {
+		count++
+	}
+	return count
+}
+
+// ScaleService scales a templated systemd service to the requested number of replicas.
+// name is the name of the service without the '.service' part.
+func (s SystemdImpl) ScaleService(replicas int, name string) error {
+	currentReplicas := s.CurrentReplicaCount(name)
+	if currentReplicas == replicas {
+		log.Info().Msgf(L("Service %[1]s already has %[2]d replicas."), name, currentReplicas)
+		return nil
+	}
+	log.Info().Msgf(L("Scale %[1]s from %[2]d to %[3]d replicas."), name, currentReplicas, replicas)
+	for i := currentReplicas; i < replicas; i++ {
+		serviceName := fmt.Sprintf("%s@%d", name, i)
+		if err := s.EnableService(serviceName); err != nil {
+			return utils.Errorf(err, L("cannot enable service"))
+		}
+	}
+	for i := replicas; i < currentReplicas; i++ {
+		serviceName := fmt.Sprintf("%s@%d", name, i)
+		if err := s.DisableService(serviceName); err != nil {
+			return utils.Errorf(err, L("cannot disable service"))
+		}
+	}
+	return s.RestartInstantiated(name)
 }
 
 // confHeader is the header for the generated systemd configuration files.
@@ -365,38 +493,4 @@ func CleanSystemdConfFile(serviceName string) error {
 	}
 
 	return nil
-}
-
-// CurrentReplicaCount returns the current enabled replica count for a template service
-// name is the name of the service without the '.service' part.
-func (s SystemdImpl) CurrentReplicaCount(name string) int {
-	count := 0
-	for s.ServiceIsEnabled(fmt.Sprintf("%s@%d", name, count)) {
-		count++
-	}
-	return count
-}
-
-// ScaleService scales a templated systemd service to the requested number of replicas.
-// name is the name of the service without the '.service' part.
-func (s SystemdImpl) ScaleService(replicas int, name string) error {
-	currentReplicas := s.CurrentReplicaCount(name)
-	if currentReplicas == replicas {
-		log.Info().Msgf(L("Service %[1]s already has %[2]d replicas."), name, currentReplicas)
-		return nil
-	}
-	log.Info().Msgf(L("Scale %[1]s from %[2]d to %[3]d replicas."), name, currentReplicas, replicas)
-	for i := currentReplicas; i < replicas; i++ {
-		serviceName := fmt.Sprintf("%s@%d", name, i)
-		if err := s.EnableService(serviceName); err != nil {
-			return utils.Errorf(err, L("cannot enable service"))
-		}
-	}
-	for i := replicas; i < currentReplicas; i++ {
-		serviceName := fmt.Sprintf("%s@%d", name, i)
-		if err := s.DisableService(serviceName); err != nil {
-			return utils.Errorf(err, L("cannot disable service"))
-		}
-	}
-	return s.RestartInstantiated(name)
 }

--- a/shared/podman/systemd_test.go
+++ b/shared/podman/systemd_test.go
@@ -96,7 +96,7 @@ Environment="PODMAN_EXTRA_ARGS="
 
 func TestGetServiceProperty(t *testing.T) {
 	newRunner = testutils.FakeRunnerGenerator("TestProperty=foo bar\n", nil)
-	tested := SystemdImpl{}
+	tested := NewSystemd()
 	actual, err := tested.GetServiceProperty("myservice", "TestProperty")
 	testutils.AssertTrue(t, "No error expected", err == nil)
 	testutils.AssertEquals(t, "Wrong expected property", "foo bar", actual)
@@ -104,7 +104,7 @@ func TestGetServiceProperty(t *testing.T) {
 
 func TestGetServicePropertyError(t *testing.T) {
 	newRunner = testutils.FakeRunnerGenerator("", errors.New("Test error"))
-	tested := SystemdImpl{}
+	tested := NewSystemd()
 	actual, err := tested.GetServiceProperty("myservice", "TestProperty")
 	testutils.AssertTrue(t, "Error message missing the root error message", strings.Contains(err.Error(), "Test error"))
 	testutils.AssertTrue(t, "Unexpected error description",

--- a/shared/testutils/asserts.go
+++ b/shared/testutils/asserts.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -46,6 +46,20 @@ func AssertHasAllFlagsIgnores(t *testing.T, cmd *cobra.Command, args []string, i
 // AssertHasAllFlags ensures that all the flags of a command are present in the args slice.
 func AssertHasAllFlags(t *testing.T, cmd *cobra.Command, args []string) {
 	AssertHasAllFlagsIgnores(t, cmd, args, []string{})
+}
+
+// AssertContains ensures a slice contains the expected value.
+func AssertContains(t *testing.T, message string, actual []string, expected string) {
+	if !contains(actual, expected) {
+		t.Error(message)
+	}
+}
+
+// AssertNotContains ensures a slice contains the expected value.
+func AssertNotContains(t *testing.T, message string, actual []string, expected string) {
+	if contains(actual, expected) {
+		t.Error(message)
+	}
 }
 
 // contains is copied from utils to avoid to dependency loop.

--- a/shared/testutils/systemd.go
+++ b/shared/testutils/systemd.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import (
+	"errors"
+	"fmt"
+)
+
+// FakeSystemdDriver is a dummy implementation of the systemd driver for unit tests.
+type FakeSystemdDriver struct {
+	// Installed is the slice of installed services.
+	// Instantiated services are to be listed with the trailing @.
+	Installed []string
+
+	// Enabled is the slice of enabled services.
+	// All the instances of the instantiated services need to be listed here.
+	Enabled []string
+
+	// Running is the slice of running services.
+	// All the instances of the instantiated services need to be listed here.
+	Running []string
+
+	// DisableServiceErrors maps an error with a service name to mock errors in DisableService.
+	DisableServiceErrors map[string]error
+
+	// EnableServiceErrors maps an error with a service name to mock errors in EnableService.
+	EnableServiceErrors map[string]error
+
+	// ReloadDaemonError is the error to return in ReloadDaemon.
+	ReloadDaemonError error
+
+	// RestartServiceErrors maps an error with a service name to mock errors in RestartService.
+	RestartServiceErrors map[string]error
+
+	// StartServiceErrors maps an error with a service name to mock errors in StartService.
+	StartServiceErrors map[string]error
+
+	// StopServiceErrors maps an error with a service name to mock errors in StopService.
+	StopServiceErrors map[string]error
+
+	// ServiceProperties maps all the properties of each service.
+	ServiceProperties map[string]map[string]string
+}
+
+// HasService returns if a systemd service is installed.
+// name is the name of the service without the '.service' part.
+func (d *FakeSystemdDriver) HasService(name string) bool {
+	return contains(d.Installed, name)
+}
+
+// ServiceIsEnabled returns if a service is enabled
+// name is the name of the service without the '.service' part.
+func (d *FakeSystemdDriver) ServiceIsEnabled(name string) bool {
+	return contains(d.Enabled, name)
+}
+
+// DisableService disables a service
+// name is the name of the service without the '.service' part.
+func (d *FakeSystemdDriver) DisableService(name string) error {
+	if !d.ServiceIsEnabled(name) {
+		return fmt.Errorf("%s service is not enabled", name)
+	}
+	err := d.DisableServiceErrors[name]
+	if err == nil {
+		d.Enabled = deleteItems(d.Enabled, name)
+	}
+	return err
+}
+
+// EnableService enables and starts a systemd service.
+func (d *FakeSystemdDriver) EnableService(service string) error {
+	err := d.EnableServiceErrors[service]
+	if err == nil && !contains(d.Enabled, service) {
+		d.Enabled = append(d.Enabled, service)
+	}
+	return err
+}
+
+// ReloadDaemon resets the failed state of services and reload the systemd daemon.
+// If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
+func (d *FakeSystemdDriver) ReloadDaemon() error {
+	return d.ReloadDaemonError
+}
+
+// IsServiceRunning returns whether the systemd service is started or not.
+func (d *FakeSystemdDriver) IsServiceRunning(service string) bool {
+	return contains(d.Running, service)
+}
+
+// RestartService restarts the systemd service.
+func (d *FakeSystemdDriver) RestartService(service string) error {
+	if !d.ServiceIsEnabled(service) {
+		return fmt.Errorf("%s service is not enabled", service)
+	}
+	err := d.RestartServiceErrors[service]
+	// Same implementation than start, may be this needs to be enhanced for unit tests observability
+	if err == nil && !contains(d.Running, service) {
+		d.Running = append(d.Running, service)
+	}
+	return err
+}
+
+// StartService starts the systemd service.
+func (d *FakeSystemdDriver) StartService(service string) error {
+	if !d.ServiceIsEnabled(service) {
+		return fmt.Errorf("%s service is not enabled", service)
+	}
+	err := d.StartServiceErrors[service]
+	if err == nil && !contains(d.Running, service) {
+		d.Running = append(d.Running, service)
+	}
+	return err
+}
+
+// StopService starts the systemd service.
+func (d *FakeSystemdDriver) StopService(service string) error {
+	if !d.ServiceIsEnabled(service) {
+		return fmt.Errorf("%s service is not enabled", service)
+	}
+	err := d.StopServiceErrors[service]
+	if err == nil {
+		d.Running = deleteItems(d.Running, service)
+	}
+	return err
+}
+
+// GetServiceProperty gets the value from the ServiceProperties structure.
+// An error is returned if either the service or property doesn't exist.
+func (d *FakeSystemdDriver) GetServiceProperty(service string, property string) (string, error) {
+	properties, exists := d.ServiceProperties[service]
+	if !exists {
+		return "", errors.New("no such service")
+	}
+	value, exists := properties[property]
+	if !exists {
+		return "", errors.New("no such property")
+	}
+	return value, nil
+}
+
+// deleteItems removes all items equal to needle in the slice.
+func deleteItems(slice []string, needle string) []string {
+	cleaned := []string{}
+	for _, item := range slice {
+		if item != needle {
+			cleaned = append(cleaned, item)
+		}
+	}
+	return cleaned
+}

--- a/uyuni-tools.changes.cbosdo.stop-fix
+++ b/uyuni-tools.changes.cbosdo.stop-fix
@@ -1,0 +1,1 @@
+- More fault tolerant mgradm stop (bsc#1243331)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

When upgrading from 5.0 to 5.1 mgradm is upgraded but the containers are still the old ones. mgradm stop and start need to handle the missing Saline and database containers in such a case. (bsc#1243331)

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27267

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
