### PR TITLE
during migration, check if backup is already existing  (bsc#1243105)

### DIFF
--- a/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
+++ b/mgradm/shared/templates/pgsqlVersionUpgradeScriptTemplate.go
@@ -24,6 +24,7 @@ echo "Testing presence of postgresql$OLD_VERSION..."
 test -d /usr/lib/postgresql$OLD_VERSION/bin
 
 echo "Create a backup at /var/lib/pgsql/data-backup..."
+test -d "/var/lib/pgsql/data-backup" && mv "/var/lib/pgsql/data-backup" "/var/lib/pgsql/data-backup-$(date '+%Y%m%d_%H%M%S')"
 mkdir -p /var/lib/pgsql/data-backup
 chown postgres:postgres /var/lib/pgsql/data-backup
 chmod 700 /var/lib/pgsql/data-backup

--- a/uyuni-tools.changes.mbussolotto.prevent
+++ b/uyuni-tools.changes.mbussolotto.prevent
@@ -1,0 +1,1 @@
+- during migration, check if backup is already existing (bsc#1243105)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

porting of https://github.com/SUSE/uyuni-tools/pull/77

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27206

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
