### PR TITLE
Fix migration of autoinstallable distributions (bsc#1243802)

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -565,7 +565,7 @@ func Migrate(
 
 	schemaUpdateRequired :=
 		oldPgVersion != newPgVersion
-	if err := RunPgsqlFinalizeScript(preparedServerImage, schemaUpdateRequired, false); err != nil {
+	if err := RunPgsqlFinalizeScript(preparedServerImage, schemaUpdateRequired, true); err != nil {
 		return utils.Errorf(err, L("cannot run PostgreSQL finalize script"))
 	}
 

--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -40,6 +40,9 @@ $SSH {{ .SourceFqdn }} "sudo systemctl stop postgresql.service"
 while IFS="," read -r target path ; do
   if $SSH -n {{ .SourceFqdn }} test -e "$path" ; then
     echo "-/ $path"
+
+    # protect the targets that can be already synced in --prepare phase
+    echo "P/ /srv/www/distributions/$target"
   fi
 done < distros > exclude_list
 

--- a/uyuni-tools.changes.nadvornik.migration-fix
+++ b/uyuni-tools.changes.nadvornik.migration-fix
@@ -1,0 +1,1 @@
+- Fix migration of autoinstallable distributions (bsc#1243802)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR fixes two issues:
- postgres finalize script was called incorrectly and the distro paths in db were not updated
- rsync with --delete deleted distros synced with --prepare option

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: manual testing

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27379
https://bugzilla.suse.com/show_bug.cgi?id=1243802

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
