### PR TITLE
Unify backup create and restore dryrun option case

### DIFF
--- a/mgradm/cmd/backup/backup.go
+++ b/mgradm/cmd/backup/backup.go
@@ -61,7 +61,7 @@ func newRestoreCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[shared.
 	restoreCmd.Flags().Bool("skipimages", false, L("Skip restore of container images"))
 	restoreCmd.Flags().Bool("skipconfig", false, L("Do not restore podman configuration. Defaults will be used"))
 	restoreCmd.Flags().Bool("restart", false, L("Restart service after restore is done"))
-	restoreCmd.Flags().Bool("dryRun", false, L("Print expected actions, but no action is done"))
+	restoreCmd.Flags().Bool("dryrun", false, L("Print expected actions, but no action is done"))
 	restoreCmd.Flags().Bool("force", false, L("Force overwrite of existing items"))
 	restoreCmd.Flags().Bool("continue", false, L("Skip existing items and restore the rest"))
 	restoreCmd.Flags().Bool("skipverify", false, L("Skip verification of the backup files"))

--- a/uyuni-tools.changes.mczernek.fix-backup-dryrun
+++ b/uyuni-tools.changes.mczernek.fix-backup-dryrun
@@ -1,0 +1,1 @@
+- Unify backup create and restore dryrun option case


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Unify the `dryrun` case, which is currently different for create and restore commands.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
