### PR TITLE
Use FQDN of the source to generate certificates during migration

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -323,6 +323,11 @@ func Upgrade(
 		return utils.Errorf(err, L("cannot setup network"))
 	}
 
+	fqdn, err := utils.GetFqdn([]string{})
+	if err != nil {
+		return err
+	}
+
 	preparedServerImage, preparedPgsqlImage, err := podman.PrepareImages(authFile, image, pgsqlFlags)
 	if err != nil {
 		return utils.Errorf(err, L("cannot prepare images"))
@@ -360,7 +365,7 @@ func Upgrade(
 			newPgVersion, oldPgVersion)
 
 		if err := configureSplitDBContainer(
-			preparedServerImage, preparedPgsqlImage, systemd, db, reportdb, ssl, tz); err != nil {
+			preparedServerImage, preparedPgsqlImage, systemd, db, reportdb, ssl, tz, fqdn); err != nil {
 			return utils.Errorf(err, L("cannot configure db container"))
 		}
 	}
@@ -564,7 +569,7 @@ func Migrate(
 	}
 
 	if err := configureSplitDBContainer(
-		preparedServerImage, preparedPgsqlImage, systemd, db, reportdb, ssl, tz); err != nil {
+		preparedServerImage, preparedPgsqlImage, systemd, db, reportdb, ssl, tz, sourceFqdn); err != nil {
 		return utils.Errorf(err, L("cannot configure db container"))
 	}
 
@@ -819,13 +824,9 @@ func configureSplitDBContainer(
 	reportdb adm_utils.DBFlags,
 	ssl adm_utils.InstallSSLFlags,
 	tz string,
+	fqdn string,
 ) error {
-	fqdn, err := utils.GetFqdn([]string{})
-	if err != nil {
-		return err
-	}
-
-	if err = PrepareSSLCertificates(serverImage, &ssl, tz, fqdn); err != nil {
+	if err := PrepareSSLCertificates(serverImage, &ssl, tz, fqdn); err != nil {
 		return err
 	}
 

--- a/uyuni-tools.changes.oholecek.fix_migration_fqdn
+++ b/uyuni-tools.changes.oholecek.fix_migration_fqdn
@@ -1,0 +1,2 @@
+- Use FQDN of the source to generate certificates during migration
+  (bsc#1244847)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

We do not support server rename during the migration, so in case original certificates are not found, we must use original FQDN as certificates CN.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27579

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
