### PR TITLE
Third party SSL certificates parameters improvements

### DIFF
--- a/mgradm/cmd/install/podman/podman.go
+++ b/mgradm/cmd/install/podman/podman.go
@@ -37,6 +37,15 @@ NOTE: installing on a remote podman is not supported yet!
 				flags.ServerFlags.Coco.IsChanged = v.IsSet("coco.replicas")
 				flags.ServerFlags.HubXmlrpc.IsChanged = v.IsSet("hubxmlrpc.replicas")
 				flags.ServerFlags.Saline.IsChanged = v.IsSet("saline.replicas") || v.IsSet("saline.port")
+
+				if flags.Installation.SSL.Ca.IsThirdParty() && !flags.Installation.SSL.DB.CA.IsThirdParty() {
+					flags.Installation.SSL.DB.CA.Root = flags.Installation.SSL.Ca.Root
+					flags.Installation.SSL.DB.CA.Intermediate = flags.Installation.SSL.Ca.Intermediate
+				}
+				if flags.Installation.SSL.Server.IsDefined() && !flags.Installation.SSL.DB.IsDefined() {
+					flags.Installation.SSL.DB.Cert = flags.Installation.SSL.Server.Cert
+					flags.Installation.SSL.DB.Key = flags.Installation.SSL.Server.Key
+				}
 			}
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, flagsUpdater, run)
 		},

--- a/mgradm/cmd/install/podman/podman_test.go
+++ b/mgradm/cmd/install/podman/podman_test.go
@@ -104,3 +104,30 @@ func TestParamsNoConfig(t *testing.T) {
 		t.Errorf("command failed with error: %s", err)
 	}
 }
+
+func TestSSLCAParams(t *testing.T) {
+	tester := func(_ *types.GlobalFlags, flags *podmanInstallFlags,
+		_ *cobra.Command, _ []string,
+	) error {
+		DBSSL := flags.ServerFlags.Installation.SSL.DB
+		testutils.AssertTrue(t, "SSL DB CA flags not reused", DBSSL.CA.IsThirdParty())
+		testutils.AssertEquals(t, "Wrong SSL DB CA root", "path/to/ca.crt", DBSSL.CA.Root)
+		testutils.AssertEquals(t, "Wrong SSL DB intermediate cert", "path/to/intermediate0.crt", DBSSL.CA.Intermediate[0])
+		testutils.AssertEquals(t, "Wrong SSL DB server cert", "path/to/srv.crt", DBSSL.Cert)
+		testutils.AssertEquals(t, "Wrong SSL DB server key", "path/to/srv.key", DBSSL.Key)
+		return nil
+	}
+
+	globalFlags := types.GlobalFlags{}
+	cmd := newCmd(&globalFlags, tester)
+
+	cmd.SetArgs([]string{"srv.fq.dn",
+		"--ssl-ca-root", "path/to/ca.crt",
+		"--ssl-ca-intermediate", "path/to/intermediate0.crt",
+		"--ssl-server-cert", "path/to/srv.crt",
+		"--ssl-server-key", "path/to/srv.key",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("command failed with error: %s", err)
+	}
+}

--- a/mgradm/shared/podman/ssl.go
+++ b/mgradm/shared/podman/ssl.go
@@ -418,7 +418,7 @@ const sslSetupDatabaseScript = `
 		--dir /root/ssl-build --password "$CERT_PASS" \
 		--set-country "$CERT_COUNTRY" --set-state "$CERT_STATE" --set-city "$CERT_CITY" \
 	    --set-org "$CERT_O" --set-org-unit "$CERT_OU" \
-	    --set-hostname reportdb.mgr.internal --cert-expiration 3650 --set-email "$CERT_EMAIL" \
+	    --cert-expiration 3650 --set-email "$CERT_EMAIL" \
 		--set-cname reportdb --set-cname db $cert_args
 
 	cp /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT /ssl/ca.crt

--- a/uyuni-tools.changes.cbosdo.ssl-ca
+++ b/uyuni-tools.changes.cbosdo.ssl-ca
@@ -1,0 +1,2 @@
+- If no DB SSL CA parameter is given, use the other one
+  (bsc#1245120)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

If the SSL DB CA chain and certificate parameters are missing but third party certificates parameters are set for apache, then reuse them. (bsc#1245120)

Also ensure that the FQDN, db and reportdb hostnames are set on the certificates.

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27583

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
