### PR TITLE
Reload systemctl daemon after refreshing the uyuni-server service

### DIFF
--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -418,6 +418,10 @@ func Upgrade(
 		return err
 	}
 
+	if err := systemd.ReloadDaemon(false); err != nil {
+		return err
+	}
+
 	log.Info().Msg(L("Waiting for the server to start…"))
 	cnx := shared.NewConnection("podman", podman.ServerContainerName, "")
 	if err := systemd.StartService(podman.ServerService); err != nil {

--- a/uyuni-tools.changes.cbosdo.daemon-reload
+++ b/uyuni-tools.changes.cbosdo.daemon-reload
@@ -1,0 +1,2 @@
+- Reload systemd daemon before starting the uyuni-server during an
+  upgrade (bsc#1245779)


### PR DESCRIPTION
## What does this PR change?

When upgrading from a single container to a split DB setup, the uyuni-server service is regenerated to remove the port 5432.

If the systemctl daemon is not reloaded, the old definition of the service will be started and fail since that port is now already in use by the uyuni-db container.

## Test coverage
- No tests: requires end to end tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27710

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
