### PR TITLE
refactoring registry: authentication and simplify behaviour

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,6 @@ linters-settings:
 
 linters:
   enable:
-    - unused
     - dupl
     - errcheck
     - errname

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/creack/pty v1.1.18 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/mgradm/cmd/inspect/inspect_test.go
+++ b/mgradm/cmd/inspect/inspect_test.go
@@ -27,6 +27,7 @@ func TestParamsParsing(t *testing.T) {
 	// Test function asserting that the args are properly parsed
 	tester := func(_ *types.GlobalFlags, flags *inspectFlags, _ *cobra.Command, _ []string) error {
 		flagstests.AssertImageFlag(t, &flags.Image)
+		flagstests.AssertRegistryFlag(t, &flags.Image.Registry)
 		flagstests.AssertSCCFlag(t, &flags.SCC)
 		flagstests.AssertPgsqlFlag(t, &flags.Pgsql)
 		if utils.KubernetesBuilt {

--- a/mgradm/cmd/inspect/kubernetes.go
+++ b/mgradm/cmd/inspect/kubernetes.go
@@ -47,7 +47,7 @@ func kuberneteInspect(
 	}
 
 	// Get the SCC credentials secret if existing
-	pullSecret, err := kubernetes.GetRegistrySecret(namespace, &types.SCCCredentials{}, kubernetes.ServerApp)
+	pullSecret, err := kubernetes.GetRegistrySecret(namespace, &types.Registry{}, kubernetes.ServerApp)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/inspect/podman.go
+++ b/mgradm/cmd/inspect/podman.go
@@ -50,7 +50,8 @@ func podmanInspect(
 		}
 	}
 
-	preparedServerImage, preparedDBImage, err := prepareImages(serverImage, pgsqlImage, flags.Image.PullPolicy, flags.SCC)
+	preparedServerImage, preparedDBImage, err :=
+		prepareImages(serverImage, pgsqlImage, flags.Image.PullPolicy, flags.Image.Registry)
 	if err != nil {
 		return err
 	}
@@ -70,14 +71,14 @@ func podmanInspect(
 }
 
 func prepareImages(
-	server string, pgsql string, pullPolicy string, scc types.SCCCredentials,
+	server string, pgsql string, pullPolicy string, registry types.Registry,
 ) (serverImage string, dbImage string, err error) {
 	hostData, err := podman.InspectHost()
 	if err != nil {
 		return "", "", err
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, scc)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, registry)
 	if err != nil {
 		return "", "", utils.Errorf(err, L("failed to login to registry.suse.com"))
 	}

--- a/mgradm/cmd/inspect/podman.go
+++ b/mgradm/cmd/inspect/podman.go
@@ -51,7 +51,7 @@ func podmanInspect(
 	}
 
 	preparedServerImage, preparedDBImage, err :=
-		prepareImages(serverImage, pgsqlImage, flags.Image.PullPolicy, flags.Image.Registry)
+		prepareImages(serverImage, pgsqlImage, flags.Image.PullPolicy, flags.Image.Registry, flags.SCC)
 	if err != nil {
 		return err
 	}
@@ -71,16 +71,16 @@ func podmanInspect(
 }
 
 func prepareImages(
-	server string, pgsql string, pullPolicy string, registry types.Registry,
+	server string, pgsql string, pullPolicy string, registry types.Registry, scc types.SCCCredentials,
 ) (serverImage string, dbImage string, err error) {
 	hostData, err := podman.InspectHost()
 	if err != nil {
 		return "", "", err
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, registry)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, registry, scc)
 	if err != nil {
-		return "", "", utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return "", "", utils.Errorf(err, L("failed to login to %s"), registry.Host)
 	}
 	defer cleaner()
 

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -39,9 +39,14 @@ func installForPodman(
 		return err
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Installation.SCC)
+	flags.Installation.CheckParameters(cmd, "podman")
+	if _, err := exec.LookPath("podman"); err != nil {
+		return errors.New(L("install podman before running this command"))
+	}
+
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry)
 	if err != nil {
-		return utils.Error(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 
@@ -50,12 +55,6 @@ func installForPodman(
 			L("Server is already initialized! Uninstall before attempting new installation or use upgrade command"),
 		)
 	}
-
-	flags.Installation.CheckParameters(cmd, "podman")
-	if _, err := exec.LookPath("podman"); err != nil {
-		return errors.New(L("install podman before running this command"))
-	}
-
 	fqdn, err := utils.GetFqdn(args)
 	if err != nil {
 		return err
@@ -138,20 +137,20 @@ func installForPodman(
 	}
 
 	if err := coco.SetupCocoContainer(
-		systemd, authFile, flags.Image.Registry, flags.Coco, flags.Image,
+		systemd, authFile, flags.Coco, flags.Image,
 		flags.Installation.DB,
 	); err != nil {
 		return err
 	}
 
 	if err := hub.SetupHubXmlrpc(
-		systemd, authFile, flags.Image.Registry, flags.Image.PullPolicy, flags.Image.Tag, flags.HubXmlrpc,
+		systemd, authFile, flags.Image, flags.HubXmlrpc,
 	); err != nil {
 		return err
 	}
 
 	if err := saline.SetupSalineContainer(
-		systemd, authFile, flags.Image.Registry, flags.Saline, flags.Image, flags.Installation.TZ,
+		systemd, authFile, flags.Image, flags.Saline, flags.Installation.TZ,
 	); err != nil {
 		return err
 	}

--- a/mgradm/cmd/install/podman/utils.go
+++ b/mgradm/cmd/install/podman/utils.go
@@ -44,7 +44,7 @@ func installForPodman(
 		return errors.New(L("install podman before running this command"))
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry, flags.Installation.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/migrate/kubernetes/utils.go
+++ b/mgradm/cmd/migrate/kubernetes/utils.go
@@ -23,9 +23,10 @@ const migrationDataPvcName = "migration-data"
 func migrateToKubernetes(
 	_ *types.GlobalFlags,
 	flags *kubernetes.KubernetesServerFlags,
-	_ *cobra.Command,
+	cmd *cobra.Command,
 	args []string,
 ) error {
+	flags.Installation.CheckUpgradeParameters(cmd, "kubectl")
 	namespace := flags.Kubernetes.Uyuni.Namespace
 
 	// Create the namespace if not present
@@ -38,7 +39,7 @@ func migrateToKubernetes(
 		return err
 	}
 
-	serverImage, err := utils.ComputeImage(flags.Image.Registry, utils.DefaultTag, flags.Image)
+	serverImage, err := utils.ComputeImage(flags.Image.Registry.Host, utils.DefaultTag, flags.Image)
 	if err != nil {
 		return utils.Errorf(err, L("failed to compute image URL"))
 	}
@@ -61,7 +62,7 @@ func migrateToKubernetes(
 
 	// Create a secret using SCC credentials if any are provided
 	pullSecret, err := shared_kubernetes.GetRegistrySecret(
-		flags.Kubernetes.Uyuni.Namespace, &flags.Installation.SCC, shared_kubernetes.ServerApp,
+		flags.Kubernetes.Uyuni.Namespace, &flags.Image.Registry, shared_kubernetes.ServerApp,
 	)
 	if err != nil {
 		return err

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -29,7 +29,7 @@ func migrateToPodman(
 		return err
 	}
 
-	authFile, cleaner, err := podman_utils.PodmanLogin(hostData, flags.Image.Registry)
+	authFile, cleaner, err := podman_utils.PodmanLogin(hostData, flags.Image.Registry, flags.Installation.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/migrate/podman/utils.go
+++ b/mgradm/cmd/migrate/podman/utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
-	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 var systemd podman_utils.Systemd = podman_utils.NewSystemd()
@@ -30,9 +29,9 @@ func migrateToPodman(
 		return err
 	}
 
-	authFile, cleaner, err := podman_utils.PodmanLogin(hostData, flags.Installation.SCC)
+	authFile, cleaner, err := podman_utils.PodmanLogin(hostData, flags.Image.Registry)
 	if err != nil {
-		return utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 
@@ -43,7 +42,6 @@ func migrateToPodman(
 
 	return podman.Migrate(
 		systemd, authFile,
-		flags.Image.Registry,
 		flags.Installation.DB,
 		flags.Installation.ReportDB,
 		flags.Installation.SSL,

--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -17,9 +17,10 @@ import (
 type podmanPTFFlags struct {
 	adm_utils.ServerFlags `mapstructure:",squash"`
 	Podman                podman.PodmanFlags
-	PTFId                 string `mapstructure:"ptf"`
-	TestID                string `mapstructure:"test"`
-	CustomerID            string `mapstructure:"user"`
+	PTFId                 string               `mapstructure:"ptf"`
+	TestID                string               `mapstructure:"test"`
+	CustomerID            string               `mapstructure:"user"`
+	SCC                   types.SCCCredentials `mapstructure:"scc"`
 }
 
 func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[podmanPTFFlags]) *cobra.Command {

--- a/mgradm/cmd/support/ptf/podman/podman.go
+++ b/mgradm/cmd/support/ptf/podman/podman.go
@@ -45,6 +45,7 @@ NOTE: for now installing on a remote podman is not supported!
 	adm_utils.AddSCCFlag(podmanCmd)
 	utils.AddPTFFlag(podmanCmd)
 	utils.AddPullPolicyFlag(podmanCmd)
+	utils.AddRegistryFlag(podmanCmd)
 
 	return podmanCmd
 }

--- a/mgradm/cmd/support/ptf/podman/podman_test.go
+++ b/mgradm/cmd/support/ptf/podman/podman_test.go
@@ -20,6 +20,10 @@ func TestParamsParsing(t *testing.T) {
 		"--test", "test123",
 		"--user", "sccuser",
 		"--pullPolicy", "never",
+		"--registry", "myOldRegistry",
+		"--registry-host", "myoverwrittenregistry",
+		"--registry-user", "user",
+		"--registry-password", "password",
 	}
 	args = append(args, flagstests.SCCFlagTestArgs...)
 
@@ -29,6 +33,8 @@ func TestParamsParsing(t *testing.T) {
 		testutils.AssertEquals(t, "Error parsing --test", "test123", flags.TestID)
 		testutils.AssertEquals(t, "Error parsing --user", "sccuser", flags.CustomerID)
 		testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.Image.PullPolicy)
+		testutils.AssertEquals(t, "Error parsing --registry", "myOldRegistry", flags.Image.Registry.Host)
+		flagstests.AssertRegistryFlag(t, &flags.ServerFlags.Image.Registry)
 		flagstests.AssertSCCFlag(t, &flags.ServerFlags.Installation.SCC)
 		return nil
 	}

--- a/mgradm/cmd/support/ptf/podman/utils.go
+++ b/mgradm/cmd/support/ptf/podman/utils.go
@@ -32,7 +32,7 @@ func ptfForPodman(
 		return err
 	}
 
-	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.Image.Registry)
+	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.Image.Registry, flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/support/ptf/podman/utils_test.go
+++ b/mgradm/cmd/support/ptf/podman/utils_test.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"testing"
 
+	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
 func TestCheckParameters(t *testing.T) {
@@ -118,6 +120,13 @@ func TestCheckParameters(t *testing.T) {
 		flags := podmanPTFFlags{
 			PTFId:      "5678",
 			CustomerID: "1234",
+			ServerFlags: adm_utils.ServerFlags{
+				Image: types.ImageFlags{
+					Registry: types.Registry{
+						Host: "registry.suse.com/suse/manager/5.0/x86_64/",
+					},
+				},
+			},
 		}
 		testCase := fmt.Sprintf("case #%d - ", i+1)
 		actualError := flags.checkParameters()

--- a/mgradm/cmd/upgrade/kubernetes/utils.go
+++ b/mgradm/cmd/upgrade/kubernetes/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,8 +15,9 @@ import (
 func upgradeKubernetes(
 	_ *types.GlobalFlags,
 	flags *kubernetes.KubernetesServerFlags,
-	_ *cobra.Command,
+	cmd *cobra.Command,
 	_ []string,
 ) error {
+	flags.Installation.CheckUpgradeParameters(cmd, "kubectl")
 	return kubernetes.Reconcile(flags, "")
 }

--- a/mgradm/cmd/upgrade/podman/podman.go
+++ b/mgradm/cmd/upgrade/podman/podman.go
@@ -68,7 +68,7 @@ func listTags(flags *podmanUpgradeFlags) error {
 		return err
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Image.Registry)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Image.Registry, flags.Installation.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/upgrade/podman/podman.go
+++ b/mgradm/cmd/upgrade/podman/podman.go
@@ -68,13 +68,13 @@ func listTags(flags *podmanUpgradeFlags) error {
 		return err
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Installation.SCC)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Image.Registry)
 	if err != nil {
-		return utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 
-	return podman.ShowAvailableTag(flags.Image.Registry, flags.Image, authFile)
+	return podman.ShowAvailableTag(flags.Image.Registry.Host, flags.Image, authFile)
 }
 
 // NewCommand to upgrade a podman server.

--- a/mgradm/cmd/upgrade/podman/utils.go
+++ b/mgradm/cmd/upgrade/podman/utils.go
@@ -23,7 +23,7 @@ func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.C
 		return err
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry, flags.Installation.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgradm/cmd/upgrade/podman/utils.go
+++ b/mgradm/cmd/upgrade/podman/utils.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	shared_podman "github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
-	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 var systemd shared_podman.Systemd = shared_podman.NewSystemd()
@@ -24,9 +23,9 @@ func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.C
 		return err
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Installation.SCC)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Image.Registry)
 	if err != nil {
-		return utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 
@@ -37,7 +36,6 @@ func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.C
 
 	return podman.Upgrade(
 		systemd, authFile,
-		flags.Image.Registry,
 		flags.Installation.DB,
 		flags.Installation.ReportDB,
 		flags.Installation.SSL,

--- a/mgradm/shared/coco/coco.go
+++ b/mgradm/shared/coco/coco.go
@@ -20,7 +20,6 @@ import (
 func Upgrade(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
 	cocoFlags adm_utils.CocoFlags,
 	baseImage types.ImageFlags,
 	db adm_utils.DBFlags,
@@ -38,7 +37,7 @@ func Upgrade(
 	}
 
 	if err := writeCocoServiceFiles(
-		systemd, authFile, registry, cocoFlags, baseImage, db,
+		systemd, authFile, cocoFlags, baseImage, db,
 	); err != nil {
 		return err
 	}
@@ -52,7 +51,6 @@ func Upgrade(
 func writeCocoServiceFiles(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
 	cocoFlags adm_utils.CocoFlags,
 	baseImage types.ImageFlags,
 	db adm_utils.DBFlags,
@@ -74,7 +72,7 @@ func writeCocoServiceFiles(
 		log.Debug().Msg("No Confidential Computing requested.")
 	}
 
-	cocoImage, err := utils.ComputeImage(registry, baseImage.Tag, image)
+	cocoImage, err := utils.ComputeImage(baseImage.Registry.Host, baseImage.Tag, image)
 	if err != nil {
 		return utils.Errorf(err, L("failed to compute image URL"))
 	}
@@ -121,13 +119,12 @@ Environment=database_connection=jdbc:postgresql://%s:%d/%s
 func SetupCocoContainer(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
 	coco adm_utils.CocoFlags,
 	baseImage types.ImageFlags,
 	db adm_utils.DBFlags,
 ) error {
 	if err := writeCocoServiceFiles(
-		systemd, authFile, registry, coco, baseImage, db,
+		systemd, authFile, coco, baseImage, db,
 	); err != nil {
 		return err
 	}

--- a/mgradm/shared/kubernetes/dbUpgradeJob.go
+++ b/mgradm/shared/kubernetes/dbUpgradeJob.go
@@ -26,7 +26,6 @@ const DBUpgradeJobName = "uyuni-db-upgrade"
 // StartDBUpgradeJob starts the database upgrade job.
 func StartDBUpgradeJob(
 	namespace string,
-	registry string,
 	image types.ImageFlags,
 	migrationImage types.ImageFlags,
 	pullSecret string,
@@ -39,9 +38,9 @@ func StartDBUpgradeJob(
 	var err error
 	if migrationImage.Name == "" {
 		imageName := fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql)
-		migrationImageURL, err = utils.ComputeImage(registry, image.Tag, image, imageName)
+		migrationImageURL, err = utils.ComputeImage(image.Registry.Host, image.Tag, image, imageName)
 	} else {
-		migrationImageURL, err = utils.ComputeImage(registry, image.Tag, migrationImage)
+		migrationImageURL, err = utils.ComputeImage(image.Registry.Host, image.Tag, migrationImage)
 	}
 	if err != nil {
 		return "", utils.Error(err, L("failed to compute image URL"))

--- a/mgradm/shared/kubernetes/reconcile.go
+++ b/mgradm/shared/kubernetes/reconcile.go
@@ -33,14 +33,14 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 		return err
 	}
 
-	serverImage, err := utils.ComputeImage(flags.Image.Registry, utils.DefaultTag, flags.Image)
+	serverImage, err := utils.ComputeImage(flags.Image.Registry.Host, utils.DefaultTag, flags.Image)
 	if err != nil {
 		return utils.Error(err, L("failed to compute image URL"))
 	}
 
 	// Create a secret using SCC credentials if any are provided
 	pullSecret, err := kubernetes.GetRegistrySecret(
-		flags.Kubernetes.Uyuni.Namespace, &flags.Installation.SCC, kubernetes.ServerApp,
+		flags.Kubernetes.Uyuni.Namespace, &flags.Image.Registry, kubernetes.ServerApp,
 	)
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 		// Run the DB Upgrade job if needed
 		if oldPgVersion < newPgVersion {
 			jobName, err := StartDBUpgradeJob(
-				namespace, flags.Image.Registry, flags.Image, flags.DBUpgradeImage, pullSecret,
+				namespace, flags.Image.Registry.Host, flags.Image, flags.DBUpgradeImage, pullSecret,
 				oldPgVersion, newPgVersion,
 			)
 			if err != nil {
@@ -300,7 +300,7 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 			}
 			kubernetes.WaitForSecret(namespace, DBAdminSecret)
 
-			dbImage, err := utils.ComputeImage(flags.Image.Registry, utils.DefaultTag, flags.Pgsql.Image)
+			dbImage, err := utils.ComputeImage(flags.Image.Registry.Host, utils.DefaultTag, flags.Pgsql.Image)
 			if err != nil {
 				return utils.Error(err, L("failed to compute image URL"))
 			}
@@ -371,7 +371,7 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 		flags.Coco.Replicas = replicas
 	}
 	if flags.Coco.Replicas > 0 {
-		cocoImage, err := utils.ComputeImage(flags.Image.Registry, flags.Image.Tag, flags.Coco.Image)
+		cocoImage, err := utils.ComputeImage(flags.Image.Registry.Host, flags.Image.Tag, flags.Coco.Image)
 		if err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 	// In an operator mind, the user would just change the custom resource to enable the feature.
 	if needsHub {
 		// Install Hub API deployment, service
-		hubAPIImage, err := utils.ComputeImage(flags.Image.Registry, flags.Image.Tag, flags.HubXmlrpc.Image)
+		hubAPIImage, err := utils.ComputeImage(flags.Image.Registry.Host, flags.Image.Tag, flags.HubXmlrpc.Image)
 		if err != nil {
 			return err
 		}

--- a/mgradm/shared/kubernetes/reconcile.go
+++ b/mgradm/shared/kubernetes/reconcile.go
@@ -144,7 +144,7 @@ func Reconcile(flags *KubernetesServerFlags, fqdn string) error {
 		// Run the DB Upgrade job if needed
 		if oldPgVersion < newPgVersion {
 			jobName, err := StartDBUpgradeJob(
-				namespace, flags.Image.Registry.Host, flags.Image, flags.DBUpgradeImage, pullSecret,
+				namespace, flags.Image, flags.DBUpgradeImage, pullSecret,
 				oldPgVersion, newPgVersion,
 			)
 			if err != nil {

--- a/mgradm/shared/pgsql/pgsql.go
+++ b/mgradm/shared/pgsql/pgsql.go
@@ -22,7 +22,7 @@ func PreparePgsqlImage(
 	globalImageFlags *types.ImageFlags,
 ) (string, error) {
 	image := pgsqlFlags.Image
-	pgsqlImage, err := utils.ComputeImage(globalImageFlags.Registry, globalImageFlags.Tag, image)
+	pgsqlImage, err := utils.ComputeImage(globalImageFlags.Registry.Host, globalImageFlags.Tag, image)
 
 	if err != nil {
 		return "", utils.Error(err, L("failed to compute image URL"))

--- a/mgradm/shared/saline/saline.go
+++ b/mgradm/shared/saline/saline.go
@@ -21,13 +21,12 @@ import (
 func Upgrade(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
-	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
+	salineFlags adm_utils.SalineFlags,
 	tz string,
 ) error {
 	if err := writeSalineServiceFiles(
-		systemd, authFile, registry, salineFlags, baseImage, tz,
+		systemd, authFile, baseImage, salineFlags, tz,
 	); err != nil {
 		return err
 	}
@@ -38,9 +37,8 @@ func Upgrade(
 func writeSalineServiceFiles(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
-	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
+	salineFlags adm_utils.SalineFlags,
 	tz string,
 ) error {
 	image := salineFlags.Image
@@ -66,7 +64,7 @@ func writeSalineServiceFiles(
 		salineFlags.Replicas = 1
 	}
 
-	salineImage, err := utils.ComputeImage(registry, baseImage.Tag, image)
+	salineImage, err := utils.ComputeImage(baseImage.Registry.Host, baseImage.Tag, image)
 	if err != nil {
 		return utils.Error(err, L("failed to compute image URL"))
 	}
@@ -118,12 +116,12 @@ func writeSalineServiceFiles(
 func SetupSalineContainer(
 	systemd podman.Systemd,
 	authFile string,
-	registry string,
-	salineFlags adm_utils.SalineFlags,
 	baseImage types.ImageFlags,
+	salineFlags adm_utils.SalineFlags,
 	tz string,
 ) error {
-	if err := writeSalineServiceFiles(systemd, authFile, registry, salineFlags, baseImage, tz); err != nil {
+	if err := writeSalineServiceFiles(systemd,
+		authFile, baseImage, salineFlags, tz); err != nil {
 		return err
 	}
 	return EnableSaline(systemd, salineFlags.Replicas)

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -188,8 +188,6 @@ It will be used as SCC credentials for products synchronization and to pull imag
 func AddImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("image", defaultImage, L("Image"))
 	cmd.Flags().String("tag", utils.DefaultTag, L("Tag Image"))
-	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
-	_ = cmd.Flags().MarkDeprecated("registry", "please use --registry-host instead")
 
 	utils.AddPullPolicyFlag(cmd)
 	utils.AddRegistryFlag(cmd)

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var defaultImage = path.Join(utils.DefaultRegistry, "server")
+var defaultImage = path.Join(utils.DefaultImagePrefix, "server")
 
 // UseProvided return true if server can use an SSL Cert provided by flags.
 func (f *InstallSSLFlags) UseProvided() bool {
@@ -123,7 +123,7 @@ func AddContainerImageFlags(
 	groupName string,
 	imageName string,
 ) {
-	defaultImage := path.Join(utils.DefaultRegistry, imageName)
+	defaultImage := path.Join(utils.DefaultImagePrefix, imageName)
 	cmd.Flags().String(container+"-image", defaultImage,
 		fmt.Sprintf(L("Image for %s container"), displayName))
 	cmd.Flags().String(container+"-tag", "",

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -176,10 +176,9 @@ func AddDBFlags(cmd *cobra.Command) {
 // AddSCCFlag add SCC flags to a command.
 func AddSCCFlag(cmd *cobra.Command) {
 	cmd.Flags().String("scc-user", "", L(`SUSE Customer Center username.
-It will be used as SCC credentials for products synchronization and to pull images from registry.suse.com`))
+It will be used as SCC credentials for products synchronization and to pull images from SCC registry`))
 	cmd.Flags().String("scc-password", "", L(`SUSE Customer Center password.
-It will be used as SCC credentials for products synchronization and to pull images from registry.suse.com`))
-
+It will be used as SCC credentials for products synchronization and to pull images from SCC registry`))
 	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "scc", Title: L("SUSE Customer Center Flags")})
 	_ = utils.AddFlagToHelpGroupID(cmd, "scc-user", "scc")
 	_ = utils.AddFlagToHelpGroupID(cmd, "scc-password", "scc")
@@ -188,16 +187,19 @@ It will be used as SCC credentials for products synchronization and to pull imag
 // AddImageFlag add Image flags to a command.
 func AddImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("image", defaultImage, L("Image"))
-	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
 	cmd.Flags().String("tag", utils.DefaultTag, L("Tag Image"))
 
 	utils.AddPullPolicyFlag(cmd)
+	utils.AddRegistryFlag(cmd)
 
 	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "image", Title: L("Image Flags")})
 	_ = utils.AddFlagToHelpGroupID(cmd, "image", "image")
-	_ = utils.AddFlagToHelpGroupID(cmd, "registry", "") // without group, since this flag is applied to all the images
 	_ = utils.AddFlagToHelpGroupID(cmd, "tag", "image")
-	_ = utils.AddFlagToHelpGroupID(cmd, "pullPolicy", "") // without group, since this flag is applied to all the images
+	// without group, since this flag is applied to all the images
+	_ = utils.AddFlagToHelpGroupID(cmd, "pullPolicy", "")
+	_ = utils.AddFlagToHelpGroupID(cmd, "registry-host", "")
+	_ = utils.AddFlagToHelpGroupID(cmd, "registry-user", "")
+	_ = utils.AddFlagToHelpGroupID(cmd, "registry-password", "")
 }
 
 // AddDBUpgradeImageFlag add Database upgrade image flags to a command.

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -188,6 +188,8 @@ It will be used as SCC credentials for products synchronization and to pull imag
 func AddImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("image", defaultImage, L("Image"))
 	cmd.Flags().String("tag", utils.DefaultTag, L("Tag Image"))
+	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
+	_ = cmd.Flags().MarkDeprecated("registry", "please use --registry-host instead")
 
 	utils.AddPullPolicyFlag(cmd)
 	utils.AddRegistryFlag(cmd)
@@ -197,9 +199,7 @@ func AddImageFlag(cmd *cobra.Command) {
 	_ = utils.AddFlagToHelpGroupID(cmd, "tag", "image")
 	// without group, since this flag is applied to all the images
 	_ = utils.AddFlagToHelpGroupID(cmd, "pullPolicy", "")
-	_ = utils.AddFlagToHelpGroupID(cmd, "registry-host", "")
-	_ = utils.AddFlagToHelpGroupID(cmd, "registry-user", "")
-	_ = utils.AddFlagToHelpGroupID(cmd, "registry-password", "")
+	_ = utils.AddFlagToHelpGroupID(cmd, "registry", "")
 }
 
 // AddDBUpgradeImageFlag add Database upgrade image flags to a command.

--- a/mgradm/shared/utils/flags.go
+++ b/mgradm/shared/utils/flags.go
@@ -50,7 +50,8 @@ type InstallationFlags struct {
 	DB           DBFlags
 	ReportDB     DBFlags
 	SSL          InstallSSLFlags
-	SCC          types.SCCCredentials
+	SCC          types.SCCCredentials `mapstructure:"scc"`
+	Registry     types.Registry
 	Debug        DebugFlags
 	Admin        apiTypes.User
 	Organization string
@@ -61,7 +62,6 @@ var systemd podman.Systemd = podman.NewSystemd()
 // CheckUpgradeParameters verifies the consistency of the parameters for upgrade and migrate commands.
 func (flags *InstallationFlags) CheckUpgradeParameters(cmd *cobra.Command, command string) {
 	flags.setPasswordIfMissing()
-
 	flags.checkUpgradeSSLParameters(cmd, command)
 }
 

--- a/mgradm/shared/utils/flags.go
+++ b/mgradm/shared/utils/flags.go
@@ -50,8 +50,7 @@ type InstallationFlags struct {
 	DB           DBFlags
 	ReportDB     DBFlags
 	SSL          InstallSSLFlags
-	SCC          types.SCCCredentials `mapstructure:"scc"`
-	Registry     types.Registry
+	SCC          types.SCCCredentials
 	Debug        DebugFlags
 	Admin        apiTypes.User
 	Organization string
@@ -62,6 +61,7 @@ var systemd podman.Systemd = podman.NewSystemd()
 // CheckUpgradeParameters verifies the consistency of the parameters for upgrade and migrate commands.
 func (flags *InstallationFlags) CheckUpgradeParameters(cmd *cobra.Command, command string) {
 	flags.setPasswordIfMissing()
+
 	flags.checkUpgradeSSLParameters(cmd, command)
 }
 

--- a/mgrpxy/cmd/install/kubernetes/utils.go
+++ b/mgrpxy/cmd/install/kubernetes/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -60,8 +60,8 @@ func installForKubernetes(_ *types.GlobalFlags,
 	}
 
 	helmArgs := []string{"--set", "ingress=" + clusterInfos.Ingress}
-	helmArgs, err = shared_kubernetes.AddSCCSecret(
-		helmArgs, flags.Helm.Proxy.Namespace, &flags.SCC, shared_kubernetes.ProxyApp,
+	helmArgs, err = shared_kubernetes.AddRegistry(
+		helmArgs, flags.Helm.Proxy.Namespace, &flags.Registry, shared_kubernetes.ProxyApp,
 	)
 	if err != nil {
 		return err

--- a/mgrpxy/cmd/install/podman/utils.go
+++ b/mgrpxy/cmd/install/podman/utils.go
@@ -59,9 +59,9 @@ func installForPodman(
 		}
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.SCC)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Registry)
 	if err != nil {
-		return shared_utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 

--- a/mgrpxy/cmd/install/podman/utils.go
+++ b/mgrpxy/cmd/install/podman/utils.go
@@ -59,7 +59,7 @@ func installForPodman(
 		}
 	}
 
-	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Registry)
+	authFile, cleaner, err := shared_podman.PodmanLogin(hostData, flags.Registry, flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/cmd/support/ptf/podman/podman.go
+++ b/mgrpxy/cmd/support/ptf/podman/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 //go:build ptf
@@ -16,6 +16,7 @@ import (
 
 type podmanPTFFlags struct {
 	UpgradeFlags podman.PodmanProxyFlags `mapstructure:",squash"`
+	SCC          types.SCCCredentials    `mapstructure:"scc"`
 	PTFId        string                  `mapstructure:"ptf"`
 	TestID       string                  `mapstructure:"test"`
 	CustomerID   string                  `mapstructure:"user"`

--- a/mgrpxy/cmd/support/ptf/podman/utils.go
+++ b/mgrpxy/cmd/support/ptf/podman/utils.go
@@ -43,7 +43,7 @@ func ptfForPodman(
 		return err
 	}
 
-	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.UpgradeFlags.Registry)
+	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.UpgradeFlags.Registry, flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/cmd/support/ptf/podman/utils.go
+++ b/mgrpxy/cmd/support/ptf/podman/utils.go
@@ -43,9 +43,9 @@ func ptfForPodman(
 		return err
 	}
 
-	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.UpgradeFlags.SCC)
+	authFile, cleaner, err := podman_shared.PodmanLogin(hostData, flags.UpgradeFlags.Registry)
 	if err != nil {
-		return utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 
@@ -118,7 +118,7 @@ func updateParameters(flags *podmanPTFFlags) error {
 		if err != nil {
 			return err
 		}
-		config.imageFlag.Name, err = utils.ComputePTF(flags.UpgradeFlags.ProxyImageFlags.Registry,
+		config.imageFlag.Name, err = utils.ComputePTF(flags.UpgradeFlags.Registry.Host,
 			flags.CustomerID, projectID, runningImage, suffix)
 		if err != nil {
 			return err

--- a/mgrpxy/shared/kubernetes/cmd.go
+++ b/mgrpxy/shared/kubernetes/cmd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,7 +20,7 @@ type HelmFlags struct {
 
 // AddHelmFlags add helm flags to a command.
 func AddHelmFlags(cmd *cobra.Command) {
-	defaultChart := fmt.Sprintf("oci://%s/proxy-helm", utils.DefaultHelmRegistry)
+	defaultChart := fmt.Sprintf("oci://%s/%s", utils.DefaultHelmRegistry, utils.DefaultProxyChart)
 
 	cmd.Flags().String("helm-proxy-namespace", "default", L("Kubernetes namespace where to install the proxy"))
 	cmd.Flags().String("helm-proxy-chart", defaultChart, L("URL to the proxy helm chart"))

--- a/mgrpxy/shared/kubernetes/deploy.go
+++ b/mgrpxy/shared/kubernetes/deploy.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/mgrpxy/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
 	shared_utils "github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
@@ -24,6 +25,7 @@ const helmAppName = "uyuni-proxy"
 // KubernetesProxyUpgradeFlags represents the flags for the mgrpxy upgrade kubernetes command.
 type KubernetesProxyUpgradeFlags struct {
 	utils.ProxyImageFlags `mapstructure:",squash"`
+	SCC                   types.SCCCredentials
 	Helm                  HelmFlags
 }
 
@@ -84,7 +86,7 @@ func Deploy(imageFlags *utils.ProxyImageFlags, helmFlags *HelmFlags, configDir s
 		"--set", "images.proxy-squid="+imageFlags.GetContainerImage("squid"),
 		"--set", "images.proxy-ssh="+imageFlags.GetContainerImage("ssh"),
 		"--set", "images.proxy-tftpd="+imageFlags.GetContainerImage("tftpd"),
-		"--set", "repository="+imageFlags.Registry,
+		"--set", "repository="+imageFlags.Registry.Host,
 		"--set", "version="+imageFlags.Tag,
 		"--set", "pullPolicy="+string(kubernetes.GetPullPolicy(imageFlags.PullPolicy)))
 

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -39,7 +39,6 @@ var newRunner = shared_utils.NewRunner
 // PodmanProxyFlags are the flags used by podman proxy install and upgrade command.
 type PodmanProxyFlags struct {
 	utils.ProxyImageFlags `mapstructure:",squash"`
-	SCC                   types.SCCCredentials
 	Podman                podman.PodmanFlags
 }
 
@@ -291,9 +290,9 @@ func Upgrade(
 		}
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.SCC)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Registry)
 	if err != nil {
-		return shared_utils.Errorf(err, L("failed to login to registry.suse.com"))
+		return err
 	}
 	defer cleaner()
 

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -290,7 +290,7 @@ func Upgrade(
 		}
 	}
 
-	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Registry)
+	authFile, cleaner, err := podman.PodmanLogin(hostData, flags.Registry, flags.SCC)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -17,6 +16,7 @@ import (
 
 // ProxyImageFlags are the flags used by install proxy command.
 type ProxyImageFlags struct {
+	Registry   types.Registry       `mapstructure:"registry"`
 	Tag        string               `mapstructure:"tag"`
 	PullPolicy string               `mapstructure:"pullPolicy"`
 	Httpd      types.ImageFlags     `mapstructure:"httpd"`
@@ -25,7 +25,6 @@ type ProxyImageFlags struct {
 	SSH        types.ImageFlags     `mapstructure:"ssh"`
 	Tftpd      types.ImageFlags     `mapstructure:"tftpd"`
 	Tuning     Tuning               `mapstructure:"tuning"`
-	Registry   types.Registry       `mapstructure:"registry"`
 	SCC        types.SCCCredentials `mapstructure:"scc"`
 }
 
@@ -76,6 +75,8 @@ func AddSCCFlag(cmd *cobra.Command) {
 // AddImageFlags will add the proxy install flags to a command.
 func AddImageFlags(cmd *cobra.Command) {
 	cmd.Flags().String("tag", utils.DefaultTag, L("image tag"))
+	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
+	_ = cmd.Flags().MarkDeprecated("registry", "please use --registry-host instead")
 	utils.AddPullPolicyFlag(cmd)
 
 	addContainerImageFlags(cmd, "httpd", "httpd")

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -17,15 +17,16 @@ import (
 
 // ProxyImageFlags are the flags used by install proxy command.
 type ProxyImageFlags struct {
-	Registry   string           `mapstructure:"registry"`
-	Tag        string           `mapstructure:"tag"`
-	PullPolicy string           `mapstructure:"pullPolicy"`
-	Httpd      types.ImageFlags `mapstructure:"httpd"`
-	SaltBroker types.ImageFlags `mapstructure:"saltBroker"`
-	Squid      types.ImageFlags `mapstructure:"squid"`
-	SSH        types.ImageFlags `mapstructure:"ssh"`
-	Tftpd      types.ImageFlags `mapstructure:"tftpd"`
-	Tuning     Tuning           `mapstructure:"tuning"`
+	Tag        string               `mapstructure:"tag"`
+	PullPolicy string               `mapstructure:"pullPolicy"`
+	Httpd      types.ImageFlags     `mapstructure:"httpd"`
+	SaltBroker types.ImageFlags     `mapstructure:"saltBroker"`
+	Squid      types.ImageFlags     `mapstructure:"squid"`
+	SSH        types.ImageFlags     `mapstructure:"ssh"`
+	Tftpd      types.ImageFlags     `mapstructure:"tftpd"`
+	Tuning     Tuning               `mapstructure:"tuning"`
+	Registry   types.Registry       `mapstructure:"registry"`
+	SCC        types.SCCCredentials `mapstructure:"scc"`
 }
 
 // Tuning are the custom configuration file provide by users.
@@ -52,7 +53,7 @@ func (f *ProxyImageFlags) GetContainerImage(name string) string {
 		log.Fatal().Msgf(L("Invalid proxy container name: %s"), name)
 	}
 
-	imageURL, err := utils.ComputeImage(f.Registry, f.Tag, *containerImage)
+	imageURL, err := utils.ComputeImage(f.Registry.Host, f.Tag, *containerImage)
 	if err != nil {
 		log.Fatal().Err(err).Msg(L("failed to compute image URL"))
 	}
@@ -62,12 +63,11 @@ func (f *ProxyImageFlags) GetContainerImage(name string) string {
 // AddSCCFlag add SCC flags to a command.
 func AddSCCFlag(cmd *cobra.Command) {
 	cmd.Flags().String("scc-user", "",
-		L("SUSE Customer Center username. It will be used to pull images from registry.suse.com"),
+		L("SUSE Customer Center username. It will be used to pull images from SCC registry"),
 	)
 	cmd.Flags().String("scc-password", "",
-		L("SUSE Customer Center password. It will be used to pull images from registry.suse.com"),
+		L("SUSE Customer Center password. It will be used to pull images from SCC registry"),
 	)
-
 	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "scc", Title: L("SUSE Customer Center Flags")})
 	_ = utils.AddFlagToHelpGroupID(cmd, "scc-user", "scc")
 	_ = utils.AddFlagToHelpGroupID(cmd, "scc-password", "scc")
@@ -76,7 +76,6 @@ func AddSCCFlag(cmd *cobra.Command) {
 // AddImageFlags will add the proxy install flags to a command.
 func AddImageFlags(cmd *cobra.Command) {
 	cmd.Flags().String("tag", utils.DefaultTag, L("image tag"))
-	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
 	utils.AddPullPolicyFlag(cmd)
 
 	addContainerImageFlags(cmd, "httpd", "httpd")
@@ -87,6 +86,7 @@ func AddImageFlags(cmd *cobra.Command) {
 
 	cmd.Flags().String("tuning-httpd", "", L("HTTPD tuning configuration file"))
 	cmd.Flags().String("tuning-squid", "", L("Squid tuning configuration file"))
+	utils.AddRegistryFlag(cmd)
 }
 
 func addContainerImageFlags(cmd *cobra.Command, paramName string, imageName string) {

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -91,7 +92,7 @@ func AddImageFlags(cmd *cobra.Command) {
 }
 
 func addContainerImageFlags(cmd *cobra.Command, paramName string, imageName string) {
-	defaultImage := path.Join(utils.DefaultRegistry, "proxy-"+imageName)
+	defaultImage := path.Join(utils.DefaultImagePrefix, "proxy-"+imageName)
 	cmd.Flags().String(paramName+"-image", defaultImage,
 		fmt.Sprintf(L("Image for %s container"), imageName))
 	cmd.Flags().String(paramName+"-tag", "",

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -76,8 +76,6 @@ func AddSCCFlag(cmd *cobra.Command) {
 // AddImageFlags will add the proxy install flags to a command.
 func AddImageFlags(cmd *cobra.Command) {
 	cmd.Flags().String("tag", utils.DefaultTag, L("image tag"))
-	cmd.Flags().String("registry", utils.DefaultRegistry, L("Specify a registry where to pull the images from"))
-	_ = cmd.Flags().MarkDeprecated("registry", "please use --registry-host instead")
 	utils.AddPullPolicyFlag(cmd)
 
 	addContainerImageFlags(cmd, "httpd", "httpd")

--- a/mgrpxy/shared/utils/flags_test.go
+++ b/mgrpxy/shared/utils/flags_test.go
@@ -23,8 +23,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "no image details",
 			proxyFlags: ProxyImageFlags{
-				Registry: "default/image",
-				Tag:      "tag",
+				Registry: types.Registry{
+					Host: "default/image",
+				},
+				Tag: "tag",
 				Httpd: types.ImageFlags{
 					Name: "",
 					Tag:  "",
@@ -35,8 +37,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "httpd image details overrule defaults",
 			proxyFlags: ProxyImageFlags{
-				Registry: "default/image",
-				Tag:      "tag",
+				Registry: types.Registry{
+					Host: "default/image",
+				},
+				Tag: "tag",
 				Httpd: types.ImageFlags{
 					Name: "default/image/proxy-httpd",
 					Tag:  "mytag",
@@ -49,8 +53,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "httpd image name overrule when contains full registry",
 			proxyFlags: ProxyImageFlags{
-				Registry: "default",
-				Tag:      "tag",
+				Registry: types.Registry{
+					Host: "default/image",
+				},
+				Tag: "tag",
 				Httpd: types.ImageFlags{
 					Name: "default/image/proxy-httpd",
 					Tag:  "mytag",
@@ -61,8 +67,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "httpd image name is appended to registry when it does not include registry",
 			proxyFlags: ProxyImageFlags{
-				Registry: "default/extra/image",
-				Tag:      "tag",
+				Registry: types.Registry{
+					Host: "default/extra/image",
+				},
+				Tag: "tag",
 				Httpd: types.ImageFlags{
 					Name: "default/image/proxy-httpd",
 					Tag:  "mytag",
@@ -75,8 +83,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "custom full httpd registry image name",
 			proxyFlags: ProxyImageFlags{
-				Registry: "registry.suse.com/suse/some/paths/",
-				Tag:      "1.0.0",
+				Registry: types.Registry{
+					Host: "registry.suse.com/suse/some/paths/",
+				},
+				Tag: "1.0.0",
 				Httpd: types.ImageFlags{
 					Name: "registry.opensuse.org/uyuni/proxy-httpd",
 					Tag:  "2.0.0",
@@ -88,8 +98,10 @@ func TestGetContainerImage(t *testing.T) {
 		{
 			name: "httpd with path-only image name",
 			proxyFlags: ProxyImageFlags{
-				Registry: "registry.suse.com/uyuni",
-				Tag:      "1.0.0",
+				Registry: types.Registry{
+					Host: "registry.suse.com/uyuni",
+				},
+				Tag: "1.0.0",
 				Httpd: types.ImageFlags{
 					Name: "path/to/proxy-httpd",
 					Tag:  "",

--- a/mgrpxy/shared/utils/flags_test.go
+++ b/mgrpxy/shared/utils/flags_test.go
@@ -35,30 +35,14 @@ func TestGetContainerImage(t *testing.T) {
 			expectedResult: "default/image:tag",
 		},
 		{
-			name: "httpd image details overrule defaults",
+			name: "httpd image with registry",
 			proxyFlags: ProxyImageFlags{
 				Registry: types.Registry{
-					Host: "default/image",
+					Host: "default",
 				},
 				Tag: "tag",
 				Httpd: types.ImageFlags{
-					Name: "default/image/proxy-httpd",
-					Tag:  "mytag",
-				},
-			},
-			expectedResult: "default/image/proxy-httpd:mytag",
-		},
-
-		// registry and image name matching
-		{
-			name: "httpd image name overrule when contains full registry",
-			proxyFlags: ProxyImageFlags{
-				Registry: types.Registry{
-					Host: "default/image",
-				},
-				Tag: "tag",
-				Httpd: types.ImageFlags{
-					Name: "default/image/proxy-httpd",
+					Name: "image/proxy-httpd",
 					Tag:  "mytag",
 				},
 			},
@@ -88,7 +72,7 @@ func TestGetContainerImage(t *testing.T) {
 				},
 				Tag: "1.0.0",
 				Httpd: types.ImageFlags{
-					Name: "registry.opensuse.org/uyuni/proxy-httpd",
+					Name: "uyuni/proxy-httpd",
 					Tag:  "2.0.0",
 				},
 			},

--- a/shared/kubernetes/kubernetes.go
+++ b/shared/kubernetes/kubernetes.go
@@ -187,17 +187,17 @@ func createDockerSecret(
 	return Apply([]runtime.Object{&secret}, fmt.Sprintf(L("failed to create the %s docker secret"), name))
 }
 
-// AddSccSecret creates a secret holding the SCC credentials and adds it to the helm args.
-func AddSCCSecret(helmArgs []string, namespace string, scc *types.SCCCredentials, appLabel string) ([]string, error) {
-	secret, err := GetRegistrySecret(namespace, scc, appLabel)
+// AddRegistry creates a secret holding the registry credentials and adds it to the helm args.
+func AddRegistry(helmArgs []string, namespace string, registry *types.Registry, appLabel string) ([]string, error) {
+	secret, err := GetRegistrySecret(namespace, registry, appLabel)
 	if secret != "" {
 		helmArgs = append(helmArgs, secret)
 	}
 	return helmArgs, err
 }
 
-// GetRegistrySecret creates a docker secret holding the SCC credentials and returns the secret name.
-func GetRegistrySecret(namespace string, scc *types.SCCCredentials, appLabel string) (string, error) {
+// GetRegistrySecret creates a docker secret holding the registry credentials and returns the secret name.
+func GetRegistrySecret(namespace string, registry *types.Registry, appLabel string) (string, error) {
 	const secretName = "registry-credentials"
 
 	// Return the existing secret if any.
@@ -206,10 +206,10 @@ func GetRegistrySecret(namespace string, scc *types.SCCCredentials, appLabel str
 		return secretName, nil
 	}
 
-	// Create the secret if SCC user and password are passed.
-	if scc.User != "" && scc.Password != "" {
+	// Create the secret if registry user and password are passed.
+	if registry.User != "" && registry.Password != "" {
 		if err := createDockerSecret(
-			namespace, secretName, "registry.suse.com", scc.User, scc.Password, appLabel,
+			namespace, secretName, registry.Host, registry.User, registry.Password, appLabel,
 		); err != nil {
 			return "", err
 		}

--- a/shared/podman/images.go
+++ b/shared/podman/images.go
@@ -81,7 +81,7 @@ func PrepareImages(
 	image types.ImageFlags,
 	pgsqlFlags types.PgsqlFlags,
 ) (string, string, error) {
-	serverImage, err := utils.ComputeImage(image.Registry, utils.DefaultTag, image)
+	serverImage, err := utils.ComputeImage(image.Registry.Host, utils.DefaultTag, image)
 	if err != nil && len(serverImage) > 0 {
 		return "", "", utils.Error(err, L("failed to determine image"))
 	}
@@ -100,7 +100,7 @@ func PrepareImages(
 		globalTag = image.Tag
 	}
 
-	pgsqlImage, err := utils.ComputeImage(image.Registry, globalTag, pgsqlFlags.Image)
+	pgsqlImage, err := utils.ComputeImage(image.Registry.Host, globalTag, pgsqlFlags.Image)
 	if err != nil && len(pgsqlImage) > 0 {
 		return "", "", utils.Error(err, L("failed to determine pgsql image"))
 	}

--- a/shared/podman/login.go
+++ b/shared/podman/login.go
@@ -15,41 +15,42 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-// PodmanLogin logs in the registry.suse.com registry if needed.
+// PodmanLogin logs in the registry if needed.
 //
 // It returns an authentication file, a cleanup function and an error.
-func PodmanLogin(hostData *HostInspectData, scc types.SCCCredentials) (string, func(), error) {
-	sccUser := hostData.SCCUsername
-	sccPassword := hostData.SCCPassword
-	if scc.User != "" && scc.Password != "" {
-		log.Info().Msg(L("SCC credentials parameters will be used. SCC credentials from host will be ignored."))
-		sccUser = scc.User
-		sccPassword = scc.Password
+func PodmanLogin(hostData *HostInspectData, registry types.Registry) (string, func(), error) {
+	User := hostData.SCCUsername
+	Password := hostData.SCCPassword
+	if registry.User != "" && registry.Password != "" {
+		log.Info().Msg(L("Registry parameters will be used. SCC credentials from host will be ignored."))
+		User = registry.User
+		Password = registry.Password
 	}
-	if sccUser != "" && sccPassword != "" {
-		// We have SCC credentials, so we are pretty likely to need registry.suse.com
-		token := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", sccUser, sccPassword)))
+	if User != "" && Password != "" {
+		token := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", User, Password)))
 		authFileContent := fmt.Sprintf(`{
 	"auths": {
-		"registry.suse.com" : {
+		"%s" : {
 			"auth": "%s"
 		}
 	}
-}`, token)
+}`, registry.Host, token)
+
 		authFile, err := os.CreateTemp("", "mgradm-")
 		if err != nil {
-			return "", nil, err
+			return "", nil, utils.Errorf(err, L("failed to set authentication for %s"), registry.Host)
 		}
 		authFilePath := authFile.Name()
 
 		if _, err := authFile.Write([]byte(authFileContent)); err != nil {
 			os.Remove(authFilePath)
-			return "", nil, err
+			return "", nil, utils.Errorf(err, L("failed to set authentication for %s"), registry.Host)
 		}
 
 		if err := authFile.Close(); err != nil {
 			os.Remove(authFilePath)
-			return "", nil, utils.Error(err, L("failed to close the temporary auth file"))
+			return "", nil, utils.Errorf(err,
+				L("failed to close the temporary auth file. Cannot set authentication for %s"), registry.Host)
 		}
 
 		return authFilePath, func() {

--- a/shared/podman/login_test.go
+++ b/shared/podman/login_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+func TestGeneratePodmanLoginContent(t *testing.T) {
+	tests := []struct {
+		hostData *HostInspectData
+		registry types.Registry
+		scc      types.SCCCredentials
+		expected string
+	}{
+		// host registered, registry == registry.suse.com, both scc and registry credentials.
+		// in this case, since registry.suse.com, scc credentials flags are used.
+		{
+			hostData: &HostInspectData{
+				SCCUsername: "sccuserhost",
+				SCCPassword: "sccpasswordhost",
+			},
+			registry: types.Registry{
+				Host:     "registry.suse.com/suse/some/paths/",
+				User:     "registryuserflag",
+				Password: "registrypasswordflag",
+			},
+			scc: types.SCCCredentials{
+				User:     "sccuserflag",
+				Password: "sccpasswordflag",
+			},
+			expected: fmt.Sprintf(`{
+	"auths": {
+		"registry.suse.com/suse/some/paths/" : {
+			"auth": "%s"
+		}
+	}
+}`, base64.StdEncoding.EncodeToString([]byte("sccuserflag:sccpasswordflag"))),
+		},
+		// host registered, registry != registry.suse.com, both scc and registry credentials.
+		// in this case, since != registry.suse.com, registry credentials flags are used.
+		{
+			hostData: &HostInspectData{
+				SCCUsername: "sccuserhost",
+				SCCPassword: "sccpasswordhost",
+			},
+			registry: types.Registry{
+				Host:     "myregistry.com/suse/some/paths/",
+				User:     "registryuserflag",
+				Password: "registrypasswordflag",
+			},
+			scc: types.SCCCredentials{
+				User:     "sccuserflag",
+				Password: "sccpasswordflag",
+			},
+			expected: fmt.Sprintf(`{
+	"auths": {
+		"myregistry.com/suse/some/paths/" : {
+			"auth": "%s"
+		}
+	}
+}`, base64.StdEncoding.EncodeToString([]byte("registryuserflag:registrypasswordflag"))),
+		},
+		// host registered, registry == registry.suse.com, no flag credentials.
+		// in this case, since == registry.suse.com, host credentials are used.
+		{
+			hostData: &HostInspectData{
+				SCCUsername: "sccuserhost",
+				SCCPassword: "sccpasswordhost",
+			},
+			registry: types.Registry{
+				Host:     "registry.suse.com",
+				User:     "registryuserflag",
+				Password: "registrypasswordflag",
+			},
+			scc: types.SCCCredentials{
+				User:     "",
+				Password: "",
+			},
+			expected: fmt.Sprintf(`{
+	"auths": {
+		"registry.suse.com" : {
+			"auth": "%s"
+		}
+	}
+}`, base64.StdEncoding.EncodeToString([]byte("sccuserhost:sccpasswordhost"))),
+		},
+		// just registry != registry.suse.com, no credentials: no auth file.
+		//
+		{
+			hostData: &HostInspectData{
+				SCCUsername: "",
+				SCCPassword: "",
+			},
+			registry: types.Registry{
+				Host:     "myregistry.com",
+				User:     "",
+				Password: "",
+			},
+			scc: types.SCCCredentials{
+				User:     "",
+				Password: "",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := GeneratePodmanLoginContent(tt.hostData, tt.registry, tt.scc)
+		if actual != tt.expected {
+			t.Errorf("PodmanLogin error:\n actual:\n %s \n expected:\n %s", actual, tt.expected)
+		}
+	}
+}

--- a/shared/testutils/flagstests/mgradm.go
+++ b/shared/testutils/flagstests/mgradm.go
@@ -105,19 +105,34 @@ var InstallSSLFlagsTestArgs = []string{
 }
 
 // ImageFlagsTestArgs is the expected values for AssertImageFlag.
-var ImageFlagsTestArgs = []string{
+var ImageOnlyFlagsTestArgs = []string{
 	"--image", "path/to/image",
-	"--registry", "myregistry",
 	"--tag", "v1.2.3",
 	"--pullPolicy", "never",
 }
 
+// RegistryFlagsTestArgs is the expected values for AssertRegistryFlag.
+var RegistryImageFlagsTestArgs = []string{
+	"--registry-host", "myregistry",
+	"--registry-user", "user",
+	"--registry-password", "password",
+}
+
+var ImageFlagsTestArgs = append(ImageOnlyFlagsTestArgs, RegistryImageFlagsTestArgs...)
+
 // AssertImageFlag checks that all image flags are parsed correctly.
 func AssertImageFlag(t *testing.T, flags *types.ImageFlags) {
 	testutils.AssertEquals(t, "Error parsing --image", "path/to/image", flags.Name)
-	testutils.AssertEquals(t, "Error parsing --registry", "myregistry", flags.Registry)
 	testutils.AssertEquals(t, "Error parsing --tag", "v1.2.3", flags.Tag)
 	testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.PullPolicy)
+	AssertRegistryFlag(t, &flags.Registry)
+}
+
+// AssertRegistryFlag checks that all registry flags are parsed correctly.
+func AssertRegistryFlag(t *testing.T, flags *types.Registry) {
+	testutils.AssertEquals(t, "Error parsing --registry-host", "myregistry", flags.Host)
+	testutils.AssertEquals(t, "Error parsing --registry-user", "user", flags.User)
+	testutils.AssertEquals(t, "Error parsing --registry-password", "password", flags.Password)
 }
 
 // DBUpdateImageFlagTestArgs is the expected values for AssertDBUpgradeImageFlag.

--- a/shared/testutils/flagstests/mgradm.go
+++ b/shared/testutils/flagstests/mgradm.go
@@ -107,6 +107,7 @@ var InstallSSLFlagsTestArgs = []string{
 // ImageFlagsTestArgs is the expected values for AssertImageFlag.
 var ImageOnlyFlagsTestArgs = []string{
 	"--image", "path/to/image",
+	"--registry", "myOldRegistry",
 	"--tag", "v1.2.3",
 	"--pullPolicy", "never",
 }
@@ -123,14 +124,16 @@ var ImageFlagsTestArgs = append(ImageOnlyFlagsTestArgs, RegistryImageFlagsTestAr
 // AssertImageFlag checks that all image flags are parsed correctly.
 func AssertImageFlag(t *testing.T, flags *types.ImageFlags) {
 	testutils.AssertEquals(t, "Error parsing --image", "path/to/image", flags.Name)
+	testutils.AssertEquals(t, "Error parsing --registry", "myOldRegistry", flags.Registry.Host)
 	testutils.AssertEquals(t, "Error parsing --tag", "v1.2.3", flags.Tag)
 	testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.PullPolicy)
+
 	AssertRegistryFlag(t, &flags.Registry)
 }
 
 // AssertRegistryFlag checks that all registry flags are parsed correctly.
 func AssertRegistryFlag(t *testing.T, flags *types.Registry) {
-	testutils.AssertEquals(t, "Error parsing --registry-host", "myregistry", flags.Host)
+	testutils.AssertEquals(t, "Error parsing --registry-host", "myOldRegistry", flags.Host)
 	testutils.AssertEquals(t, "Error parsing --registry-user", "user", flags.User)
 	testutils.AssertEquals(t, "Error parsing --registry-password", "password", flags.Password)
 }

--- a/shared/testutils/flagstests/mgrpxy_kubernetes.go
+++ b/shared/testutils/flagstests/mgrpxy_kubernetes.go
@@ -30,7 +30,6 @@ func AssertProxyHelmFlags(t *testing.T, flags *kubernetes.HelmFlags) {
 
 // ImageProxyFlagsTestArgs is the slice of parameters to use with AssertImageFlags.
 var ImageProxyFlagsTestArgs = []string{
-	"--registry", "myregistry.com",
 	"--tag", "v1.2.3",
 	"--pullPolicy", "never",
 	"--httpd-image", "path/to/httpd",
@@ -45,11 +44,16 @@ var ImageProxyFlagsTestArgs = []string{
 	"--tftpd-tag", "tftpd-tag",
 	"--tuning-httpd", "path/to/httpd.conf",
 	"--tuning-squid", "path/to/squid.conf",
+	"--registry-host", "myregistry.com",
+	"--registry-user", "user",
+	"--registry-password", "password",
 }
 
 // AssertProxyImageFlags checks that all image flags are parsed correctly.
 func AssertProxyImageFlags(t *testing.T, flags *utils.ProxyImageFlags) {
-	testutils.AssertEquals(t, "Error parsing --registry", "myregistry.com", flags.Registry)
+	testutils.AssertEquals(t, "Error parsing --registry-host", "myregistry.com", flags.Registry.Host)
+	testutils.AssertEquals(t, "Error parsing --registry-user", "user", flags.Registry.User)
+	testutils.AssertEquals(t, "Error parsing --registry-password", "password", flags.Registry.Password)
 	testutils.AssertEquals(t, "Error parsing --tag", "v1.2.3", flags.Tag)
 	testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.PullPolicy)
 	testutils.AssertEquals(t, "Error parsing --httpd-image", "path/to/httpd", flags.Httpd.Name)

--- a/shared/testutils/flagstests/mgrpxy_kubernetes.go
+++ b/shared/testutils/flagstests/mgrpxy_kubernetes.go
@@ -30,6 +30,7 @@ func AssertProxyHelmFlags(t *testing.T, flags *kubernetes.HelmFlags) {
 
 // ImageProxyFlagsTestArgs is the slice of parameters to use with AssertImageFlags.
 var ImageProxyFlagsTestArgs = []string{
+	"--registry", "myoldregistry.com",
 	"--tag", "v1.2.3",
 	"--pullPolicy", "never",
 	"--httpd-image", "path/to/httpd",
@@ -51,7 +52,8 @@ var ImageProxyFlagsTestArgs = []string{
 
 // AssertProxyImageFlags checks that all image flags are parsed correctly.
 func AssertProxyImageFlags(t *testing.T, flags *utils.ProxyImageFlags) {
-	testutils.AssertEquals(t, "Error parsing --registry-host", "myregistry.com", flags.Registry.Host)
+	testutils.AssertEquals(t, "Error parsing --registry", "myoldregistry.com", flags.Registry.Host)
+	testutils.AssertEquals(t, "Error parsing --registry-host", "myoldregistry.com", flags.Registry.Host)
 	testutils.AssertEquals(t, "Error parsing --registry-user", "user", flags.Registry.User)
 	testutils.AssertEquals(t, "Error parsing --registry-password", "password", flags.Registry.Password)
 	testutils.AssertEquals(t, "Error parsing --tag", "v1.2.3", flags.Tag)

--- a/shared/testutils/flagstests/scc.go
+++ b/shared/testutils/flagstests/scc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/shared/testutils/flagstests/server.go
+++ b/shared/testutils/flagstests/server.go
@@ -22,6 +22,7 @@ var ServerFlagsTestArgs = func() []string {
 	args = append(args, SSLGenerationFlagsTestArgs...)
 	args = append(args, SalineFlagsTestArgs...)
 	args = append(args, ImageFlagsTestArgs...)
+	args = append(args, RegistryImageFlagsTestArgs...)
 	args = append(args, DBUpdateImageFlagTestArgs...)
 	args = append(args, CocoFlagsTestArgs...)
 	args = append(args, HubXmlrpcFlagsTestArgs...)
@@ -31,6 +32,7 @@ var ServerFlagsTestArgs = func() []string {
 // AssertServerFlags checks that all the server-related common flags are parsed correctly.
 func AssertServerFlags(t *testing.T, flags *utils.ServerFlags) {
 	AssertImageFlag(t, &flags.Image)
+	AssertRegistryFlag(t, &flags.Image.Registry)
 	AssertDBUpgradeImageFlag(t, &flags.DBUpgradeImage)
 	AssertCocoFlag(t, &flags.Coco)
 	AssertHubXmlrpcFlag(t, &flags.HubXmlrpc)

--- a/shared/types/images.go
+++ b/shared/types/images.go
@@ -6,10 +6,10 @@ package types
 
 // ImageFlags represents the flags used by an image.
 type ImageFlags struct {
-	Registry   Registry
-	Name       string `mapstructure:"image"`
-	Tag        string `mapstructure:"tag"`
-	PullPolicy string `mapstructure:"pullPolicy"`
+	Registry   Registry `mapstructure:"registry"`
+	Name       string   `mapstructure:"image"`
+	Tag        string   `mapstructure:"tag"`
+	PullPolicy string   `mapstructure:"pullPolicy"`
 }
 
 // PgsqlFlags contains settings for Pgsql container.

--- a/shared/types/images.go
+++ b/shared/types/images.go
@@ -6,7 +6,7 @@ package types
 
 // ImageFlags represents the flags used by an image.
 type ImageFlags struct {
-	Registry   string `mapstructure:"registry"`
+	Registry   Registry
 	Name       string `mapstructure:"image"`
 	Tag        string `mapstructure:"tag"`
 	PullPolicy string `mapstructure:"pullPolicy"`
@@ -33,6 +33,13 @@ type Metadata struct {
 
 // SCCCredentials can store SCC Credentials.
 type SCCCredentials struct {
-	User     string
-	Password string
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+// Registry can store registry information.
+type Registry struct {
+	Host     string `json:"host"`
+	User     string `json:"user"`
+	Password string `json:"password"`
 }

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"errors"
+	"path"
 	"reflect"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -22,13 +23,19 @@ import (
 var LocaleRoot = "locale"
 
 // DefaultRegistry represents the default name used for container image.
-var DefaultRegistry = "registry.opensuse.org/uyuni"
+var DefaultRegistry = "registry.opensuse.org"
 
 // DefaultHelmRegistry represents the default name used for helm charts.
 var DefaultHelmRegistry = "registry.opensuse.org/uyuni"
 
 // DefaultTag represents the default tag used for image.
 var DefaultTag = "latest"
+
+// DefaultImagePrefix represents the default name used for image.
+var DefaultImagePrefix = "uyuni"
+
+// DefaultImage represents the default image name.
+var DefaultImage = path.Join(DefaultImagePrefix, "server")
 
 // DefaultPullPolicy represents the default pull policy used for image.
 var DefaultPullPolicy = "Always"

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -149,9 +149,11 @@ func AddRegistryFlag(cmd *cobra.Command) {
 		L("Specify a registry where to pull the images from. It will be concatenated with image name"))
 	cmd.Flags().String("registry-user", "", L("User if registry requires an authentication"))
 	cmd.Flags().String("registry-password", "", L("Password if registry requires an authentication"))
-	_ = AddFlagToHelpGroupID(cmd, "registry-host", "")
-	_ = AddFlagToHelpGroupID(cmd, "registry-user", "")
-	_ = AddFlagToHelpGroupID(cmd, "registry-password", "")
+
+	_ = AddFlagHelpGroup(cmd, &Group{ID: "registry", Title: L("Registry Flags")})
+	_ = AddFlagToHelpGroupID(cmd, "registry-host", "registry")
+	_ = AddFlagToHelpGroupID(cmd, "registry-user", "registry")
+	_ = AddFlagToHelpGroupID(cmd, "registry-password", "registry")
 }
 
 // AddPTFFlag add PTF flag to a command.

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -143,6 +143,8 @@ func AddPullPolicyFlag(cmd *cobra.Command) {
 }
 
 func AddRegistryFlag(cmd *cobra.Command) {
+	cmd.Flags().String("registry", DefaultRegistry, L("Specify a registry where to pull the images from"))
+	_ = cmd.Flags().MarkDeprecated("registry", "please use --registry-host instead")
 	cmd.Flags().String("registry-host", DefaultRegistry,
 		L("Specify a registry where to pull the images from. It will be concatenated with image name"))
 	cmd.Flags().String("registry-user", "", L("User if registry requires an authentication"))

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -28,6 +28,9 @@ var DefaultRegistry = "registry.opensuse.org"
 // DefaultHelmRegistry represents the default name used for helm charts.
 var DefaultHelmRegistry = "registry.opensuse.org"
 
+// DefaultHelmImagePrefix represents the default image prefix used for helm charts.
+var DefaultHelmImagePrefix = "uyuni"
+
 // DefaultTag represents the default tag used for image.
 var DefaultTag = "latest"
 
@@ -38,7 +41,7 @@ var DefaultImagePrefix = "uyuni"
 var DefaultImage = path.Join(DefaultImagePrefix, "server")
 
 // DefaultProxyChart represents the default proxy chart.
-var DefaultProxyChart = path.Join(DefaultImagePrefix, "proxy-chart")
+var DefaultProxyChart = path.Join(DefaultHelmImagePrefix, "proxy-chart")
 
 // DefaultPullPolicy represents the default pull policy used for image.
 var DefaultPullPolicy = "Always"

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -5,6 +5,10 @@
 package utils
 
 import (
+	"errors"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -55,10 +59,20 @@ func CommandHelper[T interface{}](
 		return err
 	}
 
-	if err := viper.Unmarshal(&flags); err != nil {
-		log.Error().Err(err).Msg(L("failed to unmarshall configuration"))
-		return Error(err, L("failed to unmarshall configuration"))
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			StringToRegistryHook(),
+		),
+		Result: &flags,
+	})
+	if err != nil {
+		return err
 	}
+
+	if err = decoder.Decode(viper.AllSettings()); err != nil {
+		return err
+	}
+
 	if flagsUpdater != nil {
 		flagsUpdater(viper)
 	}
@@ -67,6 +81,30 @@ func CommandHelper[T interface{}](
 		log.Error().Err(err).Send()
 	}
 	return err
+}
+
+func StringToRegistryHook() mapstructure.DecodeHookFunc {
+	return func(
+		_ reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		// Only intercept if the target is Registry
+		if t != reflect.TypeOf(types.Registry{}) {
+			return data, nil
+		}
+
+		switch val := data.(type) {
+		case string:
+			// If Registry is a string, create Registry struct with Host = string
+			return types.Registry{Host: val}, nil
+		case map[string]interface{}:
+			// If it's a map, decode normally
+			return data, nil
+		default:
+			return data, errors.New(L("cannot decode into Registry"))
+		}
+	}
 }
 
 // AddBackendFlag add the flag for setting the backend ('podman', 'podman-remote', 'kubectl').
@@ -92,9 +130,13 @@ func AddPullPolicyFlag(cmd *cobra.Command) {
 }
 
 func AddRegistryFlag(cmd *cobra.Command) {
-	cmd.Flags().String("registry-host", DefaultRegistry, L("registry TODO"))
-	cmd.Flags().String("registry-user", "", L("user TODO"))
-	cmd.Flags().String("registry-password", "", L("password TODO"))
+	cmd.Flags().String("registry-host", DefaultRegistry,
+		L("Specify a registry where to pull the images from. It will be concatenated with image name"))
+	cmd.Flags().String("registry-user", "", L("User if registry requires an authentication"))
+	cmd.Flags().String("registry-password", "", L("Password if registry requires an authentication"))
+	_ = AddFlagToHelpGroupID(cmd, "registry-host", "")
+	_ = AddFlagToHelpGroupID(cmd, "registry-user", "")
+	_ = AddFlagToHelpGroupID(cmd, "registry-password", "")
 }
 
 // AddPTFFlag add PTF flag to a command.

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -26,7 +26,7 @@ var LocaleRoot = "locale"
 var DefaultRegistry = "registry.opensuse.org"
 
 // DefaultHelmRegistry represents the default name used for helm charts.
-var DefaultHelmRegistry = "registry.opensuse.org/uyuni"
+var DefaultHelmRegistry = "registry.opensuse.org"
 
 // DefaultTag represents the default tag used for image.
 var DefaultTag = "latest"
@@ -36,6 +36,9 @@ var DefaultImagePrefix = "uyuni"
 
 // DefaultImage represents the default image name.
 var DefaultImage = path.Join(DefaultImagePrefix, "server")
+
+// DefaultProxyChart represents the default proxy chart.
+var DefaultProxyChart = path.Join(DefaultImagePrefix, "proxy-chart")
 
 // DefaultPullPolicy represents the default pull policy used for image.
 var DefaultPullPolicy = "Always"

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -54,6 +54,7 @@ func CommandHelper[T interface{}](
 	if err != nil {
 		return err
 	}
+
 	if err := viper.Unmarshal(&flags); err != nil {
 		log.Error().Err(err).Msg(L("failed to unmarshall configuration"))
 		return Error(err, L("failed to unmarshall configuration"))
@@ -88,6 +89,12 @@ Default guesses which to use.`),
 func AddPullPolicyFlag(cmd *cobra.Command) {
 	cmd.Flags().String("pullPolicy", DefaultPullPolicy,
 		L("set whether to pull the images or not. The value can be one of 'Never', 'IfNotPresent' or 'Always'"))
+}
+
+func AddRegistryFlag(cmd *cobra.Command) {
+	cmd.Flags().String("registry-host", DefaultRegistry, L("registry TODO"))
+	cmd.Flags().String("registry-user", "", L("user TODO"))
+	cmd.Flags().String("registry-password", "", L("password TODO"))
 }
 
 // AddPTFFlag add PTF flag to a command.

--- a/shared/utils/config.go
+++ b/shared/utils/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -93,8 +93,15 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	var errors []error
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		configName := strings.ReplaceAll(f.Name, "-", ".")
+		// Retrocompatibility: --registry maps to registry-host
+		if configName == "registry" {
+			configName = "registry.host"
+		}
 		if err := v.BindPFlag(configName, f); err != nil {
 			errors = append(errors, Errorf(err, L("failed to bind %[1]s config to parameter %[2]s"), configName, f.Name))
+		}
+		if f.Name == "registry" && f.Changed {
+			v.Set("registry.host", f.Value.String())
 		}
 	})
 

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -200,6 +200,12 @@ func RemoveRegistryFromImage(imagePath string) string {
 
 // SplitRegistryHostAndPath splits a registry string into domain and path.
 func SplitRegistryHostAndPath(registry string) (domain string, path string) {
+	separator := "://"
+	index := strings.Index(registry, separator)
+	if index != -1 {
+		registry = registry[index+len(separator):]
+	}
+
 	idx := strings.Index(registry, "/")
 	if idx == -1 {
 		return registry, ""

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -210,7 +210,11 @@ func ComputeImage(
 		registry = imageFlags.Registry.Host
 	}
 
-	name := path.Join(registry, imageFlags.Name)
+	name := imageFlags.Name
+
+	if !StartWithFQDN(name) {
+		name = path.Join(registry, imageFlags.Name)
+	}
 
 	// Compute the tag
 	tag := globalTag
@@ -438,6 +442,12 @@ func IsValidFQDN(fqdn string) error {
 // IsWellFormedFQDN returns an false if the argument is not a well formed FQDN.
 func IsWellFormedFQDN(fqdn string) bool {
 	return fqdnValid.MatchString(fqdn)
+}
+
+// StartWithFQDN returns true if the argument start with a well formed FQDN.
+func StartWithFQDN(url string) bool {
+	fqdn, _ := SplitRegistryHostAndPath(url)
+	return IsWellFormedFQDN(fqdn)
 }
 
 // CommandExists checks if cmd exists in $PATH.

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -215,33 +215,18 @@ func SplitRegistryHostAndPath(registry string) (domain string, path string) {
 
 // ComputeImage assembles the container image from its name and tag.
 func ComputeImage(
-	registry string,
+	globalRegistry string,
 	globalTag string,
 	imageFlags types.ImageFlags,
 	appendToName ...string,
 ) (string, error) {
-	name := imageFlags.Name
-
-	if !strings.Contains(DefaultRegistry, registry) {
-		log.Info().Msgf(L("Registry %[1]s would be used instead of namespace %[2]s"), registry, DefaultRegistry)
+	// Compute the registry
+	registry := globalRegistry
+	if imageFlags.Registry.Host != "" {
+		registry = imageFlags.Registry.Host
 	}
 
-	if DefaultSCCRegistry != DefaultRegistry {
-		sccHost, sccPath := SplitRegistryHostAndPath(DefaultSCCRegistry)
-		_, registryPath := SplitRegistryHostAndPath(registry)
-		nameSplit := strings.Split(imageFlags.Name, "/")
-		name = nameSplit[len(nameSplit)-1]
-		if sccPath == "" {
-			registry = path.Join(sccHost, registryPath)
-		} else {
-			registry = DefaultSCCRegistry
-		}
-		name = path.Join(registry, name)
-	}
-
-	if !strings.Contains(name, registry) {
-		name = path.Join(registry, RemoveRegistryFromImage(name))
-	}
+	name := path.Join(registry, imageFlags.Name)
 
 	// Compute the tag
 	tag := globalTag

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -214,12 +214,27 @@ func ComputeImage(
 	imageFlags types.ImageFlags,
 	appendToName ...string,
 ) (string, error) {
+	name := imageFlags.Name
+
 	if !strings.Contains(DefaultRegistry, registry) {
 		log.Info().Msgf(L("Registry %[1]s would be used instead of namespace %[2]s"), registry, DefaultRegistry)
 	}
-	name := imageFlags.Name
-	if !strings.Contains(imageFlags.Name, registry) {
-		name = path.Join(registry, RemoveRegistryFromImage(imageFlags.Name))
+
+	if DefaultSCCRegistry != DefaultRegistry {
+		sccHost, sccPath := SplitRegistryHostAndPath(DefaultSCCRegistry)
+		_, registryPath := SplitRegistryHostAndPath(registry)
+		nameSplit := strings.Split(imageFlags.Name, "/")
+		name = nameSplit[len(nameSplit)-1]
+		if sccPath == "" {
+			registry = path.Join(sccHost, registryPath)
+		} else {
+			registry = DefaultSCCRegistry
+		}
+		name = path.Join(registry, name)
+	}
+
+	if !strings.Contains(name, registry) {
+		name = path.Join(registry, RemoveRegistryFromImage(name))
 	}
 
 	// Compute the tag

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -182,22 +182,6 @@ func YesNo(question string) (bool, error) {
 	}
 }
 
-// RemoveRegistryFromImage removes registry fqdn from image path.
-func RemoveRegistryFromImage(imagePath string) string {
-	separator := "://"
-	index := strings.Index(imagePath, separator)
-	if index != -1 {
-		imagePath = imagePath[index+len(separator):]
-	}
-
-	parts := strings.Split(imagePath, "/")
-	if strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") || index != -1 {
-		// first part is a registry fqdn
-		parts = parts[1:]
-	}
-	return strings.Join(parts, "/")
-}
-
 // SplitRegistryHostAndPath splits a registry string into domain and path.
 func SplitRegistryHostAndPath(registry string) (domain string, path string) {
 	separator := "://"

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -307,28 +307,14 @@ func TestComputeImage(t *testing.T) {
 		{
 			// bsc#1226436
 			"registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64/server:bar",
-			"registry.suse.com/suse/manager/5.0/x86_64/server",
+			"suse/manager/5.0/x86_64/server",
 			"bar",
 			"registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile",
 			"",
 		},
 		{
 			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
-			"registry.suse.com/suse/manager/5.0/x86_64/server",
-			"5.0.0",
-			"cloud.com",
-			"",
-		},
-		{
-			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
 			"/suse/manager/5.0/x86_64/server",
-			"5.0.0",
-			"cloud.com",
-			"",
-		},
-		{
-			"cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
-			"suse/manager/5.0/x86_64/server",
 			"5.0.0",
 			"cloud.com",
 			"",

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -409,6 +409,32 @@ func TestComputeImageError(t *testing.T) {
 	}
 }
 
+func TestSplitRegistryHostAndPath(t *testing.T) {
+	data := [][]string{
+		{"registry.suse.com", "registry.suse.com", ""},
+		{"registry.suse.com/suse", "registry.suse.com", "suse"},
+		{"registry.suse.com/suse/multi", "registry.suse.com", "suse/multi"},
+		{"docker://registry.suse.com", "registry.suse.com", ""},
+		{"docker://registry.suse.com/", "registry.suse.com", ""},
+		{"docker://registry.suse.com/suse/multi", "registry.suse.com", "suse/multi"},
+	}
+
+	for _, testCase := range data {
+		input := testCase[0]
+		host := testCase[1]
+		path := testCase[2]
+
+		resultHost, resultPath := SplitRegistryHostAndPath(input)
+		if resultHost != host {
+			t.Errorf("Expected host for %s is %s, got %s ", input, host, resultHost)
+		}
+
+		if resultPath != path {
+			t.Errorf("Expected path for %s is %s, got %s ", input, path, resultPath)
+		}
+	}
+}
+
 func TestConfig(t *testing.T) {
 	type fakeFlags struct {
 		firstConf  string

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -396,11 +396,12 @@ func TestComputeImage(t *testing.T) {
 			registry:      "cloud.com",
 			appendToImage: []string{""},
 		},
+		// ignore registry if name contains fqdn
 		{
 			expected:      "cloud.com/my/path/server:5.0.0",
-			name:          "my/path/server",
+			name:          "cloud.com/my/path/server:5.0.0",
 			tag:           "5.0.0",
-			registry:      "cloud.com",
+			registry:      "registy.suse.com",
 			appendToImage: []string{""},
 		},
 	}

--- a/shared/utils/uyuniservices.go
+++ b/shared/utils/uyuniservices.go
@@ -50,48 +50,60 @@ var UyuniServices = []types.UyuniService{
 
 // ServerImage holds the flags to tune the server container image.
 var ServerImage = types.ImageFlags{
-	Name:       "server",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "server",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }
 
 // HubXMLRPCImage holds the flags to tune the hub XML-RPC API container image.
 var HubXMLRPCImage = types.ImageFlags{
-	Name:       "server-hub-xmlrpc-api",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "server-hub-xmlrpc-api",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }
 
 // COCOAttestationImage holds the flags to tune the confidential computing attestation container image.
 var COCOAttestationImage = types.ImageFlags{
-	Name:       "server-attestation",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "server-attestation",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }
 
 // Saline holds the flags to tune the saline container image.
 var SalineImage = types.ImageFlags{
-	Name:       "server-saline",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "server-saline",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }
 
 // Migration14To16Image holds the flags to tune the DB migration container image.
 var Migration14To16Image = types.ImageFlags{
-	Name:       "server-migration-14-16",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "server-migration-14-16",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }
 
 // PostgreSQLImage holds the flags to tune the DB container image.
 var PostgreSQLImage = types.ImageFlags{
-	Name:       "uyuni-db",
-	Tag:        DefaultTag,
-	Registry:   DefaultRegistry,
+	Name: "uyuni-db",
+	Tag:  DefaultTag,
+	Registry: types.Registry{
+		Host: DefaultRegistry,
+	},
 	PullPolicy: DefaultPullPolicy,
 }

--- a/uyuni-tools.changes.mbussolotto.scc_registry
+++ b/uyuni-tools.changes.mbussolotto.scc_registry
@@ -1,0 +1,3 @@
+- add --registry-host, --registry-user and --registry-password
+  to pull images from an authenticate registry
+- deprecate --registry

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -328,19 +328,14 @@ pull_policy=%{!?_default_pull_policy:Always}
 # "%{?_default_pull_policy}" != ""
 
 namespace=%{namespace}
-helm_registry=%{namespace}
+helm_namespace=%{namespace}
 %if "%{?_default_namespace}" != ""
-  # Set both container and helm chart namespaces as this can be the same value
   namespace='%{_default_namespace}'
-  helm_registry='%{_default_namespace}'
 %endif
-# "%{?_default_namespace}" != ""
 
-# We may have additional config for helm registry as the path is different in OBS devel projects
 %if "%{?_default_helm_registry}" != ""
-  helm_registry='%{_default_helm_registry}'
+  helm_namespace='%{_default_helm_registry}'
 %endif
-# "%{?_default_helm_registry}" != ""
 
 go_tags=""
 %if "%{?_uyuni_tools_tags}" != ""
@@ -360,13 +355,29 @@ go_path=""
 %endif
 # 0%{?ubuntu}
 
+registry="${namespace%%%%/*}"
+imageprefix="${namespace#*/}"
+
+# --- same for helm_registry ---
+helmregistry="${helm_namespace%%%%/*}"
+helmimageprefix="${helm_namespace#*/}"
+
 GOLD_FLAGS="-X '${UTILS_PATH}.Version=%{version} for ${tag} image (%{version_details}) (compilation tag: %{_uyuni_tools_tags})' -X ${UTILS_PATH}.LocaleRoot=%{_datadir}/locale"
+
 if test -n "${namespace}"; then
-    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultRegistry=${namespace}"
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultRegistry=${registry}"
 fi
 
 if test -n "${helm_registry}"; then
-    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultHelmRegistry=${helm_registry}"
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultHelmRegistry=${helmregistry}"
+fi
+
+if test -n "${imageprefix}"; then
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultImagePrefix=${imageprefix}"
+fi
+
+if test -n "${helmimageprefix}"; then
+    GOLD_FLAGS="${GOLD_FLAGS} -X ${UTILS_PATH}.DefaultHelmImagePrefix=${helmimageprefix}"
 fi
 
 if test -n "${tag}"; then


### PR DESCRIPTION
- change registry and image to image containing a namespace value
- computeImage always concatenate registry and image and tag
- help should print default image without registry (for default including namespace)
- hack registry in bind_flags to allow registry, registry-host, registry-user, registry-password 
- hack when registry is registry.suse.com, then --scc-user and --scc-password works as registry-user and registry-password

mgradm install podman --help
```
...
      --registry-host string       Specify a registry where to pull the images from. It will be concatenated with image name (default "registry.opensuse.org")
      --registry-password string   Password if registry requires an authentication
      --registry-user string       User if registry requires an authentication
...
      --image string   Image (default "uyuni/server")
...
      --pgsql-image string   Image for PostgreSQL Database container (default "uyuni/server-postgresql")
...
```


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- unit test added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27784

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
