### PR TITLE
Migrate custom auto installation snippets (bsc#1246320)

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -129,6 +129,18 @@ while IFS="," read -r target path ; do
   fi
 done < distros
 
+echo "Migrating auto-installation snippets..."
+$SSH {{ .SourceFqdn }} "find /var/lib/cobbler/snippets/spacewalk/* -type d" > snippets_dirs
+while read -r snippets_dir ; do
+  if $SSH -n {{ .SourceFqdn }} test -e $snippets_dir; then
+    echo "Copying autoinstallation snippets from $snippets_dir..."
+    mkdir -p "$snippets_dir"
+    rsync --delete -e "$SSH" --rsync-path='sudo rsync' -avz "{{ .SourceFqdn }}:$snippets_dir" "$snippets_dir";
+  else
+    echo "Skipping autoinstallation snippets from $snippets_dir.."
+  fi
+done < snippets_dirs
+
 if $SSH {{ .SourceFqdn }} test -e /etc/tomcat/conf.d; then
   echo "Copying tomcat configuration.."
   mkdir -p /etc/tomcat/conf.d

--- a/uyuni-tools.changes.meaksh.main-bsc1246320
+++ b/uyuni-tools.changes.meaksh.main-bsc1246320
@@ -1,0 +1,1 @@
+Migrate custom auto installation snippets (bsc#1246320)


### PR DESCRIPTION
## What does this PR change?

During migration process, we are taking care of migrating autoinstallation profiles and distro trees but we are missing custom autoinstallation snippets created via UI and stored under `/var/lib/cobbler/snippets/spacewalk/ORG_ID`.

This PR includes the migration of custom autoinstallation snippets as part of the migration process.

## Test coverage
- No tests: **no tests aroung migration script**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27825

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
