### PR TITLE
Workaround nft 114

### DIFF
--- a/mgradm/shared/templates/postUpgradeScriptTemplate.go
+++ b/mgradm/shared/templates/postUpgradeScriptTemplate.go
@@ -11,17 +11,18 @@ import (
 
 const postUpgradeScriptTemplate = `
 sed 's/cobbler\.host.*/cobbler\.host = localhost/' -i /etc/rhn/rhn.conf;
-if grep -q uyuni_authentication_endpoint /etc/cobbler/settings.d/zz-uyuni.settings; then
-	echo 'uyuni_authentication_endpoint: "http://localhost"' >> /etc/cobbler/settings.d/zz-uyuni.settings
-else
+if [ -f /etc/cobbler/settings.d/zz-uyuni.settings ] && \
+    grep -q uyuni_authentication_endpoint /etc/cobbler/settings.d/zz-uyuni.settings; then
 	sed 's/uyuni_authentication_endpoint.*/uyuni_authentication_endpoint: http:\/\/localhost/' \
         -i /etc/cobbler/settings.d/zz-uyuni.settings;
+else
+	echo 'uyuni_authentication_endpoint: "http://localhost"' >> /etc/cobbler/settings.d/zz-uyuni.settings
 fi
 
 if grep -q pam_auth_service /etc/rhn/rhn.conf; then
-	echo 'pam_auth_service = susemanager' >> /etc/rhn/rhn.conf
-else
 	sed 's/pam_auth_service.*/pam_auth_service = susemanager/' -i /etc/rhn/rhn.conf;
+else
+	echo 'pam_auth_service = susemanager' >> /etc/rhn/rhn.conf
 fi
 
 if test -e /etc/sysconfig/prometheus-postgres_exporter/systemd/60-server.conf; then

--- a/mgrpxy/shared/templates/pod.go
+++ b/mgrpxy/shared/templates/pod.go
@@ -48,6 +48,12 @@ ExecStartPre=/bin/sh -c '/usr/bin/podman pod create --infra-conmon-pidfile %t/uy
 		--replace ${PODMAN_EXTRA_ARGS}'
 
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/uyuni-proxy-pod.pod-id
+
+# Workaround for nft 1.1.4 and netavark incompatibility boo#1248848
+ExecStopPost=/bin/sh -c '/sbin/nft list tables | grep -q netavark && \
+	/sbin/nft flush table inet netavark && \
+	/usr/bin/podman network reload -a'
+
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/uyuni-proxy-pod.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/uyuni-proxy-pod.pod-id
 

--- a/uyuni-tools.changes.oholecek.cobbler_settings_upgrade
+++ b/uyuni-tools.changes.oholecek.cobbler_settings_upgrade
@@ -1,0 +1,1 @@
+- Fix cobbler config migration to standalone files

--- a/uyuni-tools.changes.oholecek.nft_workaround
+++ b/uyuni-tools.changes.oholecek.nft_workaround
@@ -1,0 +1,3 @@
+- Add workaround for nft-1.1.4 and netavark incompatibility
+  Netavark nft table is cleared and recreated after container stop
+  (boo#1248848)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR adds two fixes:
- nft table flush after containers are stopped. Workaround addressing [boo#1248848](https://bugzilla.suse.com/show_bug.cgi?id=1248848)
- reverse condition branched for cobbler config migration

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
