### PR TITLE
Actually use --dbupgrade-tag when computing the image URL

### DIFF
--- a/mgradm/shared/kubernetes/dbUpgradeJob.go
+++ b/mgradm/shared/kubernetes/dbUpgradeJob.go
@@ -37,11 +37,9 @@ func StartDBUpgradeJob(
 	var migrationImageURL string
 	var err error
 	if migrationImage.Name == "" {
-		imageName := fmt.Sprintf("-migration-%s-%s", oldPgsql, newPgsql)
-		migrationImageURL, err = utils.ComputeImage(image.Registry.Host, image.Tag, image, imageName)
-	} else {
-		migrationImageURL, err = utils.ComputeImage(image.Registry.Host, image.Tag, migrationImage)
+		migrationImage.Name = fmt.Sprintf("%s-migration-%s-%s", image.Name, oldPgsql, newPgsql)
 	}
+	migrationImageURL, err = utils.ComputeImage(image.Registry.Host, image.Tag, migrationImage)
 	if err != nil {
 		return "", utils.Error(err, L("failed to compute image URL"))
 	}

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -203,7 +203,7 @@ func AddImageFlag(cmd *cobra.Command) {
 // AddDBUpgradeImageFlag add Database upgrade image flags to a command.
 func AddDBUpgradeImageFlag(cmd *cobra.Command) {
 	cmd.Flags().String("dbupgrade-image", "", L("Database upgrade image"))
-	cmd.Flags().String("dbupgrade-tag", "latest", L("Database upgrade image tag"))
+	cmd.Flags().String("dbupgrade-tag", "", L("Database upgrade image tag, overrides the default value if set"))
 
 	_ = utils.AddFlagHelpGroup(cmd, &utils.Group{ID: "dbupgrade-image", Title: L("Database Upgrade Image Flags")})
 	_ = utils.AddFlagToHelpGroupID(cmd, "dbupgrade-image", "dbupgrade-image")

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -202,7 +202,6 @@ func ComputeImage(
 	globalRegistry string,
 	globalTag string,
 	imageFlags types.ImageFlags,
-	appendToName ...string,
 ) (string, error) {
 	// Compute the registry
 	registry := globalRegistry
@@ -230,17 +229,13 @@ func ComputeImage(
 		if len(tag) <= 0 {
 			return name, fmt.Errorf(L("tag missing on %s"), name)
 		}
-		if len(appendToName) > 0 {
-			name = name + strings.Join(appendToName, ``)
-		}
 		// No tag provided in the URL name, append the one passed
 		imageName := fmt.Sprintf("%s:%s", name, tag)
 		imageName = strings.ToLower(imageName) // podman does not accept repo in upper case
 		log.Info().Msgf(L("Computed image name is %s"), imageName)
 		return imageName, nil
 	}
-	imageName := submatches[1] + strings.Join(appendToName, ``) + `:` + submatches[2]
-	imageName = strings.ToLower(imageName) // podman does not accept repo in upper case
+	imageName := strings.ToLower(name) // podman does not accept repo in upper case
 	log.Info().Msgf(L("Computed image name is %s"), imageName)
 	return imageName, nil
 }

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -291,118 +291,102 @@ func TestComputePTF(t *testing.T) {
 
 func TestComputeImage(t *testing.T) {
 	tests := []struct {
-		expected      string
-		name          string
-		tag           string
-		registry      string
-		appendToImage []string
+		expected string
+		name     string
+		tag      string
+		registry string
 	}{
 		{
-			expected:      "registry:5000/path/to/image:foo",
-			name:          "REGISTRY:5000/path/to/image:foo",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{""},
+			expected: "registry:5000/path/to/image:foo",
+			name:     "REGISTRY:5000/path/to/image:foo",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry:5000/path/to/image:foo",
-			name:          "REGISTRY:5000/path/to/image:foo",
-			tag:           "BAR",
-			registry:      "",
-			appendToImage: []string{""},
+			expected: "registry:5000/path/to/image:foo",
+			name:     "REGISTRY:5000/path/to/image:foo",
+			tag:      "BAR",
+			registry: "",
 		},
 		{
-			expected:      "registry:5000/path/to/image:bar",
-			name:          "registry:5000/path/to/image",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{""},
+			expected: "registry:5000/path/to/image:bar",
+			name:     "registry:5000/path/to/image",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image:foo",
-			name:          "registry/path/to/image:foo",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{""},
+			expected: "registry/path/to/image:foo",
+			name:     "registry/path/to/image:foo",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image:bar",
-			name:          "registry/path/to/image",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{""},
+			expected: "registry/path/to/image:bar",
+			name:     "registry/path/to/image",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image:bar",
-			name:          "path/to/image",
-			tag:           "bar",
-			registry:      "registry",
-			appendToImage: []string{""},
+			expected: "registry/path/to/image:bar",
+			name:     "path/to/image",
+			tag:      "bar",
+			registry: "registry",
 		},
 		{
-			expected:      "registry:5000/path/to/image:foo",
-			name:          "path/to/image:foo",
-			tag:           "BAR",
-			registry:      "REGISTRY:5000",
-			appendToImage: []string{""},
+			expected: "registry:5000/path/to/image:foo",
+			name:     "path/to/image:foo",
+			tag:      "BAR",
+			registry: "REGISTRY:5000",
 		},
 		{
-			expected:      "registry:5000/path/to/image-migration-14-16:foo",
-			name:          "registry:5000/path/to/image:foo",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{"-migration-14-16"},
+			expected: "registry:5000/path/to/image-migration-14-16:foo",
+			name:     "registry:5000/path/to/image-migration-14-16:foo",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry:5000/path/to/image-migration-14-16:bar",
-			name:          "registry:5000/path/to/image",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{"-migration-14-16"},
+			expected: "registry:5000/path/to/image-migration-14-16:bar",
+			name:     "registry:5000/path/to/image-migration-14-16",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image-migration-14-16:foo",
-			name:          "registry/path/to/image:foo",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{"-migration-14-16"},
+			expected: "registry/path/to/image-migration-14-16:foo",
+			name:     "registry/path/to/image-migration-14-16:foo",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image-migration-14-16:bar",
-			name:          "registry/path/to/image",
-			tag:           "bar",
-			registry:      "",
-			appendToImage: []string{"-migration-14-16"},
+			expected: "registry/path/to/image-migration-14-16:bar",
+			name:     "registry/path/to/image-migration-14-16",
+			tag:      "bar",
+			registry: "",
 		},
 		{
-			expected:      "registry/path/to/image-migration-14-16:bar",
-			name:          "path/to/image",
-			tag:           "bar",
-			registry:      "registry",
-			appendToImage: []string{"-migration-14-16"},
+			expected: "registry/path/to/image-migration-14-16:bar",
+			name:     "path/to/image-migration-14-16",
+			tag:      "bar",
+			registry: "registry",
 		},
 		{
 			expected: "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/" +
 				"suse/manager/5.0/x86_64/server:bar",
-			name:          "suse/manager/5.0/x86_64/server",
-			tag:           "bar",
-			registry:      "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile",
-			appendToImage: []string{""},
+			name:     "suse/manager/5.0/x86_64/server",
+			tag:      "bar",
+			registry: "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile",
 		},
 		{
-			expected:      "cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
-			name:          "/suse/manager/5.0/x86_64/server",
-			tag:           "5.0.0",
-			registry:      "cloud.com",
-			appendToImage: []string{""},
+			expected: "cloud.com/suse/manager/5.0/x86_64/server:5.0.0",
+			name:     "/suse/manager/5.0/x86_64/server",
+			tag:      "5.0.0",
+			registry: "cloud.com",
 		},
 		// ignore registry if name contains fqdn
 		{
-			expected:      "cloud.com/my/path/server:5.0.0",
-			name:          "cloud.com/my/path/server:5.0.0",
-			tag:           "5.0.0",
-			registry:      "registy.suse.com",
-			appendToImage: []string{""},
+			expected: "cloud.com/my/path/server:5.0.0",
+			name:     "cloud.com/my/path/server:5.0.0",
+			tag:      "5.0.0",
+			registry: "registy.suse.com",
 		},
 	}
 
@@ -412,18 +396,18 @@ func TestComputeImage(t *testing.T) {
 			Tag:  testCase.tag,
 		}
 
-		actual, err := ComputeImage(testCase.registry, "defaulttag", image, testCase.appendToImage...)
+		actual, err := ComputeImage(testCase.registry, "defaulttag", image)
 
 		if err != nil {
 			t.Errorf(
-				"Testcase %d: Unexpected error while computing image with %s, %s, %s, %s: %s",
-				i, testCase.registry, image.Name, image.Tag, strings.Join(testCase.appendToImage, ","), err,
+				"Testcase %d: Unexpected error while computing image with %s, %s, %s: %s",
+				i, testCase.registry, image.Name, image.Tag, err,
 			)
 		}
 		if actual != testCase.expected {
 			t.Errorf(
-				"Testcase %d: Expected %s got %s when computing image with %s, %s, %s, %s",
-				i, testCase.expected, actual, testCase.registry, image.Name, image.Tag, strings.Join(testCase.appendToImage, ","),
+				"Testcase %d: Expected %s got %s when computing image with %s, %s, %s",
+				i, testCase.expected, actual, testCase.registry, image.Name, image.Tag,
 			)
 		}
 	}

--- a/uyuni-tools.changes.cbosdo.5.1-dbupgrade
+++ b/uyuni-tools.changes.cbosdo.5.1-dbupgrade
@@ -1,0 +1,2 @@
+- Actually use the --dbupgrade-tag parameter when computing the
+  image URL (bsc#1249400)


### PR DESCRIPTION
## What does this PR change?

There are a few points fixed in this commit around the dbupgrade computation (bsc#1249400):
  - the default tag should be "" to reuse the global tag
  - appending the migration suffix to the server image name should not be done in the ComputeImage as it makes it more complex.
  - unit tests are badly needed

The added unit test could be extended to cover more than the image that are computed and used, but this will wait.

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28367
Ports: https://github.com/SUSE/uyuni-tools/pull/137

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed