### PR TITLE
Fix calling of squid -z in mgrpxy cache clear (bsc#1247644)

### DIFF
--- a/mgrpxy/cmd/cache/kubernetes.go
+++ b/mgrpxy/cmd/cache/kubernetes.go
@@ -29,9 +29,5 @@ func kubernetesCacheClear(
 		return utils.Errorf(err, L("failed to remove cached data"))
 	}
 
-	if _, err := cnx.Exec("squid", "-z", "--foreground"); err != nil {
-		return utils.Errorf(err, L("failed to re-create the cache directories"))
-	}
-
 	return kubernetes.Restart(namespace, kubernetes.ProxyApp)
 }

--- a/mgrpxy/cmd/cache/podman.go
+++ b/mgrpxy/cmd/cache/podman.go
@@ -27,9 +27,5 @@ func podmanCacheClear(
 		return utils.Errorf(err, L("failed to remove cached data"))
 	}
 
-	if _, err := cnx.Exec("sh", "-c", "squid -z --foreground"); err != nil {
-		return utils.Errorf(err, L("failed to re-create the cache directories"))
-	}
-
 	return systemd.RestartService(podman.ProxyService)
 }

--- a/uyuni-tools.changes.nadvornik.cache_fix
+++ b/uyuni-tools.changes.nadvornik.cache_fix
@@ -1,0 +1,1 @@
+- Fix calling of squid -z in mgrpxy cache clear (bsc#1247644)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Do not call `squid -z` form `mgrpxy cache clear` directly. It is failing because squid process is still running 
and it is callled during container start anyway.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28029
https://bugzilla.suse.com/show_bug.cgi?id=1247644


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
