### PR TITLE
The systemd objects should no longer be instanciated directly

### DIFF
--- a/mgradm/cmd/server/rename/podman.go
+++ b/mgradm/cmd/server/rename/podman.go
@@ -21,7 +21,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
-var systemd podman.Systemd = podman.SystemdImpl{}
+var systemd podman.Systemd = podman.NewSystemd()
 
 func renameForPodman(_ *types.GlobalFlags, flags *renameFlags, _ *cobra.Command, args []string) error {
 	fqdn, err := utils.GetFqdn(args)

--- a/uyuni-tools.changes.cbosdo.hostname-rename-segfault
+++ b/uyuni-tools.changes.cbosdo.hostname-rename-segfault
@@ -1,0 +1,1 @@
+- Fix systemd object initialization in server rename. bsc#1250981


### PR DESCRIPTION
## What does this PR change?

Since the refactoring from commit c1b2f4c to make the systemd code easier to mock, the systemd objects need to be instanciated using `podman.NewSystemd()`. bsc#1250981

## Test coverage
- No tests: can only be found at runtime

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28537

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
