### PR TITLE
Detect apache and squid config in /etc/uyuni/proxy

### DIFF
--- a/mgrpxy/cmd/install/podman/podman.go
+++ b/mgrpxy/cmd/install/podman/podman.go
@@ -25,6 +25,9 @@ as parameter.
 
 The install podman command assumes podman is installed locally.
 
+/etc/uyuni/proxy/apache.conf and /etc/uyuni/squid.conf will be used as tuning files
+for apache and squid if available and not superseded by the matching command arguments.
+
 NOTE: for now installing on a remote podman is not supported!
 `),
 		Args: cobra.MaximumNArgs(1),

--- a/mgrpxy/cmd/upgrade/podman/podman.go
+++ b/mgrpxy/cmd/upgrade/podman/podman.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2025 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,6 +21,9 @@ func newCmd(globalFlags *types.GlobalFlags, run shared_utils.CommandFunc[podman.
 		Long: L(`Upgrade a proxy on podman
 
 The upgrade podman command assumes podman is upgraded locally.
+
+/etc/uyuni/proxy/apache.conf and /etc/uyuni/squid.conf will be used as tuning files
+for apache and squid if available and not superseded by the matching command arguments.
 
 NOTE: for now upgrading on a remote podman is not supported!
 `),

--- a/uyuni-tools.changes.cbosdo.pxy-tuning
+++ b/uyuni-tools.changes.cbosdo.pxy-tuning
@@ -1,0 +1,2 @@
+- Detect custom apache and squid config in the /etc/uyuni/proxy
+  folder


### PR DESCRIPTION
## What does this PR change?

To help the users automating the deployment of custom apache and squid configuration, detect and use the `/etc/uyuni/proxy/apache.conf` and `/etc/uyuni/proxy/squid.conf` files unless superseded by command line arguments at installation and upgrade time.

## Test coverage
- No tests: unit test would be over kill for such a trivial function, and integration tests need a full install
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28508
Ports: https://github.com/SUSE/uyuni-tools/pull/151

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
