### PR TITLE
Always start database container even if already enabled

### DIFF
--- a/mgradm/shared/pgsql/pgsql.go
+++ b/mgradm/shared/pgsql/pgsql.go
@@ -44,7 +44,10 @@ func SetupPgsql(
 		return utils.Error(err, L("cannot generate systemd service"))
 	}
 
-	if err := EnablePgsql(systemd); err != nil {
+	if err := systemd.EnableService(podman.DBService); err != nil {
+		return err
+	}
+	if err := systemd.StartService(podman.DBService); err != nil {
 		return err
 	}
 	cnx := shared.NewConnection("podman", podman.DBContainerName, "")
@@ -52,15 +55,6 @@ func SetupPgsql(
 		return utils.Errorf(err, L("%s fails healtcheck"), podman.DBContainerName)
 	}
 
-	return nil
-}
-
-// EnablePgsql enables the database service.
-// This function is meant for installation or migration, to enable and start the service.
-func EnablePgsql(systemd podman.Systemd) error {
-	if err := systemd.EnableService(podman.DBService); err != nil {
-		return utils.Errorf(err, L("cannot enable %s service"), podman.DBService)
-	}
 	return nil
 }
 
@@ -77,7 +71,7 @@ func Upgrade(
 		return err
 	}
 
-	if err := EnablePgsql(systemd); err != nil {
+	if err := systemd.EnableService(podman.DBService); err != nil {
 		return err
 	}
 

--- a/uyuni-tools.changes.oholecek.always_start_pg_container
+++ b/uyuni-tools.changes.oholecek.always_start_pg_container
@@ -1,0 +1,1 @@
+- Always start database container even if enabled


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Consider failed migration where database service already exists. We stop it, but it is still enabled. During another migration attempt we skip `enable --now` as it is already enabled and fail on startup check.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
