### PR TITLE
Fix space issue in changelog

### DIFF
--- a/uyuni-tools.changes.cbosdo.migration-ssl-fix
+++ b/uyuni-tools.changes.cbosdo.migration-ssl-fix
@@ -1,2 +1,2 @@
-- Add SSL secrets to the db setup container during migration.
+- Add SSL secrets to the db setup container during migration.
   bsc#1250976


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Replace an NBSP with a regular space in changelog

## Links

- Ports: https://github.com/SUSE/uyuni-tools/pull/158

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
