### PR TITLE
Properly pass the registry credentials to helm

### DIFF
--- a/shared/kubernetes/kubernetes.go
+++ b/shared/kubernetes/kubernetes.go
@@ -191,7 +191,7 @@ func createDockerSecret(
 func AddRegistry(helmArgs []string, namespace string, registry *types.Registry, appLabel string) ([]string, error) {
 	secret, err := GetRegistrySecret(namespace, registry, appLabel)
 	if secret != "" {
-		helmArgs = append(helmArgs, secret)
+		helmArgs = append(helmArgs, "--set", "registrySecret="+secret)
 	}
 	return helmArgs, err
 }

--- a/uyuni-tools.changes.cbosdo.pxy-registry-fixes
+++ b/uyuni-tools.changes.cbosdo.pxy-registry-fixes
@@ -1,0 +1,1 @@
+- Fix helm upgrade parameters (bsc#1253966)


### PR DESCRIPTION
## What does this PR change?

The credentials need to be passed as a --set registrySecret value. Without this, helm complains about not having 2 arguments. (bsc#1253966)

## Test coverage
- No tests: would need a CI with the kubernetes proxy deployment

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29028
Ports: https://github.com/SUSE/uyuni-tools/pull/168

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
