### PR TITLE
Add SSH tuning for the proxy (bsc#1253738)

### DIFF
--- a/mgrpxy/shared/kubernetes/deploy.go
+++ b/mgrpxy/shared/kubernetes/deploy.go
@@ -80,6 +80,14 @@ func Deploy(imageFlags *utils.ProxyImageFlags, helmFlags *HelmFlags, configDir s
 		helmParams = append(helmParams, "--set-file", "squid_tuning="+absPath)
 	}
 
+	if len(imageFlags.Tuning.SSH) > 0 {
+		absPath, err := filepath.Abs(imageFlags.Tuning.SSH)
+		if err != nil {
+			return err
+		}
+		helmParams = append(helmParams, "--set-file", "ssh_tuning="+absPath)
+	}
+
 	helmParams = append(helmParams,
 		"--set", "images.proxy-httpd="+imageFlags.GetContainerImage("httpd"),
 		"--set", "images.proxy-salt-broker="+imageFlags.GetContainerImage("salt-broker"),

--- a/mgrpxy/shared/templates/ssh.go
+++ b/mgrpxy/shared/templates/ssh.go
@@ -34,7 +34,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	{{- if .HTTPProxyFile }}
 	-v {{ .HTTPProxyFile }}:{{ .HTTPProxyFile }}:ro \
 	{{- end }}
-	--name uyuni-proxy-ssh \
+	${SSH_EXTRA_CONF} --name uyuni-proxy-ssh \
 	${UYUNI_IMAGE}'
 
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-ssh.ctr-id -t 10

--- a/mgrpxy/shared/utils/flags.go
+++ b/mgrpxy/shared/utils/flags.go
@@ -33,6 +33,7 @@ type ProxyImageFlags struct {
 type Tuning struct {
 	Httpd string `mapstructure:"httpd"`
 	Squid string `mapstructure:"squid"`
+	SSH   string `mapstructure:"ssh"`
 }
 
 // GetContainerImage gets the full container image name and tag for a container name.
@@ -86,6 +87,7 @@ func AddImageFlags(cmd *cobra.Command) {
 
 	cmd.Flags().String("tuning-httpd", "", L("HTTPD tuning configuration file"))
 	cmd.Flags().String("tuning-squid", "", L("Squid tuning configuration file"))
+	cmd.Flags().String("tuning-ssh", "", L("SSH server tuning configuration file"))
 	utils.AddRegistryFlag(cmd)
 }
 

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -160,7 +160,7 @@ func (d *systemdDriverImpl) StopService(service string) error {
 func (d *systemdDriverImpl) EnableService(service string) error {
 	if d.ServiceIsEnabled(service) {
 		log.Debug().Msgf("%s is already enabled.", service)
-		return nil
+		return d.StartService(service)
 	}
 	if err := utils.RunCmd("systemctl", "enable", "--now", service); err != nil {
 		return utils.Errorf(err, L("failed to enable %s systemd service"), service)

--- a/shared/testutils/flagstests/mgrpxy_kubernetes.go
+++ b/shared/testutils/flagstests/mgrpxy_kubernetes.go
@@ -45,6 +45,7 @@ var ImageProxyFlagsTestArgs = []string{
 	"--tftpd-tag", "tftpd-tag",
 	"--tuning-httpd", "path/to/httpd.conf",
 	"--tuning-squid", "path/to/squid.conf",
+	"--tuning-ssh", "path/to/ssh.conf",
 	"--registry-host", "myregistry.com",
 	"--registry-user", "user",
 	"--registry-password", "password",
@@ -70,4 +71,5 @@ func AssertProxyImageFlags(t *testing.T, flags *utils.ProxyImageFlags) {
 	testutils.AssertEquals(t, "Error parsing --tftpd-tag", "tftpd-tag", flags.Tftpd.Tag)
 	testutils.AssertEquals(t, "Error parsing --tuning-httpd", "path/to/httpd.conf", flags.Tuning.Httpd)
 	testutils.AssertEquals(t, "Error parsing --tuning-squid", "path/to/squid.conf", flags.Tuning.Squid)
+	testutils.AssertEquals(t, "Error parsing --tuning-ssh", "path/to/ssh.conf", flags.Tuning.SSH)
 }

--- a/uyuni-tools.changes.cbosdo.ssh-tuning
+++ b/uyuni-tools.changes.cbosdo.ssh-tuning
@@ -1,0 +1,1 @@
+- Add ssh tuning to configure sshd (bsc#1253738)


### PR DESCRIPTION
## What does this PR change?

Some users want to disable unsafe algorithms on the SSH server, but this cannot be done at the image level as that would break the connection to older distros.

Add parameters to pass an sshd configuration file to the container.

https://github.com/uyuni-project/uyuni/pull/11239 is needed for Kubernetes support.

## Test coverage

- Unit tests were changed
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29039

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
