### PR TITLE
Remove cgroup mount on the podman containers (bsc#1253347)

### DIFF
--- a/mgradm/cmd/uninstall/podman.go
+++ b/mgradm/cmd/uninstall/podman.go
@@ -43,7 +43,7 @@ func uninstallForPodman(
 	// Remove the volumes
 	if flags.Purge.Volumes {
 		allOk := true
-		volumes := []string{"cgroup"}
+		volumes := []string{}
 		for _, volume := range utils.ServerVolumeMounts {
 			volumes = append(volumes, volume.Name)
 		}

--- a/mgradm/shared/podman/podman_test.go
+++ b/mgradm/shared/podman/podman_test.go
@@ -18,7 +18,7 @@ func TestHasDebugPorts(t *testing.T) {
 ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
-        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        --rm --cap-add NET_RAW \
         -p 80:80 \
         -p 8003:8003 \
         -p 4505:4505`: true,
@@ -26,7 +26,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
-        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        --rm --cap-add NET_RAW \
         -p 80:80 \
         -p 4505:4505`: false,
 	}
@@ -43,14 +43,14 @@ func TestGetMirrorPath(t *testing.T) {
 ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
-        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        --rm --cap-add NET_RAW \
         -p 80:80 \
         -p 4505:4505`: "",
 		`[Service]
 ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
-        --rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+        --rm --cap-add NET_RAW \
 		-v   /path/to/mirror:/mirror \
         -p 80:80 \
         -p 4505:4505`: "/path/to/mirror",
@@ -58,7 +58,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 ExecStart=/bin/sh -c '/usr/bin/podman run \
         --name uyuni-server \
         --hostname uyuni-server.mgr.internal \
-		--rm --cap-add NET_RAW -v /path/to/mirror:/mirror --tmpfs /run -v cgroup:/sys/fs/cgroup:rw \
+		--rm --cap-add NET_RAW -v /path/to/mirror:/mirror \
         -p 80:80 \
         -p 4505:4505`: "/path/to/mirror",
 	}

--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -29,7 +29,7 @@ var runCmd = utils.RunCmd
 
 var runner = utils.NewRunner
 
-const commonArgs = "--rm --cap-add NET_RAW --tmpfs /run -v cgroup:/sys/fs/cgroup:rw"
+const commonArgs = "--rm --cap-add NET_RAW"
 
 // ServerContainerName represents the server container name.
 const ServerContainerName = "uyuni-server"

--- a/uyuni-tools.changes.cbosdo.systemd-params-cleanup
+++ b/uyuni-tools.changes.cbosdo.systemd-params-cleanup
@@ -1,0 +1,1 @@
+- Remove cgroup mount for podman containers (bsc#1253347)


### PR DESCRIPTION
## What does this PR change?

The host cgroup mount is no longer needed with podman and can cause issues. podman creates the tmp mounts and sets up cgroup delegation if systemd is the container's command.

## Test coverage
- No tests: would need to run the container

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28922
Port:
- 5.1: https://github.com/SUSE/uyuni-tools/pull/174
- 5.0: https://github.com/SUSE/uyuni-tools/pull/175

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
