### PR TITLE
feat: implement keepTemp flag

### DIFF
--- a/mgradm/cmd/cmd.go
+++ b/mgradm/cmd/cmd.go
@@ -66,12 +66,18 @@ func NewUyuniadmCommand() (*cobra.Command, error) {
 		if cmd.Name() != "completion" {
 			utils.LogInit(true)
 			utils.SetLogLevel(globalFlags.LogLevel)
+			utils.SetShouldPreserveTmpDir(globalFlags.KeepTempDir)
 			log.Info().Msgf(L("Starting %s"), strings.Join(os.Args, " "))
 			log.Info().Msgf(L("Use of this software implies acceptance of the End User License Agreement."))
 		}
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.ConfigPath, "config", "c", "", L("configuration file path"))
+	rootCmd.PersistentFlags().BoolVarP(&globalFlags.KeepTempDir, "keepTemp", "", false,
+		L("keep temporary directories for debugging purpose"))
+	if err := rootCmd.PersistentFlags().MarkHidden("keepTemp"); err != nil {
+		log.Warn().Err(err).Msg("Failed to hide keepTemp flag")
+	}
 	utils.AddLogLevelFlags(rootCmd, &globalFlags.LogLevel)
 
 	migrateCmd := migrate.NewCommand(globalFlags)

--- a/mgrpxy/cmd/cmd.go
+++ b/mgrpxy/cmd/cmd.go
@@ -59,12 +59,18 @@ func NewUyuniproxyCommand() (*cobra.Command, error) {
 		if cmd.Name() != "completion" && cmd.Name() != "__complete" {
 			utils.LogInit(true)
 			utils.SetLogLevel(globalFlags.LogLevel)
+			utils.SetShouldPreserveTmpDir(globalFlags.KeepTempDir)
 			log.Info().Msgf(L("Starting %s"), strings.Join(os.Args, " "))
 			log.Info().Msgf(L("Use of this software implies acceptance of the End User License Agreement."))
 		}
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.ConfigPath, "config", "c", "", L("configuration file path"))
+	rootCmd.PersistentFlags().BoolVarP(&globalFlags.KeepTempDir, "keepTemp", "", false,
+		L("keep temporary directories for debugging purpose"))
+	if err := rootCmd.PersistentFlags().MarkHidden("keepTemp"); err != nil {
+		log.Warn().Err(err).Msg("Failed to hide keepTemp flag")
+	}
 	utils.AddLogLevelFlags(rootCmd, &globalFlags.LogLevel)
 
 	installCmd := install.NewCommand(globalFlags)

--- a/shared/types/global.go
+++ b/shared/types/global.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2024-2025 SUSE LLC and contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,7 @@ package types
 
 // GlobalFlags represents the flags used by all commands.
 type GlobalFlags struct {
-	ConfigPath string
-	LogLevel   string
+	ConfigPath  string
+	LogLevel    string
+	KeepTempDir bool
 }

--- a/shared/utils/files_test.go
+++ b/shared/utils/files_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 Massimo Ambrosi
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTempDirRemovesDirectoryByDefault(t *testing.T) {
+	// Ensure preserve flag is false (default state)
+	SetShouldPreserveTmpDir(false)
+
+	tempDir, cleaner, err := TempDir()
+	if err != nil {
+		t.Fatalf("TempDir() failed: %v", err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Fatalf("TempDir() did not create directory: %v", err)
+	}
+
+	// Create a test file inside to verify removal works
+	testFile := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Call the cleaner function
+	cleaner()
+
+	// Verify directory was removed
+	if _, err := os.Stat(tempDir); err == nil {
+		t.Errorf("TempDir cleaner did not remove directory: %s still exists", tempDir)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Unexpected error checking directory: %v", err)
+	}
+}
+
+func TestTempDirPreservesDirectoryWhenFlagIsSet(t *testing.T) {
+	// Set preserve flag to true
+	SetShouldPreserveTmpDir(true)
+	defer SetShouldPreserveTmpDir(false) // Reset after test
+
+	tempDir, cleaner, err := TempDir()
+	if err != nil {
+		t.Fatalf("TempDir() failed: %v", err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Fatalf("TempDir() did not create directory: %v", err)
+	}
+
+	// Create a test file inside to verify it's preserved
+	testFile := filepath.Join(tempDir, "test.txt")
+	testContent := []byte("test content")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Call the cleaner function
+	cleaner()
+
+	// Verify directory still exists
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Errorf("TempDir cleaner removed directory when it should be preserved: %v", err)
+	}
+
+	// Verify the test file still exists and has correct content
+	if _, err := os.Stat(testFile); err != nil {
+		t.Errorf("Test file was removed when directory should be preserved: %v", err)
+	} else {
+		content, err := os.ReadFile(testFile)
+		if err != nil {
+			t.Errorf("Failed to read preserved test file: %v", err)
+		} else if string(content) != string(testContent) {
+			t.Errorf("Preserved file content mismatch: got %s, want %s", content, testContent)
+		}
+	}
+
+	// Clean up manually for this test
+	os.RemoveAll(tempDir)
+}
+
+func TestTempDirFlagStateIsCapturedAtCreation(t *testing.T) {
+	// Test that the flag value is captured when TempDir() is called,
+	// not when cleaner() is called
+
+	// Start with preserve = false
+	SetShouldPreserveTmpDir(false)
+
+	tempDir1, cleaner1, err := TempDir()
+	if err != nil {
+		t.Fatalf("TempDir() failed: %v", err)
+	}
+
+	// Change flag to true
+	SetShouldPreserveTmpDir(true)
+	defer SetShouldPreserveTmpDir(false)
+
+	// Create another temp dir with flag = true
+	tempDir2, cleaner2, err := TempDir()
+	if err != nil {
+		t.Fatalf("TempDir() failed: %v", err)
+	}
+
+	// Call cleaners
+	cleaner1() // Should remove (created when flag was false)
+	cleaner2() // Should preserve (created when flag was true)
+
+	// Verify first directory was removed
+	if _, err := os.Stat(tempDir1); err == nil {
+		t.Errorf("First temp dir should have been removed: %s still exists", tempDir1)
+	}
+
+	// Verify second directory was preserved
+	if _, err := os.Stat(tempDir2); err != nil {
+		t.Errorf("Second temp dir should have been preserved: %v", err)
+	} else {
+		// Clean up manually
+		os.RemoveAll(tempDir2)
+	}
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR contains the implementation of the keepTemp flag as discussed in #248
From my understanding, implementation got a lot easier since it seems all the cleaning logic got centralized into the TmpDir function which, from my understanding, was not the case back in 2024 when the issue was opened.

Default behaviour remains the pre-implementation one.

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #248 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
