### PR TITLE
During migration, krb5.conf.d should be copied in /etc/rhn (bsc#1254478)

### DIFF
--- a/mgradm/shared/templates/migrateScriptTemplate.go
+++ b/mgradm/shared/templates/migrateScriptTemplate.go
@@ -72,6 +72,14 @@ echo "-/ /root/.mgr-sync" >> exclude_list
 echo "-/ /etc/sysconfig/tomcat" >> exclude_list
 echo "-/ /etc/tomcat/tomcat.conf" >> exclude_list
 
+# exclude krb5 configuration. All settings should be store in /etc/rhn/krb5.conf.d
+echo "-/ /etc/krb5.conf.d" >> exclude_list
+
+# exclude /etc/rhn/krb5.conf.d configuration.
+# This folder should not exists in 4.3, but it's created by the Dockerfile in a persisted folder
+# This should prevents "rsync --delete" to delete it
+echo "-/ /etc/rhn/krb5.conf.d" >> exclude_list
+
 # exclude schema migration files
 echo "-/ /etc/sysconfig/rhn/reportdb-schema-upgrade" >> exclude_list
 echo "-/ /etc/sysconfig/rhn/schema-upgrade" >> exclude_list
@@ -149,6 +157,14 @@ if $SSH {{ .SourceFqdn }} test -e /etc/tomcat/conf.d; then
   rsync --delete -e "$SSH" --rsync-path='sudo rsync' -avz {{ .SourceFqdn }}:/etc/tomcat/conf.d /etc/tomcat/;
 else
   echo "Skipping tomcat configuration.."
+fi
+
+if $SSH {{ .SourceFqdn }} test -e /etc/krb5.conf.d; then
+  echo "Copying krb5 configuration.."
+  mkdir -p /etc/rhn/krb5.conf.d
+  rsync --delete -e "$SSH" --rsync-path='sudo rsync' -avz {{ .SourceFqdn }}:/etc/krb5.conf.d /etc/rhn/;
+else
+  echo "Skipping krb5 configuration.."
 fi
 
 echo "Migrating monitoring configuration..."

--- a/uyuni-tools.changes.mbussolotto.5.1_krb
+++ b/uyuni-tools.changes.mbussolotto.5.1_krb
@@ -1,0 +1,1 @@
+- During migration, krb5.conf.d should be copied in /etc/rhn (bsc#1254478)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

During migration, krb5.conf.d should be copied in /etc/rhn (bsc#1254478)

port of https://github.com/SUSE/uyuni-tools/pull/185
## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29138

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
