### PR TITLE
fix(mgrpxy): gofmt err cmd/support/ptf/podman/utils_test.go

### DIFF
--- a/mgrpxy/cmd/support/ptf/podman/utils_test.go
+++ b/mgrpxy/cmd/support/ptf/podman/utils_test.go
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //go:build ptf
+
 package podman
 
 import (


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Tiny change. A missing new line between comments/build tags and package throws gofmt error when using the build script:

```
./build.sh 
mgrpxy/cmd/support/ptf/podman/utils_test.go:1:1: File is not properly formatted (gofmt)
// SPDX-FileCopyrightText: 2025 SUSE LLC
^
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: Fixing a syntax issue flagged by gofmt

- [x] **DONE**

## Links

Issue(s): n/a

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
