### PR TITLE
Fix issue validating missing CA during install

### DIFF
--- a/mgradm/cmd/support/ptf/podman/podman_test.go
+++ b/mgradm/cmd/support/ptf/podman/podman_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 //go:build ptf
@@ -34,8 +34,8 @@ func TestParamsParsing(t *testing.T) {
 		testutils.AssertEquals(t, "Error parsing --user", "sccuser", flags.CustomerID)
 		testutils.AssertEquals(t, "Error parsing --pullPolicy", "never", flags.Image.PullPolicy)
 		testutils.AssertEquals(t, "Error parsing --registry", "myOldRegistry", flags.Image.Registry.Host)
-		flagstests.AssertRegistryFlag(t, &flags.ServerFlags.Image.Registry)
-		flagstests.AssertSCCFlag(t, &flags.ServerFlags.Installation.SCC)
+		flagstests.AssertRegistryFlag(t, &flags.Image.Registry)
+		flagstests.AssertSCCFlag(t, &flags.Installation.SCC)
 		return nil
 	}
 

--- a/mgrpxy/cmd/support/ptf/podman/utils.go
+++ b/mgrpxy/cmd/support/ptf/podman/utils.go
@@ -120,7 +120,7 @@ func updateParameters(flags *podmanPTFFlags, authFile string) error {
 	for _, config := range proxyImages {
 		if containerImage := getServiceImage(config.serviceName); containerImage != "" {
 			// If no image was found then skip it during the upgrade.
-			newImage, err := utils.ComputePTF(flags.UpgradeFlags.ProxyImageFlags.Registry.Host, flags.CustomerID, projectID,
+			newImage, err := utils.ComputePTF(flags.UpgradeFlags.Registry.Host, flags.CustomerID, projectID,
 				containerImage, suffix)
 			log.Debug().Msgf("computed PTF image url: %s", newImage)
 			if err != nil {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fix error validating the CA during install. This is a side effect of commit d8842f22 as the CA doesn't exist at that time.

## Test coverage
- No tests: needs to run the full installation / migration to catch SSL issues
- [x] **DONE**

## Links

Issue(s): #
Port: https://github.com/SUSE/uyuni-tools/pull/186

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
