### PR TITLE
Add mgradm ssh remove-known-host command to clear SSH known hosts entries

### DIFF
--- a/mgradm/cmd/cmd.go
+++ b/mgradm/cmd/cmd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -25,6 +25,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/restart"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/scale"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/server"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/ssh"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/start"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/status"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/stop"
@@ -99,6 +100,7 @@ func NewUyuniadmCommand() (*cobra.Command, error) {
 	rootCmd.AddCommand(gpg.NewCommand(globalFlags))
 	rootCmd.AddCommand(backup.NewCommand(globalFlags))
 	rootCmd.AddCommand(server.NewCommand(globalFlags))
+	rootCmd.AddCommand(ssh.NewCommand(globalFlags))
 
 	rootCmd.AddCommand(utils.GetConfigHelpCommand())
 

--- a/mgradm/cmd/ssh/removeknownhost/removeknownhost.go
+++ b/mgradm/cmd/ssh/removeknownhost/removeknownhost.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package removeknownhost
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/shared"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+const knownHostsPath = "/var/lib/salt/.ssh/known_hosts"
+
+type removeKnownHostFlags struct {
+	Backend string
+}
+
+func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[removeKnownHostFlags]) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove-known-host [hostname]...",
+		Short: L("Remove SSH known host entries"),
+		Long:  L("Remove entries from the SSH known_hosts file to avoid host key verification errors"),
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags removeKnownHostFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
+		},
+	}
+
+	utils.AddBackendFlag(cmd)
+	return cmd
+}
+
+// NewCommand removes SSH known host entries from the server container.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	return newCmd(globalFlags, removeKnownHost)
+}
+
+func removeKnownHost(_ *types.GlobalFlags, flags *removeKnownHostFlags, _ *cobra.Command, args []string) error {
+	cnx := shared.NewConnection(flags.Backend, podman.ServerContainerName, kubernetes.ServerFilter)
+
+	if !cnx.TestExistenceInPod(knownHostsPath) {
+		log.Info().Msg(L("No known_hosts file found, nothing to remove"))
+		return nil
+	}
+
+	for _, hostname := range args {
+		log.Info().Msgf(L("Removing SSH known host entry for %s"), hostname)
+		if err := adm_utils.ExecCommand(
+			zerolog.InfoLevel, cnx, "ssh-keygen", "-R", hostname, "-f", knownHostsPath,
+		); err != nil {
+			return utils.Errorf(err, L("failed to remove known host entry for %s"), hostname)
+		}
+	}
+
+	log.Info().Msg(L("SSH known host entries removed successfully"))
+	return nil
+}

--- a/mgradm/cmd/ssh/ssh.go
+++ b/mgradm/cmd/ssh/ssh.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/ssh/removeknownhost"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+// NewCommand to manage SSH configuration.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	sshCmd := &cobra.Command{
+		Use:     "ssh",
+		GroupID: "tool",
+		Short:   L("Manage SSH configuration"),
+	}
+
+	sshCmd.AddCommand(removeknownhost.NewCommand(globalFlags))
+
+	return sshCmd
+}

--- a/uyuni-tools.changes.digvijay.ssh-remove-known-host
+++ b/uyuni-tools.changes.digvijay.ssh-remove-known-host
@@ -1,0 +1,1 @@
+- mgradm: add ssh remove-known-host command to clear SSH known hosts entries


### PR DESCRIPTION
## What does this PR change?

This PR introduces a new `mgradm ssh remove-known-host` command that removes SSH known host entries from the Uyuni server container. This allows users to resolve "REMOTE HOST IDENTIFICATION HAS CHANGED" errors without manually accessing the container.

```bash
# Remove a single host entry
mgradm ssh remove-known-host 192.168.3.68

# Remove multiple host entries
mgradm ssh remove-known-host 192.168.3.68 192.168.1.12

# With explicit backend 
mgradm ssh remove-known-host --backend podman 192.168.3.68
```

I manually tested the build binaries by loading them in my VM. Here are some SS for reference.

<img width="983" height="843" alt="Screenshot From 2026-01-26 12-58-44" src="https://github.com/user-attachments/assets/f624e632-0565-4081-a38f-d3dde33bcafe" />
<img width="983" height="164" alt="Screenshot From 2026-01-26 12-59-38" src="https://github.com/user-attachments/assets/ca76975f-3fd3-4bfd-9b1a-377c4252cf6a" />
 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: We can add them if needed.

- [X] **DONE**

## Links

Issue(s): #501 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
