### PR TITLE
Explicitly start proxy pods after enable

### DIFF
--- a/mgrpxy/cmd/install/utils.go
+++ b/mgrpxy/cmd/install/utils.go
@@ -20,15 +20,6 @@ import (
 
 var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
-// Start the proxy services.
-func startPod() error {
-	ret := systemd.IsServiceRunning(shared_podman.ProxyService)
-	if ret {
-		return systemd.RestartService(shared_podman.ProxyService)
-	}
-	return systemd.EnableService(shared_podman.ProxyService)
-}
-
 func installForPodman(
 	_ *types.GlobalFlags,
 	flags *podman.PodmanProxyFlags,
@@ -92,5 +83,5 @@ func installForPodman(
 		return err
 	}
 
-	return startPod()
+	return podman.StartPod(systemd)
 }

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -367,7 +367,10 @@ func StartPod(systemd podman.Systemd) error {
 	if ret {
 		return systemd.RestartService(podman.ProxyService)
 	}
-	return systemd.EnableService(podman.ProxyService)
+	if err := systemd.EnableService(podman.ProxyService); err != nil {
+		return err
+	}
+	return systemd.StartService(podman.ProxyService)
 }
 
 func getSystemIDEvent() ([]byte, error) {

--- a/uyuni-tools.changes.oholecek.fix_proxy_pod_autostart
+++ b/uyuni-tools.changes.oholecek.fix_proxy_pod_autostart
@@ -1,0 +1,2 @@
+- Explicitly start proxy pods after operations
+  (bsc#1258015)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Port of https://github.com/SUSE/uyuni-tools/pull/206

`EnableService` skip starting the service if the service is already enabled. This PR adds explicit start of the service.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links https://github.com/SUSE/spacewalk/issues/29630

Issue(s): #

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
