### PR TITLE
Set proxy config file permissions (bsc#1257660)

### DIFF
--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -247,6 +247,10 @@ func UnpackConfig(configPath string) error {
 		return err
 	}
 
+	if err := os.Chmod(proxyConfigDir, 0755); err != nil {
+		return err
+	}
+
 	if err := checkPermissions(proxyConfigDir, 0005|0050|0500); err != nil {
 		return err
 	}
@@ -290,6 +294,10 @@ func validateInstallYamlFiles(dir string) error {
 			return fmt.Errorf(L("missing required configuration file: %s"), filePath)
 		}
 		if file == "config.yaml" {
+			if err := os.Chmod(filePath, 0644); err != nil {
+				return err
+			}
+
 			if err := checkPermissions(filePath, 0004|0040|0400); err != nil {
 				return err
 			}

--- a/mgrpxy/shared/podman/podman_test.go
+++ b/mgrpxy/shared/podman/podman_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,20 +36,6 @@ func TestValidateYamlFiles(t *testing.T) {
 	// Test: when all files are present and have correct permissions
 	if err := validateInstallYamlFiles(tempDir); err != nil {
 		t.Errorf("Expected no error, got %v", err)
-	}
-
-	// Change the permission of config.yaml to 0600 to simulate a permission error
-	configFilePath := path.Join(tempDir, "config.yaml")
-	if err := os.Chmod(configFilePath, 0600); err != nil {
-		t.Fatalf("Failed to change permissions for %s: %v", configFilePath, err)
-	}
-	if err := validateInstallYamlFiles(tempDir); err == nil {
-		t.Errorf("Expected an error due to incorrect permissions on config.yaml, but got none")
-	}
-
-	// Restore the correct permissions for the next test run
-	if err := os.Chmod(configFilePath, 0644); err != nil {
-		t.Fatalf("Failed to restore permissions for %s: %v", configFilePath, err)
 	}
 
 	// Test: Missing file scenario, remove one file and expect an error

--- a/uyuni-tools.changes.nadvornik.config_perm
+++ b/uyuni-tools.changes.nadvornik.config_perm
@@ -1,0 +1,1 @@
+- Set proxy config file permissions (bsc#1257660)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Port of https://github.com/SUSE/uyuni-tools/pull/203

This PR explicitly sets the permission of config.yaml and /etc/uyuni/proxy directory. This way it can work with more restrictive umask 0027.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29572

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
