### PR TITLE
Disable TFTP by default on the server

### DIFF
--- a/mgradm/cmd/install/flags.go
+++ b/mgradm/cmd/install/flags.go
@@ -5,7 +5,6 @@
 package install
 
 import (
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	cmd_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
@@ -18,10 +17,6 @@ func AddInstallFlags(cmd *cobra.Command) {
 	cmd.Flags().String("email", "admin@example.com", L("Administrator e-mail"))
 	cmd.Flags().String("emailfrom", "notifications@example.com", L("E-Mail sending the notifications"))
 	cmd.Flags().String("issParent", "", L("InterServerSync v1 parent FQDN"))
-	cmd.Flags().Bool("tftp", true, L("Enable TFTP"))
-	if err := cmd.Flags().MarkDeprecated("tftp", "Use --tftpd-disable instead"); err != nil {
-		log.Error().Err(err).Msg(L("failed to mark tftp deprecated"))
-	}
 
 	cmd_utils.AddServerFlags(cmd)
 

--- a/mgradm/cmd/install/install.go
+++ b/mgradm/cmd/install/install.go
@@ -61,6 +61,7 @@ func getFlagsUpdater(flags *podmanInstallFlags) utils.FlagsUpdaterFunc {
 		flags.Coco.IsChanged = v.IsSet("coco.replicas")
 		flags.HubXmlrpc.IsChanged = v.IsSet("hubxmlrpc.replicas")
 		flags.Saline.IsChanged = v.IsSet("saline.replicas") || v.IsSet("saline.port")
+		flags.TFTPD.IsChanged = v.IsSet("tftpd.enable")
 
 		if flags.Installation.SSL.Ca.IsThirdParty() && !flags.Installation.SSL.DB.CA.IsThirdParty() {
 			flags.Installation.SSL.DB.CA.Root = flags.Installation.SSL.Ca.Root
@@ -69,9 +70,6 @@ func getFlagsUpdater(flags *podmanInstallFlags) utils.FlagsUpdaterFunc {
 		if flags.Installation.SSL.Server.IsDefined() && !flags.Installation.SSL.DB.IsDefined() {
 			flags.Installation.SSL.DB.Cert = flags.Installation.SSL.Server.Cert
 			flags.Installation.SSL.DB.Key = flags.Installation.SSL.Server.Key
-		}
-		if !flags.Installation.Tftp {
-			flags.TFTPD.Enable = false
 		}
 	}
 }

--- a/mgradm/cmd/install/utils.go
+++ b/mgradm/cmd/install/utils.go
@@ -109,7 +109,7 @@ func installForPodman(
 		coco.SetupCocoContainer(systemd, authFile, flags.Coco, flags.Image, flags.Installation.DB),
 		hub.SetupHubXmlrpc(systemd, authFile, flags.Image, flags.HubXmlrpc),
 		saline.SetupSalineContainer(systemd, authFile, flags.Image, flags.Saline, flags.Installation.TZ),
-		tftp.SetupTFTPContainer(systemd, authFile, flags.Image, flags.TFTPD, fqdn),
+		tftp.SetupTFTPContainer(systemd, authFile, flags.Image, flags.TFTPD, fqdn, false),
 	)
 }
 

--- a/mgradm/cmd/upgrade/upgrade.go
+++ b/mgradm/cmd/upgrade/upgrade.go
@@ -36,6 +36,7 @@ func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[podmanUpgradeF
 				flags.Coco.IsChanged = v.IsSet("coco.replicas")
 				flags.HubXmlrpc.IsChanged = v.IsSet("hubxmlrpc.replicas")
 				flags.Saline.IsChanged = v.IsSet("saline.replicas") || v.IsSet("saline.port")
+				flags.TFTPD.IsChanged = v.IsSet("tftpd.enable")
 			}
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, flagsUpdater, run)
 		},

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -334,7 +334,11 @@ func Upgrade(
 		return err
 	}
 
+	hasTFTP := systemd.ServiceIsEnabled(podman.TFTPService)
 	if systemd.HasService(podman.ServerService) {
+		if !hasTFTP {
+			hasTFTP = serverExposesTFTP(systemd)
+		}
 		if err := systemd.StopService(podman.ServerService); err != nil {
 			return utils.Errorf(err, L("cannot stop service"))
 		}
@@ -478,9 +482,18 @@ func Upgrade(
 		coco.Upgrade(systemd, authFile, cocoFlags, image, inspectedDB),
 		hub.Upgrade(systemd, authFile, image, hubXmlrpcFlags),
 		saline.Upgrade(systemd, authFile, image, salineFlags, utils.GetLocalTimezone()),
-		tftp.Upgrade(systemd, authFile, image, tftpdFlags, fqdn),
+		tftp.Upgrade(systemd, authFile, image, tftpdFlags, fqdn, hasTFTP),
 		systemd.ReloadDaemon(false),
 	)
+}
+
+func serverExposesTFTP(systemd podman.Systemd) bool {
+	def, err := systemd.GetServiceDefinition(podman.ServerService)
+	if err != nil {
+		log.Error().Err(err).Msg(L("Failed to read server service definition to look for TFTP port"))
+		return false
+	}
+	return strings.Contains(def, "-p 69:69/udp")
 }
 
 func WaitForSystemStart(

--- a/mgradm/shared/tftp/tftp.go
+++ b/mgradm/shared/tftp/tftp.go
@@ -24,20 +24,24 @@ func SetupTFTPContainer(
 	baseImage types.ImageFlags,
 	tftpFlags adm_utils.TFTPDFlags,
 	fqdn string,
+	hasTFTP bool,
 ) error {
-	if !tftpFlags.Enable && systemd.ServiceIsEnabled(podman.TFTPService) {
+	log.Debug().Msgf("TFTP server already enabled: %v", hasTFTP)
+	if hasTFTP && tftpFlags.IsChanged && !tftpFlags.Enable {
 		log.Debug().Msgf("The TFTP service is no longer requested")
 		if err := systemd.DisableService(podman.TFTPService); err != nil {
 			return err
 		}
 	}
 
+	enable := hasTFTP && !tftpFlags.IsChanged || tftpFlags.IsChanged && tftpFlags.Enable
+
 	tftpImage, err := utils.ComputeImage(baseImage.Registry.Host, baseImage.Tag, tftpFlags.Image)
 	if err != nil {
 		return utils.Errorf(err, L("failed to compute image URL"))
 	}
 
-	preparedImage, err := podman.PrepareImage(authFile, tftpImage, baseImage.PullPolicy, tftpFlags.Enable)
+	preparedImage, err := podman.PrepareImage(authFile, tftpImage, baseImage.PullPolicy, enable)
 	if err != nil {
 		return err
 	}
@@ -46,7 +50,7 @@ func SetupTFTPContainer(
 		return utils.Errorf(err, L("cannot generate systemd service"))
 	}
 
-	if tftpFlags.Enable {
+	if enable {
 		if err := systemd.EnableService(podman.TFTPService); err != nil {
 			return err
 		}
@@ -61,26 +65,21 @@ func Upgrade(
 	baseImage types.ImageFlags,
 	tftpFlags adm_utils.TFTPDFlags,
 	fqdn string,
+	hasTFTP bool,
 ) error {
 	if tftpFlags.Image.Name == "" {
 		// Don't touch the tftp service in ptf if not already present.
 		return nil
 	}
-	if err := SetupTFTPContainer(systemd, authFile, baseImage, tftpFlags, fqdn); err != nil {
+
+	if err := SetupTFTPContainer(systemd, authFile, baseImage, tftpFlags, fqdn, hasTFTP); err != nil {
 		return err
 	}
 
-	if err := systemd.ReloadDaemon(false); err != nil {
-		return err
-	}
-
-	if !tftpFlags.IsChanged {
-		return systemd.RestartInstantiated(podman.HubXmlrpcService)
-	}
 	if systemd.ServiceIsEnabled(podman.TFTPService) {
 		return systemd.RestartService(podman.TFTPService)
 	}
-	return systemd.EnableService(podman.TFTPService)
+	return nil
 }
 
 // generateTFTPSystemdService creates the TFTP systemd files.

--- a/mgradm/shared/utils/flags.go
+++ b/mgradm/shared/utils/flags.go
@@ -47,7 +47,6 @@ type InstallationFlags struct {
 	Email        string
 	EmailFrom    string
 	IssParent    string
-	Tftp         bool
 	DB           DBFlags
 	ReportDB     DBFlags
 	SSL          InstallSSLFlags

--- a/shared/podman/interfaces.go
+++ b/shared/podman/interfaces.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -76,4 +76,7 @@ type Systemd interface {
 
 	// Show calls the systemctl show command and returns the output.
 	Show(service string, property string) (string, error)
+
+	// GetServiceDefinition returns the output of systemctl cat.
+	GetServiceDefinition(service string) (string, error)
 }

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -80,6 +80,9 @@ type SystemdDriver interface {
 
 	// GetServiceProperty returns the value of a systemd service property.
 	GetServiceProperty(service string, property string) (string, error)
+
+	// GetServiceDefinition returns the output of systemctl cat for a service.
+	GetServiceDefinition(service string) (string, error)
 }
 
 type systemdDriverImpl struct {
@@ -183,6 +186,18 @@ func (d *systemdDriverImpl) GetServiceProperty(service string, property string) 
 	return strings.TrimPrefix(strings.TrimSpace(string(out)), property+"="), nil
 }
 
+func (d *systemdDriverImpl) GetServiceDefinition(service string) (string, error) {
+	serviceName := service
+	if strings.HasSuffix(service, "@") {
+		serviceName = service + "0"
+	}
+	out, err := newRunner("systemctl", "cat", serviceName).Exec()
+	if err != nil {
+		return "", utils.Errorf(err, L("Failed to get the definition from %[2]s service"), service)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // NewSystemd returns a new Systemd instance.
 func NewSystemd() Systemd {
 	driver := systemdDriverImpl{}
@@ -229,6 +244,10 @@ func GetServicePath(name string) string {
 
 func (s SystemdImpl) GetServiceProperty(service string, property string) (string, error) {
 	return s.driver.GetServiceProperty(service, property)
+}
+
+func (s SystemdImpl) GetServiceDefinition(service string) (string, error) {
+	return s.driver.GetServiceDefinition(service)
 }
 
 // GetServiceConfFolder return the conf folder for systemd services.
@@ -452,7 +471,7 @@ func GenerateSystemdConfFile(serviceName string, filename string, body string, w
 	if withHeader {
 		header = confHeader
 	}
-	content := []byte(fmt.Sprintf("%s[Service]\n%s\n", header, body))
+	content := fmt.Appendf([]byte(header), "[Service]\n%s\n", body)
 	if err := os.WriteFile(systemdConfFilePath, content, 0644); err != nil {
 		return utils.Errorf(err, L("cannot write %s file"), systemdConfFilePath)
 	}

--- a/shared/testutils/flagstests/mgradm_install.go
+++ b/shared/testutils/flagstests/mgradm_install.go
@@ -18,7 +18,6 @@ var InstallFlagsTestArgs = func() []string {
 		"--email", "admin@foo.bar",
 		"--emailfrom", "sender@foo.bar",
 		"--issParent", "parent.iss.com",
-		"--tftp=false",
 		"--reportdb-user", "reportdbuser",
 		"--reportdb-password", "reportdbpass",
 		"--reportdb-name", "reportdbname",
@@ -54,7 +53,6 @@ func AssertInstallFlags(t *testing.T, flags *utils.ServerFlags) {
 	testutils.AssertEquals(t, "Error parsing --email", "admin@foo.bar", flags.Installation.Email)
 	testutils.AssertEquals(t, "Error parsing --emailfrom", "sender@foo.bar", flags.Installation.EmailFrom)
 	testutils.AssertEquals(t, "Error parsing --issParent", "parent.iss.com", flags.Installation.IssParent)
-	testutils.AssertEquals(t, "Error parsing --tftp", false, flags.Installation.Tftp)
 	testutils.AssertTrue(t, "Error parsing --debug-java", flags.Installation.Debug.Java)
 	testutils.AssertEquals(t, "Error parsing --admin-login", "adminuser", flags.Installation.Admin.Login)
 	testutils.AssertEquals(t, "Error parsing --admin-password", "adminpass", flags.Installation.Admin.Password)

--- a/shared/testutils/systemd.go
+++ b/shared/testutils/systemd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -43,6 +43,9 @@ type FakeSystemdDriver struct {
 
 	// ServiceProperties maps all the properties of each service.
 	ServiceProperties map[string]map[string]string
+
+	// ServiceCat maps the definition of each service.
+	ServiceCat map[string]string
 }
 
 // HasService returns if a systemd service is installed.
@@ -139,6 +142,16 @@ func (d *FakeSystemdDriver) GetServiceProperty(service string, property string) 
 		return "", errors.New("no such property")
 	}
 	return value, nil
+}
+
+// GetServiceDefinition gets the definition from the ServiceCat field.
+// An error is returned if the service doesn't exist.
+func (d *FakeSystemdDriver) GetServiceDefinition(service string) (string, error) {
+	cat, exists := d.ServiceCat[service]
+	if !exists {
+		return "", errors.New("no such service")
+	}
+	return cat, nil
 }
 
 // deleteItems removes all items equal to needle in the slice.

--- a/shared/utils/cmd.go
+++ b/shared/utils/cmd.go
@@ -53,14 +53,14 @@ var DefaultPullPolicy = "Always"
 var Version = "0.0.0"
 
 // CommandFunc is a function to be executed by a Cobra command.
-type CommandFunc[F interface{}] func(*types.GlobalFlags, *F, *cobra.Command, []string) error
+type CommandFunc[F any] func(*types.GlobalFlags, *F, *cobra.Command, []string) error
 
 // FlagsUpdaterFunc is a function to be executed to update the flags from the viper instance used to parsed the config.
 type FlagsUpdaterFunc func(*viper.Viper)
 
 // CommandHelper parses the configuration file into the flags and runs the fn function.
 // This function should be passed to Command's RunE.
-func CommandHelper[T interface{}](
+func CommandHelper[T any](
 	globalFlags *types.GlobalFlags,
 	cmd *cobra.Command,
 	args []string,
@@ -101,8 +101,8 @@ func StringToRegistryHook() mapstructure.DecodeHookFunc {
 	return func(
 		_ reflect.Type,
 		t reflect.Type,
-		data interface{},
-	) (interface{}, error) {
+		data any,
+	) (any, error) {
 		// Only intercept if the target is Registry
 		if t != reflect.TypeOf(types.Registry{}) {
 			return data, nil
@@ -112,7 +112,7 @@ func StringToRegistryHook() mapstructure.DecodeHookFunc {
 		case string:
 			// If Registry is a string, create Registry struct with Host = string
 			return types.Registry{Host: val}, nil
-		case map[string]interface{}:
+		case map[string]any:
 			// If it's a map, decode normally
 			return data, nil
 		default:
@@ -201,7 +201,7 @@ func AddLogLevelFlags(cmd *cobra.Command, logLevel *string) {
 func AddTFTPDFlags(cmd *cobra.Command, allowDisable bool, groupName string) {
 	AddContainerImageFlags(cmd, "tftpd", L("TFTPD"), groupName, "proxy-tftpd")
 	if allowDisable {
-		cmd.Flags().Bool("tftpd-enable", true, L("Start the TFTP server container"))
+		cmd.Flags().Bool("tftpd-enable", false, L("Start the TFTP server container"))
 		if groupName != "" {
 			_ = AddFlagToHelpGroupID(cmd, "tftpd-enable", groupName)
 		}

--- a/uyuni-tools.changes.cbosdo.tftp-split
+++ b/uyuni-tools.changes.cbosdo.tftp-split
@@ -1,0 +1,1 @@
+- Disable TFTP by default on the server


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

The TFTP container will be disabled on the server by default. It will be enabled when upgrading from a server container exposing the TFTP port.

The rationale behind this change is that the TFTP server should not be used from the server but using the retail branch server: aka proxy.

## Test coverage
- No tests: Needs manual tests for the real installation

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29758

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
