### PR TITLE
feat: implement mgrctl get system command with table/JSON output (Issue #238)

### DIFF
--- a/mgrctl/cmd/cmd.go
+++ b/mgrctl/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/api"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/cp"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/exec"
+	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/get"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/proxy"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/term"
 	"github.com/uyuni-project/uyuni-tools/shared/completion"
@@ -51,6 +52,7 @@ func NewUyunictlCommand() *cobra.Command {
 	apiCmd := api.NewCommand(globalFlags)
 	rootCmd.AddCommand(apiCmd)
 	rootCmd.AddCommand(exec.NewCommand(globalFlags))
+	rootCmd.AddCommand(get.NewCommand(globalFlags))
 	rootCmd.AddCommand(term.NewCommand(globalFlags))
 	rootCmd.AddCommand(cp.NewCommand(globalFlags))
 	rootCmd.AddCommand(completion.NewCommand(globalFlags))

--- a/mgrctl/cmd/get/get.go
+++ b/mgrctl/cmd/get/get.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package get
+
+import (
+    "github.com/spf13/cobra"
+    "github.com/uyuni-project/uyuni-tools/shared/api"
+    . "github.com/uyuni-project/uyuni-tools/shared/l10n"
+    "github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+type getFlags struct {
+    api.ConnectionDetails `mapstructure:"api"`
+    Output                string `mapstructure:"output"`
+}
+
+// NewCommand returns the get command.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+    getCmd := &cobra.Command{
+        Use:   "get",
+        Short: L("Query Uyuni server resources"),
+        Long: L(`Query resources from the Uyuni server API.
+
+Supports multiple resource types and output formats.
+
+Examples:
+  # List all systems in table format
+  mgrctl get system
+
+  # Search for a system by name
+  mgrctl get system webserver
+
+  # Output as JSON
+  mgrctl get system -o json`),
+    }
+
+    getCmd.AddCommand(newSystemCommand(globalFlags))
+    api.AddAPIFlags(getCmd)
+
+    return getCmd
+}

--- a/mgrctl/cmd/get/get_test.go
+++ b/mgrctl/cmd/get/get_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package get
+
+import (
+    "testing"
+
+    "github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+func TestNewCommand(t *testing.T) {
+    var globalFlags types.GlobalFlags
+    cmd := NewCommand(&globalFlags)
+    if cmd == nil {
+        t.Fatal("NewCommand returned nil")
+    }
+    if cmd.Use != "get" {
+        t.Errorf("expected Use 'get', got '%s'", cmd.Use)
+    }
+    // Verify system subcommand exists
+    found := false
+    for _, sub := range cmd.Commands() {
+        if sub.Use == "system [name]" {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Error("system subcommand not found")
+    }
+}
+
+func TestPrintSystemsTable(t *testing.T) {
+    systems := []System{
+        {ID: 1, Name: "web-server", LastCheckin: "2026-03-26"},
+    }
+    // Should not error
+    if err := printSystems(systems, "table"); err != nil {
+        t.Errorf("unexpected error: %v", err)
+    }
+}
+
+func TestPrintSystemsJSON(t *testing.T) {
+    systems := []System{
+        {ID: 1, Name: "web-server", LastCheckin: "2026-03-26"},
+    }
+    if err := printSystems(systems, "json"); err != nil {
+        t.Errorf("unexpected error: %v", err)
+    }
+}
+
+func TestPrintSystemsInvalidFormat(t *testing.T) {
+    systems := []System{}
+    if err := printSystems(systems, "invalid"); err == nil {
+        t.Error("expected error for invalid format")
+    }
+}

--- a/mgrctl/cmd/get/system.go
+++ b/mgrctl/cmd/get/system.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package get
+
+import (
+    "encoding/json"
+    "fmt"
+    "strings"
+    "text/tabwriter"
+    "os"
+
+    "github.com/spf13/cobra"
+    "github.com/uyuni-project/uyuni-tools/shared/api"
+    . "github.com/uyuni-project/uyuni-tools/shared/l10n"
+    "github.com/uyuni-project/uyuni-tools/shared/types"
+    "github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+// System represents a system from the Uyuni API.
+type System struct {
+    ID          int    `json:"id"`
+    Name        string `json:"name"`
+    LastCheckin string `json:"last_checkin"`
+}
+
+func newSystemCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+    var flags getFlags
+
+    cmd := &cobra.Command{
+        Use:   "system [name]",
+        Short: L("List or search systems"),
+        Long: L(`List all registered systems or search by name.
+
+Examples:
+  # List all systems
+  mgrctl get system
+
+  # Search systems by name
+  mgrctl get system webserver
+
+  # Output as JSON
+  mgrctl get system -o json`),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, runSystem)
+        },
+    }
+
+    cmd.Flags().StringP("output", "o", "table", L("Output format: table, json, yaml"))
+
+    return cmd
+}
+
+func runSystem(_ *types.GlobalFlags, flags *getFlags, _ *cobra.Command, args []string) error {
+    client, err := api.Init(&flags.ConnectionDetails)
+    if err != nil {
+        return utils.Errorf(err, L("failed to initialize API client"))
+    }
+
+    if client.Details.User != "" || client.Details.InSession {
+        if err = client.Login(); err != nil {
+            return utils.Errorf(err, L("unable to login to the server"))
+        }
+    }
+
+    if len(args) > 0 {
+        return searchSystem(client, args[0], flags.Output)
+    }
+    return listSystems(client, flags.Output)
+}
+
+func listSystems(client *api.APIClient, format string) error {
+    res, err := api.Get[[]System](client, "system/listSystems")
+    if err != nil {
+        return utils.Errorf(err, L("failed to list systems"))
+    }
+
+    return printSystems(res.Result, format)
+}
+
+func searchSystem(client *api.APIClient, name string, format string) error {
+    res, err := api.Get[[]System](client, fmt.Sprintf("system/searchByName?searchTerm=%s", name))
+    if err != nil {
+        return utils.Errorf(err, L("failed to search systems"))
+    }
+
+    return printSystems(res.Result, format)
+}
+
+func printSystems(systems []System, format string) error {
+    switch strings.ToLower(format) {
+    case "json":
+        out, err := json.MarshalIndent(systems, "", "  ")
+        if err != nil {
+            return utils.Errorf(err, L("failed to format output as JSON"))
+        }
+        fmt.Println(string(out))
+    case "table", "":
+        w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+        fmt.Fprintln(w, "ID\tNAME\tLAST CHECKIN")
+        for _, s := range systems {
+            fmt.Fprintf(w, "%d\t%s\t%s\n", s.ID, s.Name, s.LastCheckin)
+        }
+        w.Flush()
+    default:
+        return fmt.Errorf(L("unsupported output format: %s"), format)
+    }
+
+    return nil
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?
It adds the `mgrctl get system` command with support 
listing and searching systems in json/table output formats.

i also have added basic unit tests.

there `get group` command not yet implement
also properity base filtering yet not wrtten like (`-f cpu=x86_64`)
also yaml not yet implement

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #238 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
