### PR TITLE
Add the TFTP port back to the proxy

### DIFF
--- a/mgradm/cmd/backup/restore/restore.go
+++ b/mgradm/cmd/backup/restore/restore.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -249,7 +249,7 @@ func restoreSystemdConfig(inputDirectory string, flags *shared.Flagpole) error {
 	systemdConfigFile := path.Join(inputDirectory, shared.SystemdConfBackupFile)
 	if !utils.FileExists(systemdConfigFile) {
 		log.Warn().Msg(L("systemd backup not found in the backup location, generating defaults"))
-		return generateDefaltSystemdServices(flags)
+		return generateDefaultSystemdServices(flags)
 	}
 	if !flags.SkipVerify {
 		if err := utils.ValidateChecksum(systemdConfigFile); err != nil {

--- a/mgradm/cmd/backup/restore/systemd_utils.go
+++ b/mgradm/cmd/backup/restore/systemd_utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -96,7 +96,7 @@ func restoreFileAttributes(filename string, th *tar.Header) error {
 	return e
 }
 
-func generateDefaltSystemdServices(flags *shared.Flagpole) error {
+func generateDefaultSystemdServices(flags *shared.Flagpole) error {
 	if flags.DryRun {
 		log.Info().Msg(L("Would generate default systemd services"))
 		return nil

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -33,10 +33,9 @@ import (
 
 var systemd podman.Systemd = podman.NewSystemd()
 
-// GetExposedPorts returns the port exposed.
-func GetExposedPorts(debug bool) []types.PortMap {
+// getExposedPorts returns the port exposed.
+func getExposedPorts(debug bool) []types.PortMap {
 	ports := utils.GetServerPorts(debug)
-	ports = append(ports, utils.NewPortMap(utils.WebServiceName, "https", 443, 443))
 	ports = append(ports, utils.TCPPodmanPorts...)
 	return ports
 }
@@ -51,9 +50,9 @@ func GenerateServerSystemdService(mirrorPath string, debug bool) error {
 		args = append(args, "-v", mirrorPath+":/mirror")
 	}
 
-	ports := GetExposedPorts(debug)
+	ports := getExposedPorts(debug)
 	if _, err := exec.LookPath("csp-billing-adapter"); err == nil {
-		ports = append(ports, utils.NewPortMap("csp", "csp-billing", 18888, 18888))
+		ports = append(ports, utils.NewPortMap(18888))
 		args = append(args, "-e ISPAYG=1")
 	}
 

--- a/mgradm/shared/templates/templates_test.go
+++ b/mgradm/shared/templates/templates_test.go
@@ -31,7 +31,7 @@ func TestTemplatesRender(t *testing.T) {
 			template: HubXmlrpcServiceTemplateData{
 				CaSecret:   "ca-secret",
 				CaPath:     "/etc/pki/ca.crt",
-				Ports:      []types.PortMap{utils.NewPortMap("hub", "xmlrpc", 2830, 2830)},
+				Ports:      []types.PortMap{utils.NewPortMap(2830)},
 				NamePrefix: "uyuni",
 				Network:    "uyuni-network",
 				ServerHost: "uyuni-server",
@@ -42,7 +42,7 @@ func TestTemplatesRender(t *testing.T) {
 			template: PgsqlServiceTemplateData{
 				Volumes:         []types.VolumeMount{{Name: "var-pgsql", MountPath: "/var/lib/pgsql"}},
 				NamePrefix:      "uyuni",
-				Ports:           []types.PortMap{utils.NewPortMap("db", "pgsql", 5432, 5432)},
+				Ports:           []types.PortMap{utils.NewPortMap(5432)},
 				Network:         "uyuni-network",
 				IPV6Enabled:     false,
 				CaSecret:        "ca-secret",
@@ -77,7 +77,7 @@ func TestTemplatesRender(t *testing.T) {
 				Volumes:         []types.VolumeMount{{Name: "var-spacewalk", MountPath: "/var/spacewalk"}},
 				NamePrefix:      "uyuni",
 				Args:            "--arg value",
-				Ports:           []types.PortMap{utils.NewPortMap("http", "web", 80, 80)},
+				Ports:           []types.PortMap{utils.NewPortMap(80)},
 				Network:         "uyuni-network",
 				IPV6Enabled:     false,
 				CaSecret:        "ca-secret",
@@ -94,6 +94,14 @@ func TestTemplatesRender(t *testing.T) {
 				ManagerPassword: "manager-pass",
 				ReportUser:      "report-user",
 				ReportPassword:  "report-pass",
+			},
+		},
+		{
+			name: "TFTPDTemplateData",
+			template: TFTPDTemplateData{
+				Network:    "uyuni-network",
+				CaSecret:   "ca-secret",
+				ServerFQDN: "uyuni.test.org",
 			},
 		},
 	}

--- a/mgrpxy/cmd/install/utils.go
+++ b/mgrpxy/cmd/install/utils.go
@@ -77,8 +77,19 @@ func installForPodman(
 		return err
 	}
 
+	err = shared_podman.SetupNetwork(true)
+	if err != nil {
+		return shared_utils.Errorf(err, L("cannot setup network"))
+	}
+
+	ipv6Enabled := shared_podman.HasIpv6Enabled(shared_podman.UyuniNetwork)
+
+	log.Info().Msg(L("Generating systemd services"))
+	httpProxyConfig := podman.GetHTTPProxyConfig()
+
 	// Setup the systemd service configuration options
-	err = podman.GenerateSystemdService(systemd, httpdImage, saltBrokerImage, squidImage, sshImage, tftpdImage, flags)
+	err = podman.GenerateSystemdService(systemd, httpdImage, saltBrokerImage, squidImage, sshImage, tftpdImage,
+		flags, ipv6Enabled, httpProxyConfig)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/cmd/support/ptf/utils.go
+++ b/mgrpxy/cmd/support/ptf/utils.go
@@ -55,9 +55,14 @@ func ptfForPodman(
 	sshImage := getImage(authFile, flags.UpgradeFlags.SSH.Name, pullPolicy)
 	tftpdImage := getImage(authFile, flags.UpgradeFlags.Tftpd.Name, pullPolicy)
 
+	ipv6Enabled := podman_shared.HasIpv6Enabled(podman_shared.UyuniNetwork)
+
+	log.Info().Msg(L("Generating systemd services"))
+	httpProxyConfig := podman.GetHTTPProxyConfig()
+
 	// Setup the systemd service configuration options
 	err = podman.GenerateSystemdService(systemd, httpdImage, saltBrokerImage, squidImage, sshImage,
-		tftpdImage, &flags.UpgradeFlags)
+		tftpdImage, &flags.UpgradeFlags, ipv6Enabled, httpProxyConfig)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -43,6 +43,7 @@ const (
 
 var contextRunner = shared_utils.NewRunnerWithContext
 var newRunner = shared_utils.NewRunner
+var systemdGenerator func(shared_utils.Template, string, string, string) error = generateSystemdFile
 
 // PodmanProxyFlags are the flags used by podman proxy install and upgrade command.
 type PodmanProxyFlags struct {
@@ -59,20 +60,10 @@ func GenerateSystemdService(
 	sshImage string,
 	tftpdImage string,
 	flags *PodmanProxyFlags,
+	ipv6Enabled bool,
+	httpProxyConfig string,
 ) error {
-	err := podman.SetupNetwork(true)
-	if err != nil {
-		return shared_utils.Errorf(err, L("cannot setup network"))
-	}
-
-	ipv6Enabled := podman.HasIpv6Enabled(podman.UyuniNetwork)
-
-	log.Info().Msg(L("Generating systemd services"))
-	httpProxyConfig := getHTTPProxyConfig()
-
-	ports := []types.PortMap{}
-	ports = append(ports, shared_utils.ProxyTCPPorts...)
-	ports = append(ports, shared_utils.ProxyPodmanPorts...)
+	ports := shared_utils.GetProxyPorts()
 
 	// Pod
 	dataPod := templates.PodTemplateData{
@@ -82,13 +73,11 @@ func GenerateSystemdService(
 		IPV6Enabled:   ipv6Enabled,
 	}
 	podEnv := fmt.Sprintf(`Environment="PODMAN_EXTRA_ARGS=%s"`, strings.Join(flags.Podman.Args, " "))
-	if err := generateSystemdFile(dataPod, "pod", "", podEnv); err != nil {
+	if err := systemdGenerator(dataPod, "pod", "", podEnv); err != nil {
 		return err
 	}
 
 	// Httpd
-	volumeOptions := ""
-
 	{
 		dataHttpd := templates.HttpdTemplateData{
 			Volumes:       shared_utils.ProxyHttpdVolumes,
@@ -106,11 +95,11 @@ func GenerateSystemdService(
 
 		if additionHTTPConfPath != "" {
 			additionHttpdTuningSettings = fmt.Sprintf(
-				`Environment=HTTPD_EXTRA_CONF=-v%s:/etc/apache2/conf.d/apache_tuning.conf:ro%s`,
-				additionHTTPConfPath, volumeOptions,
+				`Environment=HTTPD_EXTRA_CONF=-v%s:/etc/apache2/conf.d/apache_tuning.conf:ro`,
+				additionHTTPConfPath,
 			)
 		}
-		if err := generateSystemdFile(dataHttpd, "httpd", httpdImage, additionHttpdTuningSettings); err != nil {
+		if err := systemdGenerator(dataHttpd, "httpd", httpdImage, additionHttpdTuningSettings); err != nil {
 			return err
 		}
 	}
@@ -119,7 +108,7 @@ func GenerateSystemdService(
 		dataSaltBroker := templates.SaltBrokerTemplateData{
 			HTTPProxyFile: httpProxyConfig,
 		}
-		if err := generateSystemdFile(dataSaltBroker, "salt-broker", saltBrokerImage, ""); err != nil {
+		if err := systemdGenerator(dataSaltBroker, "salt-broker", saltBrokerImage, ""); err != nil {
 			return err
 		}
 	}
@@ -136,11 +125,11 @@ func GenerateSystemdService(
 		}
 		if additionSquidConfPath != "" {
 			additionSquidTuningSettings = fmt.Sprintf(
-				`Environment=SQUID_EXTRA_CONF=-v%s:/etc/squid/conf.d/squid_tuning.conf:ro%s`,
-				additionSquidConfPath, volumeOptions,
+				`Environment=SQUID_EXTRA_CONF=-v%s:/etc/squid/conf.d/squid_tuning.conf:ro`,
+				additionSquidConfPath,
 			)
 		}
-		if err := generateSystemdFile(dataSquid, "squid", squidImage, additionSquidTuningSettings); err != nil {
+		if err := systemdGenerator(dataSquid, "squid", squidImage, additionSquidTuningSettings); err != nil {
 			return err
 		}
 	}
@@ -156,11 +145,11 @@ func GenerateSystemdService(
 		}
 		if additionSSHConfPath != "" {
 			additionSSHTuningSettings = fmt.Sprintf(
-				`Environment=SSH_EXTRA_CONF=-v%s:/etc/ssh/sshd_config.d/10-tuning.conf:ro%s`,
-				additionSSHConfPath, volumeOptions,
+				`Environment=SSH_EXTRA_CONF=-v%s:/etc/ssh/sshd_config.d/10-tuning.conf:ro`,
+				additionSSHConfPath,
 			)
 		}
-		if err := generateSystemdFile(dataSSH, "ssh", sshImage, additionSSHTuningSettings); err != nil {
+		if err := systemdGenerator(dataSSH, "ssh", sshImage, additionSSHTuningSettings); err != nil {
 			return err
 		}
 	}
@@ -170,7 +159,7 @@ func GenerateSystemdService(
 			Volumes:       shared_utils.ProxyTftpdVolumes,
 			HTTPProxyFile: httpProxyConfig,
 		}
-		if err := generateSystemdFile(dataTftpd, "tftpd", tftpdImage, ""); err != nil {
+		if err := systemdGenerator(dataTftpd, "tftpd", tftpdImage, ""); err != nil {
 			return err
 		}
 	}
@@ -216,7 +205,8 @@ func generateSystemdFile(template shared_utils.Template, service string, image s
 	return nil
 }
 
-func getHTTPProxyConfig() string {
+// GetHTTPProxyConfig returns the HTTP proxy configuration file to mount in containers if any.
+func GetHTTPProxyConfig() string {
 	const httpProxyConfigPath = "/etc/sysconfig/proxy"
 
 	// Only SUSE distros seem to have such a file for HTTP proxy settings
@@ -359,8 +349,14 @@ func Upgrade(
 		log.Warn().Msgf(L("cannot find tftpd image: it will no be upgraded"))
 	}
 
+	ipv6Enabled := podman.HasIpv6Enabled(podman.UyuniNetwork)
+
+	log.Info().Msg(L("Generating systemd services"))
+	httpProxyConfig := GetHTTPProxyConfig()
+
 	// Setup the systemd service configuration options
-	err = GenerateSystemdService(systemd, httpdImage, saltBrokerImage, squidImage, sshImage, tftpdImage, flags)
+	err = GenerateSystemdService(systemd, httpdImage, saltBrokerImage, squidImage, sshImage, tftpdImage, flags,
+		ipv6Enabled, httpProxyConfig)
 	if err != nil {
 		return err
 	}

--- a/mgrpxy/shared/podman/podman_test.go
+++ b/mgrpxy/shared/podman/podman_test.go
@@ -5,12 +5,18 @@
 package podman
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 	"testing"
 
+	"github.com/uyuni-project/uyuni-tools/mgrpxy/shared/templates"
+	pxyutils "github.com/uyuni-project/uyuni-tools/mgrpxy/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 func TestCheckDirPermissions(t *testing.T) {
@@ -74,4 +80,140 @@ func TestGetSystemID(t *testing.T) {
 	// unquote raw string before comparing.
 	unquotedSystemid, _ := strconv.Unquote(`"` + systemid + `"`)
 	testutils.AssertEquals(t, "received systemid differs", unquotedSystemid, receivedSystemid)
+}
+
+func TestGenerateSystemdService(t *testing.T) {
+	driver := testutils.FakeSystemdDriver{
+		ReloadDaemonError: nil,
+	}
+	systemd := podman.NewSystemdWithDriver(&driver)
+
+	const httpProxyConfig = "/fake/proxy"
+	const ipv6 = true
+	var callsCount = 0
+
+	systemdGenerator = func(template utils.Template, service string, image string, config string) error {
+		callsCount++
+
+		// Assert that the calls are correct
+		switch service {
+		case "httpd":
+			testutils.AssertEquals(t, "Wrong httpd image", "fake/httpd:latest", image)
+			testutils.AssertStringContains(t, "Missing httpd tuning configuration", config,
+				"Environment=HTTPD_EXTRA_CONF=-v/my/apache.conf:/etc/apache2/conf.d/apache_tuning.conf:ro",
+			)
+			httpTemplate, ok := template.(templates.HttpdTemplateData)
+			testutils.AssertTrue(t, "httpd template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong http service data",
+				templates.HttpdTemplateData{
+					Volumes:       utils.ProxyHttpdVolumes,
+					HTTPProxyFile: httpProxyConfig,
+				},
+				httpTemplate,
+			)
+
+		case "salt-broker":
+			testutils.AssertEquals(t, "Wrong salt-broker image", "fake/salt-broker:latest", image)
+			saltBrokerTemplate, ok := template.(templates.SaltBrokerTemplateData)
+			testutils.AssertTrue(t, "salt broker template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong salt broker service data",
+				templates.SaltBrokerTemplateData{
+					HTTPProxyFile: httpProxyConfig,
+				},
+				saltBrokerTemplate,
+			)
+
+		case "squid":
+			testutils.AssertEquals(t, "Wrong squid image", "fake/squid:latest", image)
+			testutils.AssertStringContains(t, "Missing squid tuning configuration", config,
+				"Environment=SQUID_EXTRA_CONF=-v/my/squid.conf:/etc/squid/conf.d/squid_tuning.conf:ro",
+			)
+			squidTemplate, ok := template.(templates.SquidTemplateData)
+			testutils.AssertTrue(t, "squid template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong squid service data",
+				templates.SquidTemplateData{
+					Volumes:       utils.ProxySquidVolumes,
+					HTTPProxyFile: httpProxyConfig,
+				},
+				squidTemplate,
+			)
+
+		case "ssh":
+			testutils.AssertEquals(t, "Wrong ssh image", "fake/ssh:latest", image)
+			testutils.AssertStringContains(t, "Missing squid tuning configuration", config,
+				"Environment=SSH_EXTRA_CONF=-v/my/sshd.conf:/etc/ssh/sshd_config.d/10-tuning.conf:ro",
+			)
+			sshTemplate, ok := template.(templates.SSHTemplateData)
+			testutils.AssertTrue(t, "ssh template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong ssh service data",
+				templates.SSHTemplateData{
+					HTTPProxyFile: httpProxyConfig,
+				},
+				sshTemplate,
+			)
+
+		case "tftpd":
+			testutils.AssertEquals(t, "Wrong tftp image", "fake/tftp:latest", image)
+			tftpdTemplate, ok := template.(templates.TFTPDTemplateData)
+			testutils.AssertTrue(t, "tftpd template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong tftpd service data",
+				templates.TFTPDTemplateData{
+					Volumes:       utils.ProxyTftpdVolumes,
+					HTTPProxyFile: httpProxyConfig,
+				},
+				tftpdTemplate,
+			)
+
+		case "pod":
+			testutils.AssertEquals(t, "The pod should not have an image", "", image)
+			testutils.AssertStringContains(t, "Missing podman extra args", config,
+				"Environment=\"PODMAN_EXTRA_ARGS=--arg1 --arg2\"",
+			)
+			podTemplate, ok := template.(templates.PodTemplateData)
+			testutils.AssertTrue(t, "pod template of unexpected type", ok)
+			testutils.AssertEquals(t, "Wrong pod data", templates.PodTemplateData{
+				Ports: []types.PortMap{
+					{
+						Port:    22,
+						Exposed: 8022,
+					},
+					utils.NewPortMap(4505),
+					utils.NewPortMap(4506),
+					utils.NewPortMap(443),
+					utils.NewPortMap(80),
+					{
+						Exposed:  69,
+						Port:     69,
+						Protocol: "udp",
+					},
+				},
+				HTTPProxyFile: httpProxyConfig,
+				Network:       podman.UyuniNetwork,
+				IPV6Enabled:   ipv6,
+			}, podTemplate)
+
+		default:
+			t.Errorf("Unexpected systemd service generation: %s", service)
+		}
+		return nil
+	}
+
+	err := GenerateSystemdService(systemd, "fake/httpd:latest", "fake/salt-broker:latest",
+		"fake/squid:latest", "fake/ssh:latest",
+		"fake/tftp:latest", &PodmanProxyFlags{
+			Podman: podman.PodmanFlags{Args: []string{"--arg1", "--arg2"}},
+			ProxyImageFlags: pxyutils.ProxyImageFlags{
+				Tuning: pxyutils.Tuning{
+					Httpd: "/my/apache.conf",
+					Squid: "/my/squid.conf",
+					SSH:   "/my/sshd.conf",
+				},
+			},
+		},
+		ipv6, httpProxyConfig)
+	testutils.AssertTrue(t, fmt.Sprintf("Unexpected error: %v", err), err == nil)
+	testutils.AssertEquals(t, "Unexpected number of services generated", 6, callsCount)
+
+	// Restore the mocked variables
+	systemdGenerator = generateSystemdFile
 }

--- a/mgrpxy/shared/templates/templates_test.go
+++ b/mgrpxy/shared/templates/templates_test.go
@@ -28,7 +28,7 @@ func TestTemplatesRender(t *testing.T) {
 		{
 			name: "PodTemplateData",
 			template: PodTemplateData{
-				Ports:         []types.PortMap{utils.NewPortMap("tcp", "ssh", 8022, 22)},
+				Ports:         []types.PortMap{{Exposed: 8022, Port: 22}},
 				HTTPProxyFile: "/etc/sysconfig/proxy",
 				Network:       "uyuni-network",
 				IPV6Enabled:   true,

--- a/shared/testutils/asserts.go
+++ b/shared/testutils/asserts.go
@@ -68,6 +68,13 @@ func AssertHasAllFlags(t *testing.T, cmd *cobra.Command, args []string) {
 	AssertHasAllFlagsIgnores(t, cmd, args, []string{})
 }
 
+// AssertStringContains ensures a string contains the expected value.
+func AssertStringContains(t *testing.T, message string, actual string, expected string) {
+	if !strings.Contains(actual, expected) {
+		t.Errorf(message+"got '%v' expected to contain '%v'", actual, expected)
+	}
+}
+
 // AssertContains ensures a slice contains the expected value.
 func AssertContains(t *testing.T, message string, actual []string, expected string) {
 	if !contains(actual, expected) {

--- a/shared/types/networks.go
+++ b/shared/types/networks.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,8 +6,6 @@ package types
 
 // PortMap describes a port.
 type PortMap struct {
-	Service  string
-	Name     string
 	Exposed  int
 	Port     int
 	Protocol string

--- a/shared/utils/ports.go
+++ b/shared/utils/ports.go
@@ -8,87 +8,70 @@ import (
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
 
-const (
-	// WebServiceName is the name of the server web service.
-	WebServiceName = "web"
-	// SaltServiceName is the name of the server salt service.
-	SaltServiceName = "salt"
-	// ReportdbServiceName is the name of the server report database service.
-	ReportdbServiceName = "reportdb"
-	// DBServiceName is the name of the server internal database service.
-	DBServiceName = "db"
-	// DBExporterServiceName is the name of the Prometheus database exporter service.
-	DBExporterServiceName = "db"
-	// TaskoServiceName is the name of the server taskomatic service.
-	TaskoServiceName = "taskomatic"
-	// TomcatServiceName is the name of the server tomcat service.
-	TomcatServiceName = "tomcat"
-	// SearchServiceName is the name of the server search service.
-	SearchServiceName = "search"
-
-	// HubAPIServiceName is the name of the server hub API service.
-	HubAPIServiceName = "hub-api"
-
-	// ProxyTCPServiceName is the name of the proxy TCP service.
-	ProxyTCPServiceName = "uyuni-proxy-tcp"
-
-	// ProxyUDPServiceName is the name of the proxy UDP service.
-	ProxyUDPServiceName = "uyuni-proxy-udp"
-)
-
 // NewPortMap is a constructor for PortMap type.
-func NewPortMap(service string, name string, exposed int, port int) types.PortMap {
+func NewPortMap(port int) types.PortMap {
 	return types.PortMap{
-		Service: service,
-		Name:    name,
-		Exposed: exposed,
+		Exposed: port,
 		Port:    port,
 	}
 }
 
 // WebPorts is the list of ports for the server web service.
 var WebPorts = []types.PortMap{
-	NewPortMap(WebServiceName, "http", 80, 80),
+	NewPortMap(80),
+	NewPortMap(443),
 }
 
 // DBExporterPorts is the list of ports for the db exporter service.
 var DBExporterPorts = []types.PortMap{
-	NewPortMap(DBExporterServiceName, "exporter", 9187, 9187),
+	NewPortMap(9187),
 }
 
 // ReportDBPorts is the list of ports for the server report db service.
 var ReportDBPorts = []types.PortMap{
-	NewPortMap(ReportdbServiceName, "pgsql", 5432, 5432),
+	NewPortMap(5432),
 }
 
 // DBPorts is the list of ports for the server internal db service.
 var DBPorts = []types.PortMap{
-	NewPortMap(DBServiceName, "pgsql", 5432, 5432),
+	NewPortMap(5432),
 }
 
 // SaltPorts is the list of ports for the server salt service.
 var SaltPorts = []types.PortMap{
-	NewPortMap(SaltServiceName, "publish", 4505, 4505),
-	NewPortMap(SaltServiceName, "request", 4506, 4506),
+	NewPortMap(4505),
+	NewPortMap(4506),
 }
 
 // TaskoPorts is the list of ports for the server taskomatic service.
 var TaskoPorts = []types.PortMap{
-	NewPortMap(TaskoServiceName, "jmx", 5556, 5556),
-	NewPortMap(TaskoServiceName, "mtrx", 9800, 9800),
-	NewPortMap(TaskoServiceName, "debug", 8001, 8001),
+	NewPortMap(5556),
+	NewPortMap(9800),
+	NewPortMap(8001),
 }
 
 // TomcatPorts is the list of ports for the server tomcat service.
 var TomcatPorts = []types.PortMap{
-	NewPortMap(TomcatServiceName, "jmx", 5557, 5557),
-	NewPortMap(TomcatServiceName, "debug", 8003, 8003),
+	NewPortMap(5557),
+	NewPortMap(8003),
 }
 
 // SearchPorts is the list of ports for the server search service.
 var SearchPorts = []types.PortMap{
-	NewPortMap(SearchServiceName, "debug", 8002, 8002),
+	NewPortMap(8002),
 }
+
+// TftpPorts is the list of ports for the server tftp service.
+var TftpPorts = []types.PortMap{
+	{
+		Exposed:  69,
+		Port:     69,
+		Protocol: "udp",
+	},
+}
+
+const debugPortsStart = 8001
+const debugPortsEnd = 8003
 
 // GetServerPorts returns all the server container ports.
 //
@@ -107,7 +90,7 @@ func GetServerPorts(debug bool) []types.PortMap {
 
 func appendPorts(ports []types.PortMap, debug bool, newPorts ...types.PortMap) []types.PortMap {
 	for _, newPort := range newPorts {
-		if debug || newPort.Name != "debug" && !debug {
+		if debug || (newPort.Port < debugPortsStart || newPort.Port > debugPortsEnd) && !debug {
 			ports = append(ports, newPort)
 		}
 	}
@@ -116,39 +99,31 @@ func appendPorts(ports []types.PortMap, debug bool, newPorts ...types.PortMap) [
 
 // TCPPodmanPorts are the tcp ports required by the server on podman.
 var TCPPodmanPorts = []types.PortMap{
-	// TODO: Replace Node exporter with cAdvisor
-	NewPortMap("tomcat", "node-exporter", 9100, 9100),
+	NewPortMap(9100),
 }
 
 // HubXmlrpcPorts are the tcp ports required by the Hub XMLRPC API service.
 var HubXmlrpcPorts = []types.PortMap{
-	NewPortMap(HubAPIServiceName, "xmlrpc", 2830, 2830),
-}
-
-// ProxyTCPPorts are the tcp ports required by the proxy.
-var ProxyTCPPorts = []types.PortMap{
-	NewPortMap(ProxyTCPServiceName, "ssh", 8022, 22),
-	NewPortMap(ProxyTCPServiceName, "publish", 4505, 4505),
-	NewPortMap(ProxyTCPServiceName, "request", 4506, 4506),
-}
-
-// ProxyPodmanPorts are the http/s ports required by the proxy.
-var ProxyPodmanPorts = []types.PortMap{
-	NewPortMap(ProxyTCPServiceName, "https", 443, 443),
-	NewPortMap(ProxyTCPServiceName, "http", 80, 80),
+	NewPortMap(2830),
 }
 
 // GetProxyPorts returns all the proxy container ports.
 func GetProxyPorts() []types.PortMap {
-	ports := []types.PortMap{}
-	ports = appendPorts(ports, false, ProxyTCPPorts...)
-	ports = appendPorts(ports, false, types.PortMap{
-		Service:  ProxyUDPServiceName,
-		Name:     "tftp",
-		Exposed:  69,
-		Port:     69,
-		Protocol: "udp",
-	})
+	ports := []types.PortMap{
+		{
+			Port:    22,
+			Exposed: 8022,
+		},
+		NewPortMap(4505),
+		NewPortMap(4506),
+		NewPortMap(443),
+		NewPortMap(80),
+		{
+			Exposed:  69,
+			Port:     69,
+			Protocol: "udp",
+		},
+	}
 
 	return ports
 }

--- a/uyuni-tools.changes.cbosdo.ports-fix
+++ b/uyuni-tools.changes.cbosdo.ports-fix
@@ -1,0 +1,1 @@
+- Add the TFTP port back to the proxy (bsc#1260905)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?
The proxy pod always needs to expose the TFTP port. (bsc#1260905)

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
