### PR TITLE
rename missleading parameter name

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -6,7 +6,7 @@
 
 # This script is called by push-packages-to-obs
 
-OSCAPI=$1
+PRODUCT=$1
 GIT_DIR=$2
 PKG_NAME=$3
 
@@ -17,7 +17,10 @@ REMOTE_BRANCH=$(git for-each-ref --format='%(upstream:lstrip=-1)' $(git rev-pars
 COMMIT_ID=$(git rev-parse --short HEAD)
 popd
 
-if [ "${OSCAPI}" == "https://api.suse.de" ]; then
+# convert legacy value
+test "${PRODUCT}" == "https://api.suse.de" && PRODUCT="MLM"
+
+if [ "${PRODUCT}" == "MLM" ]; then
   VERSION="HEAD"
   case ${REMOTE_BRANCH} in Manager-*)
     VERSION="${REMOTE_BRANCH#Manager-}"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

We only need to distinguish between the products.
We do not call "osc"

Port of https://github.com/SUSE/uyuni-tools/pull/233

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
