### PR TITLE
Do not stop container on healthcheck failure

### DIFF
--- a/mgradm/cmd/install/utils.go
+++ b/mgradm/cmd/install/utils.go
@@ -90,6 +90,9 @@ func installForPodman(
 		return utils.Error(err, L("failed to generate server service"))
 	}
 
+	log.Info().Msg(L("Waiting for server to start. This include service setup operations and can take a very long time."))
+	log.Info().Msg(L("Use `journalctl -f -u uyuni-server` for tracking progress"))
+
 	cnx := shared.NewConnection("podman", shared_podman.ServerContainerName, "")
 	if err := podman.WaitForSystemStart(systemd, cnx); err != nil {
 		return utils.Error(err, L("cannot wait for system start"))

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -488,14 +488,15 @@ func Upgrade(
 		return err
 	}
 
-	log.Info().Msg(L("Waiting for the server to start…"))
+	log.Info().Msg(L("Waiting for server to start. This include service setup operations and can take a very long time."))
+	log.Info().Msg(L("Use `journalctl -f -u uyuni-server` for tracking progress"))
 	cnx := shared.NewConnection("podman", podman.ServerContainerName, "")
 	if err := systemd.StartService(podman.ServerService); err != nil {
 		return utils.Error(err, L("cannot start service"))
 	}
 
 	if err := cnx.WaitForHealthcheck(); err != nil {
-		log.Warn().Err(err)
+		return utils.Error(err, L("cannot wait for system start"))
 	}
 
 	inspectedDB := types.DBFlags{

--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -67,7 +67,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret {{ .AdminUserSecret }},type=env,target=ADMIN_USER \
 	--secret {{ .AdminPassSecret }},type=env,target=ADMIN_PASS \
 	{{- end }}
-	--health-on-failure=stop \
+	--health-on-failure=none \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \

--- a/mgradm/shared/templates/templates_test.go
+++ b/mgradm/shared/templates/templates_test.go
@@ -139,7 +139,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret uyuni-scc-pass,type=env,target=SCC_PASS \
 	--secret uyuni-admin-user,type=env,target=ADMIN_USER \
 	--secret uyuni-admin-pass,type=env,target=ADMIN_PASS \
-	--health-on-failure=stop \
+	--health-on-failure=none \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \
@@ -216,7 +216,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret cert-secret,type=mount,target=/etc/pki/tls.crt \
 	--secret key-secret,type=mount,target=/etc/pki/tls.key \
 	--secret db-ca-secret,type=mount,target=/etc/pki/db-ca.crt \
-	--health-on-failure=stop \
+	--health-on-failure=none \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -361,12 +361,25 @@ func (c *Connection) WaitForContainer() error {
 	return errors.New(L("container didn't start within 10s."))
 }
 
-// WaitForHealthcheck waits at most 180s for healtcheck to succeed.
+// WaitForHealthcheck waits for healtcheck to succeed.
 func (c *Connection) WaitForHealthcheck() error {
-	// On update consider healtcheck configuration in the container Dockerfile
-	const maxWaitTime = 180
-	// Wait for the system to be up
-	for i := 0; i < maxWaitTime; i++ {
+	// This is a quick workaround for long startups
+	// Generally check is intentionally infinite, we guard only for 15s grace period for container to start
+	startupTimeout := 15
+
+	for {
+		c.podName = ""
+		if _, err := c.GetPodName(); err != nil {
+			// container did not yet start or is already stopped
+			startupTimeout--
+			if startupTimeout < 0 {
+				return errors.New(L("container didn't start within 15s or failed. Check the service status"))
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		// once here, container started at least once, clear startupTimeout
+		startupTimeout = 0
 		_, err := c.Healthcheck()
 		if err != nil {
 			log.Debug().Err(err)
@@ -375,7 +388,6 @@ func (c *Connection) WaitForHealthcheck() error {
 		}
 		return nil
 	}
-	return fmt.Errorf(L("container didn't start within %ds. Check for the service status"), maxWaitTime)
 }
 
 // Copy transfers a file to or from the container.

--- a/uyuni-tools.changes.oholecek.temp_disable_healtcheck_stop
+++ b/uyuni-tools.changes.oholecek.temp_disable_healtcheck_stop
@@ -1,0 +1,2 @@
+- Do not stop container on health check failure
+  Temporary workaround for bsc#1263157


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

This PR temporarily disable stopping container on health check failure until correct/agreed upon solution is found and implemented.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30492

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
