### PR TITLE
Change the go version on Ubuntu to a minimum

### DIFF
--- a/uyuni-tools.changes.cbosdo.ubuntu-fix
+++ b/uyuni-tools.changes.cbosdo.ubuntu-fix
@@ -1,0 +1,1 @@
+- Set the Go version as a minimum on Ubuntu

--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -83,7 +83,7 @@ BuildRequires:  golang(API) >= 1.25
 
 %if 0%{?ubuntu}
 %define go_version      1.22
-BuildRequires:  golang-%{go_version}
+BuildRequires:  golang >= %{go_version}
 %endif
 # ubuntu
 
@@ -324,7 +324,9 @@ go_tags=""
 
 go_path=""
 %if 0%{?ubuntu}
-  go_path=/usr/lib/go-%{go_version}/bin/
+  if test -d /usr/lib/go-%{go_version}/bin/; then
+    go_path=/usr/lib/go-%{go_version}/bin/
+  fi
 %else
   %if "%{?_go_bin}" != ""
     go_path='%{_go_bin}/'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Hardcoding the go version on Ubuntu is bad.
## Test coverage
- No tests: packaging change

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
