### PR TITLE
Add startup check on the server container

### DIFF
--- a/mgradm/shared/templates/serviceTemplate.go
+++ b/mgradm/shared/templates/serviceTemplate.go
@@ -67,7 +67,10 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret {{ .AdminUserSecret }},type=env,target=ADMIN_USER \
 	--secret {{ .AdminPassSecret }},type=env,target=ADMIN_PASS \
 	{{- end }}
-	--health-on-failure=none \
+	--health-on-failure=stop \
+	--health-cmd=/usr/bin/healthcheck.sh \
+	--health-startup-cmd=/usr/bin/startup-check.sh \
+	--health-startup-interval=10s \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \

--- a/mgradm/shared/templates/templates_test.go
+++ b/mgradm/shared/templates/templates_test.go
@@ -139,7 +139,10 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret uyuni-scc-pass,type=env,target=SCC_PASS \
 	--secret uyuni-admin-user,type=env,target=ADMIN_USER \
 	--secret uyuni-admin-pass,type=env,target=ADMIN_PASS \
-	--health-on-failure=none \
+	--health-on-failure=stop \
+	--health-cmd=/usr/bin/healthcheck.sh \
+	--health-startup-cmd=/usr/bin/startup-check.sh \
+	--health-startup-interval=10s \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \
@@ -216,7 +219,10 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--secret cert-secret,type=mount,target=/etc/pki/tls.crt \
 	--secret key-secret,type=mount,target=/etc/pki/tls.key \
 	--secret db-ca-secret,type=mount,target=/etc/pki/db-ca.crt \
-	--health-on-failure=none \
+	--health-on-failure=stop \
+	--health-cmd=/usr/bin/healthcheck.sh \
+	--health-startup-cmd=/usr/bin/startup-check.sh \
+	--health-startup-interval=10s \
 	${PODMAN_EXTRA_ARGS} ${UYUNI_IMAGE}'
 
 ExecStop=-/usr/bin/podman exec \

--- a/uyuni-tools.changes.cbosdo.reindex_healthy
+++ b/uyuni-tools.changes.cbosdo.reindex_healthy
@@ -1,0 +1,2 @@
+- Use a startup check with no limit for the main server container
+  (bsc#1263157)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Differenciate the startup check from the health check: the startup can start for ever with a potential database reindexing (bsc#1263157)

## Test coverage
- Unit tests were changed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30492

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
