### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 name: Changelogs
 
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -5,6 +5,9 @@
 
 name: Git Checks
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/mingo_build.yml
+++ b/.github/workflows/mingo_build.yml
@@ -4,6 +4,9 @@
 
 name: Build with oldest go
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:

--- a/.github/workflows/prebuilt_devcontainer.yml
+++ b/.github/workflows/prebuilt_devcontainer.yml
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'pre-built devcontainer'
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 on:
   push:
     branches:
@@ -11,10 +17,6 @@ on:
 jobs:
   devcontainer-build-and-push:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
     steps:
       - name: Checkout
         id: checkout

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -4,6 +4,9 @@
 
 name: REUSE Compliance Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -4,6 +4,9 @@
 
 name: Vulnerability check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
## Summary

Following security best practices (supply chain hardening), add explicit top-level permissions to all GitHub Actions workflows to enforce the principle of least privilege.

## Changes

- `build.yml` — added `permissions: contents: read`
- `reuse.yml` — added `permissions: contents: read`
- `changelogs.yml` — added `permissions: contents: read` + `pull-requests: write` (needed for comment creation)
- `git-checks.yml` — added `permissions: contents: read`
- `vulncheck.yml` — added `permissions: contents: read`
- `mingo_build.yml` — added `permissions: contents: read`
- `prebuilt_devcontainer.yml` — moved job-level permissions to top-level

Workflows that already had correct top-level permissions (`checks.yml`, `golangci-lint.yml`) were left unchanged.

## Context

This addresses the GitHub Actions permissions requirements from the Rancher Security Team supply chain risk scan, following the same pattern as https://github.com/uyuni-project/uyuni-docs-helper/pull/70.

References:
- [How to act - GitHub Actions Permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes)
- Supply chain risk mitigation per RST guidelines