### PR TITLE
Fix Go version discovery on Ubuntu versions

### DIFF
--- a/uyuni-tools.spec
+++ b/uyuni-tools.spec
@@ -82,13 +82,13 @@ BuildRequires:  golang(API) >= 1.25
 # suse_version
 
 %if 0%{?ubuntu}
-%if 0%{?ubuntu} >= 2404
-# Will use the default golang of the OS which is higher than minimal required go_version
-BuildRequires:  golang
-%else
-# Overwrite with new go version the OS default
 %define go_version      1.22
-BuildRequires:  golang-%{go_version}
+# On Ubuntu 22.04, the metapackage golang is too old (1.18) and
+# we must use the versioned package name specifically for this OS version.
+%if 0%{?ubuntu} == 2204
+BuildRequires:  golang-%{go_version}-go
+%else
+BuildRequires:  golang >= %{go_version}
 %endif
 %endif
 # ubuntu
@@ -330,15 +330,36 @@ go_tags=""
 
 go_path=""
 %if 0%{?ubuntu}
-  if test -d /usr/lib/go-%{go_version}/bin/; then
-    go_path=/usr/lib/go-%{go_version}/bin/
+  # Pinpoint the highest binary
+  go_path=$(find /usr/lib/go-*/bin/go 2>/dev/null | sort | tail -n 1)
+  [ -z "$go_path" ] && go_path="/usr/bin/go"
+
+  if [ -x "$go_path" ]; then
+    # Query GOVERSION
+    v_str=$("$go_path" env GOVERSION 2>/dev/null)
+    # Strip the leading 'go' prefix
+    v_str="${v_str#go}"
+    # Parse required and found versions
+    echo "%{go_version}" | { IFS="." read -r req_major req_minor req_patch;
+    echo "$v_str"        | { IFS="." read -r max_major max_minor max_patch;
+      # Fallbacks to guarantee whole integers if trailing elements are empty
+      [ -z "$max_patch" ] && max_patch=0
+      [ -z "$max_minor" ] && max_minor=0
+      if [ "$max_major" -lt "$req_major" ] || { [ "$max_major" -eq "$req_major" ] && [ "$max_minor" -lt "$req_minor" ]; }; then
+        echo "ERROR: Found Go version ${v_str} at ${go_path}, but version >= %{go_version} is required."
+        exit 1
+      fi
+    }; }
+    # Format the path variable suffix for the rest of the spec compilation steps
+    go_path="${go_path%go}"
+  else
+    echo "ERROR: No Go compiler found at ${go_path} or /usr/bin/go"
+    exit 1
   fi
 %else
   %if "%{?_go_bin}" != ""
     go_path='%{_go_bin}/'
   %endif
-# "_go_bin" != ""
-
 %endif
 # ubuntu
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

follow-up of https://github.com/uyuni-project/uyuni-tools/pull/775 

The build for Ubuntu 22.04 was failing with the error undefined: `fmt.Appendf`. This occurred because the codebase requires Go 1.19+ (where `fmt.Appendf` was introduced), but the Ubuntu 22.04 build environment was defaulting to Go 1.18.

The failure was caused by two main factors:

- Metapackage Resolution: On Ubuntu 22.04, the metapackage golang points to version 1.18. Even with a version constraint like `BuildRequires: golang >= 1.22`, the package manager falls back to the only available package named golang (1.18) if a higher version isn't found under that exact name.
- Naming Conventions: Newer Go versions on Ubuntu 22.04 are provided as versioned packages (e.g., golang-1.22-go). These are seen as distinct packages rather than updates to the base golang package.

Changes done:
- Uses the versioned Go package dependency on Ubuntu 22.04.
- Add build-time discovery of the newest available Go binary across versioned and system paths.
- Fails the build if no suitable Go compiler is found.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- Manual tests: https://build.suse.de/package/show/home:deneb_alpha:uyuni-tools_ubuntu_fixgo/uyuni-tools

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/pull/775

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
