### PR TITLE
Fix the healthcheck wait (bsc#1266012)

### DIFF
--- a/shared/connection.go
+++ b/shared/connection.go
@@ -307,26 +307,34 @@ func (c *Connection) ExecScript(script string) ([]byte, error) {
 }
 
 // Healthcheck runs healthcheck command inside the container.
-func (c *Connection) Healthcheck() ([]byte, error) {
+func (c *Connection) Healthcheck() error {
 	if c.podName == "" {
 		if _, err := c.GetPodName(); c.podName == "" {
-			return nil, utils.Errorf(err, L("Healthcheck not executed"))
+			return utils.Errorf(err, L("Healthcheck not executed"))
 		}
 	}
 
 	cmd, cmdErr := c.GetCommand()
 	if cmdErr != nil {
-		return nil, cmdErr
+		return cmdErr
 	}
 
 	if cmd == "host" {
 		// Healthcheck not supported on host, always return nil
-		return nil, nil
+		return nil
 	}
 
-	cmdArgs := []string{"healthcheck", "run", c.podName}
+	cmdArgs := []string{"inspect", "--format", "{{ .State.Health.Status }}", c.podName}
 
-	return runner(cmd, cmdArgs...).Log(zerolog.DebugLevel).Spinner("").Exec()
+	out, err := runner(cmd, cmdArgs...).Log(zerolog.DebugLevel).Spinner("").Exec()
+	if err != nil {
+		return err
+	}
+	outStr := strings.TrimSpace(string(out))
+	if outStr != "healthy" && outStr != "running" {
+		return errors.New(L("not healthy or running"))
+	}
+	return nil
 }
 
 // WaitForContainer waits up to 10 sec for the container to appear.
@@ -380,7 +388,7 @@ func (c *Connection) WaitForHealthcheck() error {
 		}
 		// once here, container started at least once, clear startupTimeout
 		startupTimeout = 0
-		_, err := c.Healthcheck()
+		err := c.Healthcheck()
 		if err != nil {
 			log.Debug().Err(err)
 			time.Sleep(1 * time.Second)

--- a/uyuni-tools.changes.cbosdo.healthcheck-wait
+++ b/uyuni-tools.changes.cbosdo.healthcheck-wait
@@ -1,0 +1,2 @@
+- Do not call podman healthcheck run to wait for pods to be ready
+  (bsc#1266012)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Running `podman healthcheck run` counts in the failure threshold. This means that the wait for the healthcheck running every second was hitting the threshold earlier than needed.

The health is checked using podman inspect to extract the health status.

## Test coverage
- No tests: needs end to end test against podman

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30775

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
