### PR TITLE
Add mgrctl commands for GPG key management

### DIFF
--- a/mgradm/cmd/gpg/add/gpg.go
+++ b/mgradm/cmd/gpg/add/gpg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,6 +39,7 @@ func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[gpgAddFlags]) 
 			var flags gpgAddFlags
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
 		},
+		Deprecated: "please use `mgrctl gpg upload` instead",
 	}
 
 	gpgAddKeyCmd.Flags().BoolP("force", "f", false, L("Import without asking confirmation"))

--- a/mgradm/cmd/gpg/gpg.go
+++ b/mgradm/cmd/gpg/gpg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,11 @@ import (
 // NewCommand import gpg keys from 3rd party repository.
 func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
 	gpgKeyCmd := &cobra.Command{
-		Use:     "gpg",
-		GroupID: "tool",
-		Short:   L("Manage GPG keys for 3rd party repositories"),
-		Args:    cobra.ExactArgs(1),
+		Use:        "gpg",
+		GroupID:    "tool",
+		Short:      L("Manage GPG keys for 3rd party repositories"),
+		Args:       cobra.ExactArgs(1),
+		Deprecated: "please use `mgrctl gpg` instead",
 	}
 
 	gpgKeyCmd.AddCommand(gpgadd.NewCommand(globalFlags))

--- a/mgradm/cmd/gpg/list/gpg.go
+++ b/mgradm/cmd/gpg/list/gpg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,6 +36,7 @@ func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[gpgListFlags])
 			var flags gpgListFlags
 			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
 		},
+		Deprecated: "please use `mgrctl gpg list` instead",
 	}
 
 	gpgListKeyCmd.Flags().BoolP("system", "s", false, L("List keys from system keyring"))

--- a/mgrctl/cmd/cmd.go
+++ b/mgrctl/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/api"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/cp"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/exec"
+	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/gpg"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/proxy"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/ssh"
 	"github.com/uyuni-project/uyuni-tools/mgrctl/cmd/term"
@@ -57,6 +58,7 @@ func NewUyunictlCommand() *cobra.Command {
 	rootCmd.AddCommand(completion.NewCommand(globalFlags))
 	rootCmd.AddCommand(proxy.NewCommand(globalFlags))
 	rootCmd.AddCommand(ssh.NewCommand(globalFlags))
+	rootCmd.AddCommand(gpg.NewCommand(globalFlags))
 
 	rootCmd.AddCommand(utils.GetConfigHelpCommand())
 

--- a/mgrctl/cmd/gpg/gpg.go
+++ b/mgrctl/cmd/gpg/gpg.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type apiFlags struct {
+	api.ConnectionDetails `mapstructure:"api"`
+}
+
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	var flags apiFlags
+
+	gpgCmd := &cobra.Command{
+		Use:   "gpg",
+		Short: L("GPG key management commands"),
+	}
+
+	gpgUploadKeyCmd := &cobra.Command{
+		Use:   "upload [path or URL]",
+		Short: L("Upload a GPG key to the server"),
+		Long:  L(`Uploads an armored GPG key to the server from a local file or a remote URL.`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, runGpgKeyUpload)
+		},
+		Args: cobra.ExactArgs(1),
+	}
+
+	gpgListKeysCmd := &cobra.Command{
+		Use:   "list",
+		Short: L("List all GPG keys on the server"),
+		Long:  L(`Retrieves a list of registered and/or previously uploaded GPG keys.`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, runGpgKeyList)
+		},
+	}
+
+	gpgRemoveKeyCmd := &cobra.Command{
+		Use:   "remove [fingerprint]",
+		Short: L("Remove a GPG key from the server"),
+		Long:  L(`Removes a key identified by its fingerprint from the server's GPG keyring.`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, runGpgKeyRemove)
+		},
+		Args: cobra.ExactArgs(1),
+	}
+
+	gpgCmd.AddCommand(gpgUploadKeyCmd)
+	gpgCmd.AddCommand(gpgListKeysCmd)
+	gpgCmd.AddCommand(gpgRemoveKeyCmd)
+	api.AddAPIFlags(gpgCmd)
+
+	return gpgCmd
+}

--- a/mgrctl/cmd/gpg/list.go
+++ b/mgrctl/cmd/gpg/list.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+type ListGpgKeysResponse struct {
+	KeyType     int64    `mapstructure:"keyType"`
+	KeySize     int64    `mapstructure:"keySize"`
+	Fingerprint string   `mapstructure:"fingerprint"`
+	Names       []string `mapstructure:"names"`
+}
+
+func gpgKeyList(client *api.APIClient) error {
+	response, err := api.GetChecked[[]ListGpgKeysResponse](
+		client,
+		"admin/gpg/listGpgKeys",
+		"api.admin.gpg.list_gpg_keys",
+	)
+
+	if err != nil {
+		return utils.Errorf(err, L("error listing GPG keys"))
+	}
+
+	if !response.Success {
+		return fmt.Errorf(L("failed to list GPG keys: %s"), response.Message)
+	}
+
+	if len(response.Result) == 0 {
+		fmt.Println("No GPG keys stored.")
+	}
+
+	for keyIdx, key := range response.Result {
+		fmt.Printf("[%d]\tFingerprint:\t%s\n", keyIdx, key.Fingerprint)
+
+		typeName := "unknown"
+
+		switch key.KeyType {
+		case 1:
+			typeName = "rsa"
+		case 16:
+			typeName = "elgamal"
+		case 17:
+			typeName = "dsa"
+		case 18:
+			typeName = "ecdh"
+		case 19:
+			typeName = "ecdsa"
+		case 22:
+			typeName = "eddsa"
+		case 25:
+			typeName = "x25519"
+		}
+
+		fmt.Printf("\tKey type:\t%s%d\n", typeName, key.KeySize)
+
+		for nameIdx, name := range key.Names {
+			fmt.Printf("\t[%d]\t%s\n", nameIdx, name)
+		}
+		fmt.Printf("\n")
+	}
+
+	return nil
+}
+
+func runGpgKeyList(_ *types.GlobalFlags, flags *apiFlags, _ *cobra.Command, _ []string) error {
+	log.Debug().Msgf("Requesting GPG keys from the server...")
+	client, err := api.Init(&flags.ConnectionDetails)
+	if err == nil {
+		err = client.Login()
+	}
+	if err != nil {
+		return utils.Errorf(err, L("unable to login to the server"))
+	}
+
+	return gpgKeyList(client)
+}

--- a/mgrctl/cmd/gpg/remove.go
+++ b/mgrctl/cmd/gpg/remove.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+func gpgKeyRemove(client *api.APIClient, fingerprint string) error {
+	response, err := api.PostChecked[float64](
+		client,
+		"admin/gpg/removeGpgKey",
+		"api.admin.gpg.remove_gpg_key",
+		map[string]interface{}{
+			"fingerprint": fingerprint,
+		},
+	)
+
+	if err != nil {
+		return utils.Errorf(err, L("error removing GPG key"))
+	}
+
+	if !response.Success {
+		return fmt.Errorf(L("failed to remove GPG key: %s"), response.Message)
+	}
+
+	if int(response.Result) == 1 {
+		fmt.Println(L("GPG key successfully removed"))
+	} else {
+		fmt.Println(L("unable to remove GPG key, server returned an error"))
+	}
+
+	return nil
+}
+
+func runGpgKeyRemove(_ *types.GlobalFlags, flags *apiFlags, _ *cobra.Command, args []string) error {
+	fingerprint := args[0]
+
+	log.Debug().Msgf("Requesting GPG key deletion from the server...")
+
+	client, err := api.Init(&flags.ConnectionDetails)
+	if err == nil {
+		err = client.Login()
+	}
+	if err != nil {
+		return utils.Errorf(err, L("unable to login to the server"))
+	}
+
+	return gpgKeyRemove(client, fingerprint)
+}

--- a/mgrctl/cmd/gpg/upload.go
+++ b/mgrctl/cmd/gpg/upload.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+const armorHeader = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
+
+func gpgKeyUpload(client *api.APIClient, key string) error {
+	response, err := api.PostChecked[float64](
+		client,
+		"admin/gpg/uploadGpgKey",
+		"api.admin.gpg.upload_gpg_key",
+		map[string]interface{}{
+			"gpgKey": key,
+		},
+	)
+
+	if err != nil {
+		return utils.Errorf(err, L("error uploading GPG key"))
+	}
+
+	if !response.Success {
+		return fmt.Errorf(L("failed to upload GPG key: %s"), response.Message)
+	}
+
+	if int(response.Result) == 1 {
+		fmt.Println(L("GPG key successfully uploaded"))
+	} else {
+		fmt.Println(L("unable to upload GPG key, server returned an error"))
+	}
+
+	return nil
+}
+
+func readKey(source string) (string, error) {
+	var data []byte
+	var err error
+
+	if _, err = os.Stat(source); err == nil {
+		log.Debug().Msgf("Reading GPG key from file %s", source)
+		data, err = os.ReadFile(source)
+		if err != nil {
+			return "", utils.Errorf(err, L("failed to read key file %s"), source)
+		}
+	} else {
+		log.Debug().Msgf("Downloading GPG key from %s", source)
+		data, err = utils.GetURLBody(source)
+		if err != nil {
+			return "", utils.Errorf(err, L("failed to download key from %s"), source)
+		}
+	}
+
+	key := string(data)
+	// Armored GPG keys start with this header.
+	if !strings.Contains(key, armorHeader) {
+		return "", errors.New(L("the provided key is not an armored GPG key"))
+	}
+
+	return key, nil
+}
+
+func runGpgKeyUpload(_ *types.GlobalFlags, flags *apiFlags, _ *cobra.Command, args []string) error {
+	source := args[0]
+
+	key, err := readKey(source)
+	if err != nil {
+		return err
+	}
+
+	log.Debug().Msgf("Uploading GPG key...")
+	client, err := api.Init(&flags.ConnectionDetails)
+	if err == nil {
+		err = client.Login()
+	}
+	if err != nil {
+		return utils.Errorf(err, L("unable to login to the server"))
+	}
+
+	return gpgKeyUpload(client, key)
+}

--- a/mgrctl/cmd/gpg/upload_test.go
+++ b/mgrctl/cmd/gpg/upload_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/api"
+	"github.com/uyuni-project/uyuni-tools/shared/api/mocks"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+const user = "testUser"
+const password = "testPwd"
+const server = "testServer"
+
+var connectionDetails = &api.ConnectionDetails{User: user, Password: password, Server: server}
+
+type gpgKeyUploadRequest struct {
+	Key string `json:"gpgKey"`
+}
+
+// Test gpgKeyUpload function.
+func TestGpgKeyUpload(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		statusCode    int
+		body          string
+		expectedError string
+	}{
+		{
+			name:          "Test uploading a GPG key",
+			key:           "-----BEGIN PGP PUBLIC KEY BLOCK-----\ntest\n-----END PGP PUBLIC KEY BLOCK-----",
+			statusCode:    200,
+			body:          `{"success":true,"result":1}`,
+			expectedError: "",
+		},
+		{
+			name:          "Test uploading a GPG key with special characters",
+			key:           "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey+with/special=chars\n-----END PGP PUBLIC KEY BLOCK-----",
+			statusCode:    200,
+			body:          `{"success":true,"result":1}`,
+			expectedError: "",
+		},
+		{
+			name:          "Test server returns error status",
+			key:           "-----BEGIN PGP PUBLIC KEY BLOCK-----\ntest\n-----END PGP PUBLIC KEY BLOCK-----",
+			statusCode:    500,
+			body:          ``,
+			expectedError: "error uploading GPG key: 500:",
+		},
+		{
+			name:          "Test server reports upload failure",
+			key:           "-----BEGIN ABC PUBLIC KEY BLOCK-----\ntest\n-----END PGP PUBLIC KEY BLOCK-----",
+			statusCode:    200,
+			body:          `{"success":false,"message":"invalid key format"}`,
+			expectedError: "failed to upload GPG key: invalid key format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := api.Init(connectionDetails)
+			if err != nil {
+				t.FailNow()
+			}
+
+			client.Client = &mocks.MockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					testutils.AssertEquals(t, "Wrong URL called", req.URL.Path, "/rhn/manager/api/admin/gpg/uploadGpgKey")
+					testutils.AssertEquals(t, "Wrong content type", req.Header.Get("Content-Type"), "application/json; charset=utf-8")
+
+					var data gpgKeyUploadRequest
+					if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
+						t.Fatalf("Failed to decode JSON body: %v", err)
+					}
+					testutils.AssertEquals(t, "The key is not properly passed", tt.key, data.Key)
+
+					return testutils.GetResponse(tt.statusCode, tt.body)
+				},
+			}
+
+			errorMessage := ""
+			if err := gpgKeyUpload(client, tt.key); err != nil {
+				errorMessage = err.Error()
+			}
+			testutils.AssertStringContains(t, "Unexpected error message", errorMessage, tt.expectedError)
+		})
+	}
+}

--- a/uyuni-tools.changes.mfriedrich.add_mgrctl_gpg_commands
+++ b/uyuni-tools.changes.mfriedrich.add_mgrctl_gpg_commands
@@ -1,0 +1,1 @@
+- Add mgrctl commands for GPG key management


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Adds a new `mgrctl gpg` command with verbs `upload`, `list` and `remove` for managing GPG keys via server API. Also marks the `mgradm gpg` command as deprecated.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29690

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
