### PR TITLE
Improve readability of utils.YesNo for translators

### DIFF
--- a/extract_strings
+++ b/extract_strings
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# SPDX-FileCopyrightText: 2024 SUSE LLC
+# SPDX-FileCopyrightText: 2026 SUSE LLC
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@ export LANG=C.UTF-8
 for MODULE in mgrctl mgradm mgrpxy shared; do
     # Generate the pot file
     echo "Generate locale/${MODULE}/${MODULE}.pot"
-    find ${MODULE} -type f -not -name '*_test.go' -name '*.go' | sort | xargs xgettext --no-wrap --keyword="PL:1c,2" --keyword="NL:1,2" --keyword="L" --language=Javascript --from-code=UTF-8 -o locale/${MODULE}/${MODULE}.pot -
+    find ${MODULE} -type f -not -name '*_test.go' -name '*.go' | sort | xargs xgettext --add-comments=Translators --no-wrap --keyword="PL:1c,2" --keyword="NL:1,2" --keyword="L" --language=Javascript --from-code=UTF-8 -o locale/${MODULE}/${MODULE}.pot -
     msguniq --no-wrap -o locale/${MODULE}/${MODULE}-uniq.pot locale/${MODULE}/${MODULE}.pot
     mv locale/${MODULE}/${MODULE}-uniq.pot locale/${MODULE}/${MODULE}.pot
 

--- a/mgradm/cmd/backup/db/disable.go
+++ b/mgradm/cmd/backup/db/disable.go
@@ -21,7 +21,7 @@ func Disable(flags *Flagpole) error {
 	if _, err := cnx.GetPodName(); err == nil {
 		wasRunning = true
 		if !flags.Force {
-			res, err := utils.YesNo(L("Database service needs to be restarted to reload backup configurations, continue"))
+			res, err := utils.YesNo(L("Database service needs to be restarted to reload backup configurations, continue?"))
 			if err != nil || !res {
 				log.Info().Msg(L("Backup reconfiguration aborted"))
 				return nil

--- a/mgradm/cmd/backup/db/enable.go
+++ b/mgradm/cmd/backup/db/enable.go
@@ -32,7 +32,7 @@ func Enable(force bool) error {
 
 	if wasRunning {
 		if !force {
-			res, err := utils.YesNo(L("Database service needs to be restarted to reload backup configurations, continue"))
+			res, err := utils.YesNo(L("Database service needs to be restarted to reload backup configurations, continue?"))
 			if err != nil || !res {
 				log.Info().Msg(L("Backup configuration aborted"))
 				return nil

--- a/mgradm/cmd/backup/db/restore.go
+++ b/mgradm/cmd/backup/db/restore.go
@@ -25,7 +25,7 @@ func Restore(force bool) error {
 	log.Info().Msg(L("Restoring DB backup"))
 
 	if !force {
-		if res, err := utils.YesNo(L("Restoring from backup is a destructive operation. Proceed")); err != nil || !res {
+		if res, err := utils.YesNo(L("Restoring from backup is a destructive operation. Proceed?")); err != nil || !res {
 			log.Info().Msg(L("Aborting"))
 			return nil
 		}

--- a/mgradm/cmd/gpg/add/gpg.go
+++ b/mgradm/cmd/gpg/add/gpg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -103,7 +103,7 @@ func gpgAddKeys(_ *types.GlobalFlags, flags *gpgAddFlags, _ *cobra.Command, args
 			continue
 		}
 		if !flags.Force {
-			ret, err := utils.YesNo(L("Do you really want to trust this key"))
+			ret, err := utils.YesNo(L("Do you really want to trust this key?"))
 			if err != nil {
 				return err
 			}

--- a/mgradm/cmd/gpg/add/gpg.go
+++ b/mgradm/cmd/gpg/add/gpg.go
@@ -104,7 +104,7 @@ func gpgAddKeys(_ *types.GlobalFlags, flags *gpgAddFlags, _ *cobra.Command, args
 			continue
 		}
 		if !flags.Force {
-			ret, err := utils.YesNo(L("Do you really want to trust this key"))
+			ret, err := utils.YesNo(L("Do you really want to trust this key?"))
 			if err != nil {
 				return err
 			}

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -164,7 +164,8 @@ func AskIfMissing(value *string, prompt string, minValue int, maxValue int, chec
 func YesNo(question string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		fmt.Printf("%s [y/N]?", question)
+		// Translators: This is appended to the end of a question. Choices are short for `yes` and `no`.
+		fmt.Printf(L("%s [y/N]"), question)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {
@@ -173,10 +174,14 @@ func YesNo(question string) (bool, error) {
 
 		response = strings.ToLower(strings.TrimSpace(response))
 
-		if strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
+		// Empty responses imply `no`.
+		if len(response) == 0 {
+			return false, nil
+		}
+		if strings.HasPrefix(L("yes"), response) {
 			return true, nil
 		}
-		if strings.ToLower(response) == "n" || strings.ToLower(response) == "no" {
+		if strings.HasPrefix(L("no"), response) {
 			return false, nil
 		}
 	}

--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -161,7 +161,8 @@ func AskIfMissing(value *string, prompt string, minValue int, maxValue int, chec
 func YesNo(question string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		fmt.Printf("%s [y/N]?", question)
+		// Translators: This is appended to the end of a question. Choices are short for `yes` and `no`.
+		fmt.Printf(L("%s [y/N]"), question)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {
@@ -170,10 +171,14 @@ func YesNo(question string) (bool, error) {
 
 		response = strings.ToLower(strings.TrimSpace(response))
 
-		if strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
+		// Empty responses imply `no`.
+		if len(response) == 0 {
+			return false, nil
+		}
+		if strings.HasPrefix(L("yes"), response) {
 			return true, nil
 		}
-		if strings.ToLower(response) == "n" || strings.ToLower(response) == "no" {
+		if strings.HasPrefix(L("no"), response) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Improves the `utils.YesNo` function, allowing the strings to be translated easier.
Also added a check that makes the function return false when no response is given (as previously implied by `[y/N]`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
