### PR TITLE
Check for CA's basicConstraints to be marked critical

### DIFF
--- a/shared/ssl/ssl.go
+++ b/shared/ssl/ssl.go
@@ -192,6 +192,9 @@ func extractCertificateData(content []byte) (certificate, error) {
 			} else if nextVal == "authKeyId" && strings.HasPrefix(line, "    keyid:") {
 				cert.authKeyID = strings.ToUpper(strings.TrimSpace(strings.SplitN(line, ":", 2)[1]))
 			} else if nextVal == "basicConstraints" && strings.Contains(line, "CA:TRUE") {
+				if !strings.Contains(line, "critical") {
+					log.Error().Msg(L("CA basicConstraints section is not marked as 'critical'"))
+				}
 				cert.isCa = true
 			} else {
 				// Unhandled extension value

--- a/uyuni-tools.changes.cbosdo.critical-check
+++ b/uyuni-tools.changes.cbosdo.critical-check
@@ -1,0 +1,1 @@
+- Report error if CA misses critical basicConstraints


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

RFC5280 requires the SSL CA to be have the basicConstraints extension marked as 'critical'. Reporting an error for now without failing.

## Test coverage
- No tests: only an error message

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
