### PR TITLE
Check and warn if CA certificate isn't marked as critical

### DIFF
--- a/shared/ssl/ssl.go
+++ b/shared/ssl/ssl.go
@@ -97,6 +97,7 @@ type certificate struct {
 	subjectKeyID string
 	authKeyID    string
 	isCa         bool
+	isCritical   bool
 	isRoot       bool
 }
 
@@ -193,6 +194,8 @@ func extractCertificateData(content []byte) (certificate, error) {
 				cert.authKeyID = strings.ToUpper(strings.TrimSpace(strings.SplitN(line, ":", 2)[1]))
 			} else if nextVal == "basicConstraints" && strings.Contains(line, "CA:TRUE") {
 				cert.isCa = true
+			} else if nextVal == "basicConstraints" && strings.Contains(line, "critical") {
+				cert.isCritical = true
 			} else {
 				// Unhandled extension value
 				continue
@@ -204,6 +207,11 @@ func extractCertificateData(content []byte) (certificate, error) {
 			// second issue_hash without key to identify this value
 			cert.issuerHash = strings.TrimSpace(line)
 		}
+	}
+
+	// This configuration might not work anymore in the future.
+	if cert.isCa && !cert.isCritical {
+		log.Warn().Msgf(L("Basic constraints for CA should be marked as `%s`, could cause issues otherwise!"), "critical")
 	}
 
 	if cert.subject == cert.issuer {

--- a/uyuni-tools.changes.mfriedrich.warn-if-not-critical
+++ b/uyuni-tools.changes.mfriedrich.warn-if-not-critical
@@ -1,0 +1,1 @@
+- Check and warn if CA certificate isn't marked as critical


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Issue a warning if a CA is not marked as `critical`. See https://datatracker.ietf.org/doc/html/rfc5280 for details.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
