### PR TITLE
Add timezone to the database container (bsc#1267871)

### DIFF
--- a/mgradm/cmd/backup/restore/systemd_utils.go
+++ b/mgradm/cmd/backup/restore/systemd_utils.go
@@ -115,6 +115,7 @@ func generateDefaultSystemdServices(flags *shared.Flagpole) error {
 	return utils.JoinErrors(
 		podman.GenerateUpgradeServerEnvironmentFile(false),
 		podman.GenerateSystemdService(systemd, serverImage, adm_utils.InstallationFlags{}, []string{}, ""),
+		pgsql.GenerateCustomConfig(""),
 		pgsql.GeneratePgsqlSystemdService(systemd, dbImage),
 		systemd.ReloadDaemon(false),
 	)

--- a/mgradm/cmd/install/flags.go
+++ b/mgradm/cmd/install/flags.go
@@ -13,7 +13,6 @@ import (
 
 // AddInstallFlags add flags to install command.
 func AddInstallFlags(cmd *cobra.Command) {
-	cmd.Flags().String("tz", "", L("Time zone to set on the server. Defaults to the host timezone"))
 	cmd.Flags().String("email", "admin@example.com", L("Administrator e-mail"))
 	cmd.Flags().String("emailfrom", "notifications@example.com", L("E-Mail sending the notifications"))
 	cmd.Flags().String("issParent", "", L("InterServerSync v1 parent FQDN"))

--- a/mgradm/cmd/install/utils.go
+++ b/mgradm/cmd/install/utils.go
@@ -75,7 +75,9 @@ func installForPodman(
 	}
 
 	// Create all the database credentials secrets and setup the DB
-	if err := setupDatabase(flags.Installation.DB, flags.Installation.ReportDB, preparedPgsqlImage); err != nil {
+	if err := setupDatabase(
+		flags.Installation.DB, flags.Installation.ReportDB, preparedPgsqlImage, flags.Installation.TZ,
+	); err != nil {
 		return err
 	}
 
@@ -118,7 +120,7 @@ func installForPodman(
 	)
 }
 
-func setupDatabase(dbFlags types.DBFlags, reportdbFlags types.DBFlags, preparedImage string) error {
+func setupDatabase(dbFlags types.DBFlags, reportdbFlags types.DBFlags, preparedImage string, tz string) error {
 	if err := shared_podman.CreateCredentialsSecrets(
 		shared_podman.DBUserSecret, dbFlags.User,
 		shared_podman.DBPassSecret, dbFlags.Password,
@@ -149,7 +151,7 @@ func setupDatabase(dbFlags types.DBFlags, reportdbFlags types.DBFlags, preparedI
 		return err
 	}
 	// Run the DB container setup if the user doesn't set a custom host name for it.
-	if err := pgsql.SetupPgsql(systemd, preparedImage); err != nil {
+	if err := pgsql.SetupPgsql(systemd, preparedImage, tz); err != nil {
 		return err
 	}
 	if dbFlags.Walbackup {

--- a/mgradm/shared/pgsql/pgsql.go
+++ b/mgradm/shared/pgsql/pgsql.go
@@ -6,6 +6,7 @@ package pgsql
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/templates"
 	"github.com/uyuni-project/uyuni-tools/shared"
@@ -37,11 +38,31 @@ func PreparePgsqlImage(
 	return preparedImage, err
 }
 
+func GenerateCustomConfig(tz string) error {
+	customConfFilePath := path.Join(podman.GetServiceConfFolder(podman.DBService), podman.CustomConf)
+	if !utils.FileExists(customConfFilePath) {
+		if tz == "" {
+			tz = "Etc/UTC"
+		}
+		environment := fmt.Sprintf("Environment=TZ=%s\n", tz)
+
+		if err := podman.GenerateSystemdConfFile(podman.DBService, podman.CustomConf, environment, true); err != nil {
+			return utils.Error(err, L("cannot generate systemd custom configuration file"))
+		}
+	}
+	return nil
+}
+
 // SetupPgsql prepares the systemd service and starts it if needed.
 func SetupPgsql(
 	systemd podman.Systemd,
 	pgsqlImage string,
+	tz string,
 ) error {
+	if err := GenerateCustomConfig(tz); err != nil {
+		return err
+	}
+
 	if err := GeneratePgsqlSystemdService(systemd, pgsqlImage); err != nil {
 		return utils.Error(err, L("cannot generate systemd service"))
 	}
@@ -64,7 +85,11 @@ func SetupPgsql(
 func Upgrade(
 	preparedImage string,
 	systemd podman.Systemd,
+	tz string,
 ) error {
+	if err := GenerateCustomConfig(tz); err != nil {
+		return err
+	}
 	if err := GeneratePgsqlSystemdService(systemd, preparedImage); err != nil {
 		return utils.Error(err, L("cannot generate systemd service"))
 	}

--- a/mgradm/shared/podman/podman.go
+++ b/mgradm/shared/podman/podman.go
@@ -538,7 +538,7 @@ func Upgrade(
 		return utils.Errorf(err, L("cannot configure db container"))
 	}
 
-	if err := pgsql.Upgrade(preparedPgsqlImage, systemd); err != nil {
+	if err := pgsql.Upgrade(preparedPgsqlImage, systemd, tz); err != nil {
 		return err
 	}
 
@@ -591,7 +591,7 @@ func Upgrade(
 	return utils.JoinErrors(
 		coco.Upgrade(systemd, authFile, cocoFlags, image, inspectedDB),
 		hub.Upgrade(systemd, authFile, image, hubXmlrpcFlags),
-		saline.Upgrade(systemd, authFile, image, salineFlags, utils.GetLocalTimezone()),
+		saline.Upgrade(systemd, authFile, image, salineFlags, tz),
 		tftp.Upgrade(systemd, authFile, image, tftpdFlags, fqdn, hasTFTP),
 		systemd.ReloadDaemon(false),
 	)
@@ -785,7 +785,7 @@ func configureDBContainer(
 		}
 
 		// Run the DB container setup if the user doesn't set a custom host name for it.
-		if err := pgsql.SetupPgsql(systemd, pgsqlImage); err != nil {
+		if err := pgsql.SetupPgsql(systemd, pgsqlImage, ""); err != nil {
 			return err
 		}
 	} else {

--- a/mgradm/shared/templates/pgsqlServiceTemplate.go
+++ b/mgradm/shared/templates/pgsqlServiceTemplate.go
@@ -39,6 +39,7 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
 	--hostname {{ .NamePrefix }}-db.mgr.internal \
 	--network-alias db \
 	--network-alias reportdb \
+	-e TZ=${TZ} \
 	--secret {{ .CaSecret }},type=mount,target={{ .CaPath }} \
 	--secret {{ .KeySecret }},type=mount,uid=999,mode=0400,target={{ .KeyPath }} \
 	--secret {{ .CertSecret }},type=mount,target={{ .CertPath }} \

--- a/mgradm/shared/utils/cmd_utils.go
+++ b/mgradm/shared/utils/cmd_utils.go
@@ -213,6 +213,7 @@ func AddPgsqlFlags(cmd *cobra.Command) {
 
 // AddServerFlags add flags common to install, upgrade and migration.
 func AddServerFlags(cmd *cobra.Command) {
+	cmd.Flags().String("tz", "", L("Time zone to set on the server. Defaults to the host timezone"))
 	AddImageFlag(cmd)
 	AddSCCFlag(cmd)
 	AddPgsqlFlags(cmd)

--- a/shared/testutils/flagstests/mgradm_install.go
+++ b/shared/testutils/flagstests/mgradm_install.go
@@ -14,7 +14,7 @@ import (
 // InstallFlagsTestArgs is the slice of command parameters to use with AssertInstallFlags.
 var InstallFlagsTestArgs = func() []string {
 	args := []string{
-		"--tz", "CEST",
+		"--tz", "Europe/Berlin",
 		"--email", "admin@foo.bar",
 		"--emailfrom", "sender@foo.bar",
 		"--issParent", "parent.iss.com",
@@ -49,7 +49,7 @@ var InstallFlagsTestArgs = func() []string {
 
 // AssertInstallFlags checks that all the install flags are parsed correctly.
 func AssertInstallFlags(t *testing.T, flags *utils.ServerFlags) {
-	testutils.AssertEquals(t, "Error parsing --tz", "CEST", flags.Installation.TZ)
+	testutils.AssertEquals(t, "Error parsing --tz", "Europe/Berlin", flags.Installation.TZ)
 	testutils.AssertEquals(t, "Error parsing --email", "admin@foo.bar", flags.Installation.Email)
 	testutils.AssertEquals(t, "Error parsing --emailfrom", "sender@foo.bar", flags.Installation.EmailFrom)
 	testutils.AssertEquals(t, "Error parsing --issParent", "parent.iss.com", flags.Installation.IssParent)

--- a/shared/testutils/flagstests/server.go
+++ b/shared/testutils/flagstests/server.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
 )
 
 // ServerFlagsTestArgs is the slide of server-related command parameters to use with AssertServerFlags.
 var ServerFlagsTestArgs = func() []string {
-	args := []string{}
+	args := []string{"--tz", "Europe/Berlin"}
 	args = append(args, SCCFlagTestArgs...)
 	args = append(args, PgsqlFlagsTestArgs...)
 	args = append(args, DBFlagsTestArgs...)
@@ -33,6 +34,7 @@ var ServerFlagsTestArgs = func() []string {
 
 // AssertServerFlags checks that all the server-related common flags are parsed correctly.
 func AssertServerFlags(t *testing.T, flags *utils.ServerFlags) {
+	testutils.AssertEquals(t, "Error parsing --tz", "Europe/Berlin", flags.Installation.TZ)
 	AssertImageFlag(t, &flags.Image)
 	AssertRegistryFlag(t, &flags.Image.Registry)
 	AssertDBUpgradeImageFlag(t, &flags.DBUpgradeImage)

--- a/uyuni-tools.changes.cbosdo.db-timezone
+++ b/uyuni-tools.changes.cbosdo.db-timezone
@@ -1,0 +1,1 @@
+- Set the timezone on the database container too (bsc#1267871)


### PR DESCRIPTION
## What does this PR change?

Align the database timezone with the server one for fresh installations. For upgrade, the current `Etc/UTC` is set in the custom config and would need to be manually changed if the user wishes to using the new --tz parameter.

## Test coverage
- Unit tests were altered for the `--tz` flag

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30904
Port: 5.1: https://github.com/SUSE/uyuni-tools/pull/249 5.2: https://github.com/SUSE/uyuni-tools/pull/259

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
