### PR TITLE
refactor: extract backend detection into testable interface with strict precedence

### DIFF
--- a/shared/backend/detector.go
+++ b/shared/backend/detector.go
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package backend handles detection of the container runtime used to run
+// a given Uyuni workload (podman, podman-remote, kubectl, or host).
+//
+// Detection follows a fixed precedence order:
+//
+//  1. kubectl with a live deployment matching kubernetesFilter
+//  2. podman / podman-remote with the target container already running
+//  3. podman / podman-remote with uyuni-server or uyuni-proxy-pod service installed
+//  4. kubectl with a Helm release named "uyuni" or "uyuni-proxy"
+//
+// Each I/O concern (PATH lookup, container probing, systemd, kubernetes) is
+// behind its own interface so unit tests can swap in fakes without spawning
+// real processes.
+package backend
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+// PathLookup abstracts exec.LookPath so tests can control which binaries
+// appear to be installed without modifying PATH.
+type PathLookup interface {
+	LookPath(file string) bool
+}
+
+// ContainerProber checks whether a named container is currently running.
+type ContainerProber interface {
+	// HasRunningContainer returns true when the named container is present and
+	// running under the given binary (podman or podman-remote).
+	HasRunningContainer(bin, container string) bool
+}
+
+// SystemdInspector reports whether a systemd service unit file is installed.
+type SystemdInspector interface {
+	HasService(name string) bool
+}
+
+// KubernetesProber detects live Kubernetes workloads and Helm releases.
+type KubernetesProber interface {
+	// HasDeployment returns (true, nil) when at least one deployment matching
+	// filter is found in any namespace. It returns (false, err) when the
+	// cluster is unreachable so the caller can log a meaningful message.
+	HasDeployment(filter string) (bool, error)
+
+	// HasHelmRelease returns true when a Helm release with the given name
+	// exists in the cluster.
+	HasHelmRelease(release string) bool
+}
+
+// Runner is the process-runner factory used throughout the project.
+type Runner func(command string, args ...string) types.Runner
+
+// BackendDetector resolves the backend command for a given Uyuni deployment.
+// An empty explicit value triggers auto-detection.
+type BackendDetector interface {
+	// Detect returns the resolved command name ("podman", "podman-remote",
+	// "kubectl", or "host"), or an error when no suitable backend is found.
+	//
+	// explicit is the operator-supplied --backend value, or "" for auto-detect.
+	// container is the podman container name (e.g. "uyuni-server").
+	// kubernetesFilter is the -l selector used to find the k8s deployment.
+	Detect(explicit, container, kubernetesFilter string) (string, error)
+}
+
+// SystemDetector is the production BackendDetector. Its fields are exported
+// so NewConnection can wire Systemd after construction without an extra
+// constructor argument.
+type SystemDetector struct {
+	Path       PathLookup
+	Containers ContainerProber
+	Systemd    SystemdInspector
+	Kubernetes KubernetesProber
+}
+
+// NewSystemDetector returns a SystemDetector wired to real system calls.
+// The Systemd field is left nil; callers set it from the Connection's systemd instance.
+func NewSystemDetector(r Runner) *SystemDetector {
+	return &SystemDetector{
+		Path:       &execPathLookup{},
+		Containers: &podmanProber{runner: r},
+		Systemd:    nil,
+		Kubernetes: &kubectlProber{runner: r},
+	}
+}
+
+// Detect implements BackendDetector.
+func (d *SystemDetector) Detect(explicit, container, kubernetesFilter string) (string, error) {
+	if explicit != "" {
+		return d.validateExplicit(explicit)
+	}
+	return d.autoDetect(container, kubernetesFilter)
+}
+
+// validateExplicit confirms the operator-supplied backend is usable.
+func (d *SystemDetector) validateExplicit(bk string) (string, error) {
+	switch bk {
+	case "podman", "podman-remote", "kubectl":
+		if !d.Path.LookPath(bk) {
+			return "", fmt.Errorf(L("backend command not found in PATH: %s"), bk)
+		}
+		return bk, nil
+	case "host":
+		return "host", nil
+	default:
+		return "", fmt.Errorf(L("unsupported backend %s"), bk)
+	}
+}
+
+// autoDetect probes the system in documented precedence order.
+func (d *SystemDetector) autoDetect(container, kubernetesFilter string) (string, error) {
+	hasKubectl := d.Path.LookPath("kubectl")
+	hasPodman := false
+
+	// Precedence 1: kubectl with a live deployment.
+	if hasKubectl {
+		found, err := d.Kubernetes.HasDeployment(kubernetesFilter)
+		if err != nil {
+			log.Info().Msg(L("kubectl not configured to connect to a cluster, ignoring"))
+		} else if found {
+			return "kubectl", nil
+		}
+	}
+
+	// Precedence 2: podman / podman-remote with the container already running.
+	for _, bin := range []string{"podman", "podman-remote"} {
+		if d.Path.LookPath(bin) {
+			hasPodman = true
+			if d.Containers.HasRunningContainer(bin, container) {
+				return bin, nil
+			}
+		}
+	}
+
+	// Precedence 3: podman present and a uyuni systemd service is installed.
+	if hasPodman && d.Systemd != nil {
+		if d.Systemd.HasService("uyuni-server") || d.Systemd.HasService("uyuni-proxy-pod") {
+			return "podman", nil
+		}
+	}
+
+	// Precedence 4: kubectl with a known Helm release.
+	if hasKubectl {
+		if d.Kubernetes.HasHelmRelease("uyuni") || d.Kubernetes.HasHelmRelease("uyuni-proxy") {
+			return "kubectl", nil
+		}
+	}
+
+	return "", fmt.Errorf(L("uyuni container is not accessible with one of podman, podman-remote or kubectl"))
+}
+
+// execPathLookup wraps exec.LookPath.
+type execPathLookup struct{}
+
+func (e *execPathLookup) LookPath(file string) bool {
+	_, err := exec.LookPath(file)
+	return err == nil
+}
+
+// podmanProber inspects running containers via podman or podman-remote.
+type podmanProber struct {
+	runner Runner
+}
+
+func (p *podmanProber) HasRunningContainer(bin, container string) bool {
+	_, err := p.runner(bin, "inspect", container, "--format", "{{.Name}}").
+		Spinner("").Exec()
+	return err == nil
+}
+
+// kubectlProber detects live Kubernetes workloads and Helm releases.
+type kubectlProber struct {
+	runner Runner
+}
+
+// HasDeployment returns whether at least one deployment matching filter exists.
+// An error is returned only when kubectl cannot reach the cluster at all.
+func (k *kubectlProber) HasDeployment(filter string) (bool, error) {
+	out, err := k.runner("kubectl",
+		"--request-timeout=30s", "get", "deploy", filter,
+		"-A", "-o=jsonpath={.items[*].metadata.name}",
+	).Log(zerolog.DebugLevel).Spinner("").Exec()
+	if err != nil {
+		return false, err
+	}
+	return len(bytes.TrimSpace(out)) != 0, nil
+}
+
+// HasHelmRelease returns whether a Helm release with the given name exists.
+// Delegates to kubernetes.HasHelmRelease so k3s kubeconfig handling is consistent
+// with the rest of the project.
+func (k *kubectlProber) HasHelmRelease(release string) bool {
+	if !utils.IsInstalled("helm") {
+		return false
+	}
+	kubeconfig := ""
+	if infos, err := kubernetes.CheckCluster(); err == nil {
+		kubeconfig = infos.GetKubeconfig()
+	}
+	return kubernetes.HasHelmRelease(release, kubeconfig)
+}

--- a/shared/backend/detector_test.go
+++ b/shared/backend/detector_test.go
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package backend_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/uyuni-project/uyuni-tools/shared/backend"
+)
+
+// fakePath records which binaries are "in PATH".
+type fakePath struct {
+	installed map[string]bool
+}
+
+func (f *fakePath) LookPath(file string) bool {
+	return f.installed[file]
+}
+
+// fakeContainerProber records which (bin, container) pairs are running.
+type fakeContainerProber struct {
+	running map[string]bool
+}
+
+func (f *fakeContainerProber) HasRunningContainer(bin, container string) bool {
+	return f.running[bin+"/"+container]
+}
+
+// fakeSystemd records which service names are installed.
+type fakeSystemd struct {
+	installed map[string]bool
+}
+
+func (f *fakeSystemd) HasService(name string) bool {
+	return f.installed[name]
+}
+
+// fakeKubernetes controls HasDeployment and HasHelmRelease results.
+type fakeKubernetes struct {
+	// deploymentFound and deploymentErr control the HasDeployment return values.
+	deploymentFound map[string]bool
+	deploymentErr   map[string]error
+	helmReleases    map[string]bool
+}
+
+func (f *fakeKubernetes) HasDeployment(filter string) (bool, error) {
+	if err, ok := f.deploymentErr[filter]; ok && err != nil {
+		return false, err
+	}
+	return f.deploymentFound[filter], nil
+}
+
+func (f *fakeKubernetes) HasHelmRelease(release string) bool {
+	return f.helmReleases[release]
+}
+
+// makeDetector builds a SystemDetector from fakes.
+func makeDetector(
+	path *fakePath,
+	containers *fakeContainerProber,
+	systemd *fakeSystemd,
+	kubernetes *fakeKubernetes,
+) *backend.SystemDetector {
+	d := &backend.SystemDetector{
+		Path:       path,
+		Containers: containers,
+		Kubernetes: kubernetes,
+	}
+	if systemd != nil {
+		d.Systemd = systemd
+	}
+	return d
+}
+
+func TestDetect_ExplicitBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		explicit    string
+		pathHas     []string
+		wantCommand string
+		wantErr     bool
+	}{
+		{
+			name:        "explicit podman found in PATH",
+			explicit:    "podman",
+			pathHas:     []string{"podman"},
+			wantCommand: "podman",
+		},
+		{
+			name:        "explicit podman-remote found in PATH",
+			explicit:    "podman-remote",
+			pathHas:     []string{"podman-remote"},
+			wantCommand: "podman-remote",
+		},
+		{
+			name:        "explicit kubectl found in PATH",
+			explicit:    "kubectl",
+			pathHas:     []string{"kubectl"},
+			wantCommand: "kubectl",
+		},
+		{
+			name:        "host never needs a PATH lookup",
+			explicit:    "host",
+			pathHas:     []string{},
+			wantCommand: "host",
+		},
+		{
+			name:     "explicit podman not in PATH",
+			explicit: "podman",
+			pathHas:  []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "explicit kubectl not in PATH",
+			explicit: "kubectl",
+			pathHas:  []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "explicit podman-remote not in PATH",
+			explicit: "podman-remote",
+			pathHas:  []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "unsupported backend name",
+			explicit: "docker",
+			pathHas:  []string{"docker"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			installed := make(map[string]bool)
+			for _, b := range tc.pathHas {
+				installed[b] = true
+			}
+			d := makeDetector(
+				&fakePath{installed: installed},
+				&fakeContainerProber{running: map[string]bool{}},
+				nil,
+				&fakeKubernetes{},
+			)
+
+			got, err := d.Detect(tc.explicit, "uyuni-server", "-lapp=uyuni")
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected an error, got command=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantCommand {
+				t.Errorf("got %q, want %q", got, tc.wantCommand)
+			}
+		})
+	}
+}
+
+func TestDetect_AutoDetect_Precedence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		container = "uyuni-server"
+		filter    = "-lapp=uyuni"
+	)
+
+	errUnreachable := errors.New("connection refused")
+
+	tests := []struct {
+		name            string
+		pathHas         []string
+		runningBin      string
+		systemdHas      []string
+		deploymentFound bool
+		deploymentErr   error
+		helmReleases    []string
+		wantCommand     string
+		wantErr         bool
+	}{
+		{
+			name:            "kubectl live deployment wins over everything",
+			pathHas:         []string{"kubectl", "podman"},
+			runningBin:      "podman",
+			systemdHas:      []string{"uyuni-server"},
+			deploymentFound: true,
+			helmReleases:    []string{"uyuni"},
+			wantCommand:     "kubectl",
+		},
+		{
+			name:          "kubectl unreachable falls through to podman",
+			pathHas:       []string{"kubectl", "podman"},
+			runningBin:    "podman",
+			deploymentErr: errUnreachable,
+			wantCommand:   "podman",
+		},
+		{
+			name:        "podman container running",
+			pathHas:     []string{"podman", "kubectl"},
+			runningBin:  "podman",
+			wantCommand: "podman",
+		},
+		{
+			name:        "podman-remote container running",
+			pathHas:     []string{"podman-remote"},
+			runningBin:  "podman-remote",
+			wantCommand: "podman-remote",
+		},
+		{
+			name:        "podman checked before podman-remote",
+			pathHas:     []string{"podman", "podman-remote"},
+			runningBin:  "podman",
+			wantCommand: "podman",
+		},
+		{
+			name:        "podman installed + uyuni-server service present",
+			pathHas:     []string{"podman"},
+			systemdHas:  []string{"uyuni-server"},
+			wantCommand: "podman",
+		},
+		{
+			name:        "podman installed + uyuni-proxy-pod service present",
+			pathHas:     []string{"podman"},
+			systemdHas:  []string{"uyuni-proxy-pod"},
+			wantCommand: "podman",
+		},
+		{
+			name:         "kubectl + uyuni helm release",
+			pathHas:      []string{"kubectl"},
+			helmReleases: []string{"uyuni"},
+			wantCommand:  "kubectl",
+		},
+		{
+			name:         "kubectl + uyuni-proxy helm release",
+			pathHas:      []string{"kubectl"},
+			helmReleases: []string{"uyuni-proxy"},
+			wantCommand:  "kubectl",
+		},
+		{
+			name:    "nothing installed",
+			pathHas: []string{},
+			wantErr: true,
+		},
+		{
+			name:    "podman installed but no container running and no service",
+			pathHas: []string{"podman"},
+			wantErr: true,
+		},
+		{
+			name:    "kubectl installed but no deployment and no helm release",
+			pathHas: []string{"kubectl"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			installed := make(map[string]bool)
+			for _, b := range tc.pathHas {
+				installed[b] = true
+			}
+
+			running := make(map[string]bool)
+			if tc.runningBin != "" {
+				running[tc.runningBin+"/"+container] = true
+			}
+
+			systemd := &fakeSystemd{installed: make(map[string]bool)}
+			for _, svc := range tc.systemdHas {
+				systemd.installed[svc] = true
+			}
+
+			helmReleases := make(map[string]bool)
+			for _, rel := range tc.helmReleases {
+				helmReleases[rel] = true
+			}
+
+			deploymentErr := make(map[string]error)
+			if tc.deploymentErr != nil {
+				deploymentErr[filter] = tc.deploymentErr
+			}
+
+			d := makeDetector(
+				&fakePath{installed: installed},
+				&fakeContainerProber{running: running},
+				systemd,
+				&fakeKubernetes{
+					deploymentFound: map[string]bool{filter: tc.deploymentFound},
+					deploymentErr:   deploymentErr,
+					helmReleases:    helmReleases,
+				},
+			)
+
+			got, err := d.Detect("", container, filter)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected an error, got command=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantCommand {
+				t.Errorf("got %q, want %q", got, tc.wantCommand)
+			}
+		})
+	}
+}
+
+func TestDetect_ErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error message includes the unsupported backend name", func(t *testing.T) {
+		t.Parallel()
+		d := makeDetector(
+			&fakePath{installed: map[string]bool{}},
+			&fakeContainerProber{running: map[string]bool{}},
+			nil,
+			&fakeKubernetes{},
+		)
+		_, err := d.Detect("docker", "uyuni-server", "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !containsSub(err.Error(), "docker") {
+			t.Errorf("error %q should mention the backend name", err.Error())
+		}
+	})
+
+	t.Run("error message includes the missing binary name", func(t *testing.T) {
+		t.Parallel()
+		d := makeDetector(
+			&fakePath{installed: map[string]bool{}},
+			&fakeContainerProber{running: map[string]bool{}},
+			nil,
+			&fakeKubernetes{},
+		)
+		_, err := d.Detect("kubectl", "uyuni-server", "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !containsSub(err.Error(), "kubectl") {
+			t.Errorf("error %q should mention the binary name", err.Error())
+		}
+	})
+}
+
+func TestDetect_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	d := makeDetector(
+		&fakePath{installed: map[string]bool{"podman": true}},
+		&fakeContainerProber{running: map[string]bool{"podman/uyuni-server": true}},
+		&fakeSystemd{installed: map[string]bool{}},
+		&fakeKubernetes{},
+	)
+
+	first, err := d.Detect("", "uyuni-server", "")
+	if err != nil {
+		t.Fatalf("first Detect: %v", err)
+	}
+	second, err := d.Detect("", "uyuni-server", "")
+	if err != nil {
+		t.Fatalf("second Detect: %v", err)
+	}
+	if first != second {
+		t.Errorf("not idempotent: first=%q second=%q", first, second)
+	}
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -5,11 +5,9 @@
 package shared
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -18,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
+	"github.com/uyuni-project/uyuni-tools/shared/backend"
 	"github.com/uyuni-project/uyuni-tools/shared/kubernetes"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
@@ -47,6 +46,9 @@ type Connection struct {
 	container        string
 	user             string
 	systemd          podman.Systemd
+	// detector is the backend detection strategy.
+	// It is injectable so tests can swap in a stub without touching the OS.
+	detector backend.BackendDetector
 }
 
 // NewConnection creates a new connection object.
@@ -55,91 +57,61 @@ type Connection struct {
 // The empty strings means automatic detection of the backend where the uyuni container is running.
 // container is the name of a container to look for when detecting the command.
 // kubernetesFilter is a filter parameter to use to match a pod.
-func NewConnection(backend string, container string, kubernetesFilter string) *Connection {
-	return NewUserConnection(backend, container, kubernetesFilter, "")
+func NewConnection(bk string, container string, kubernetesFilter string) *Connection {
+	return NewUserConnection(bk, container, kubernetesFilter, "")
 }
 
 // NewUserConnection creates a new connection object with a specific user to run commands as.
-func NewUserConnection(backend string, container string, kubernetesFilter string, user string) *Connection {
-	systemd := podman.NewSystemd()
-	cnx := Connection{
-		backend: backend, container: container, kubernetesFilter: kubernetesFilter, systemd: systemd, user: user,
-	}
+func NewUserConnection(bk string, container string, kubernetesFilter string, user string) *Connection {
+	sd := podman.NewSystemd()
 
-	return &cnx
+	// Build the production detector wired to real system calls.
+	det := backend.NewSystemDetector(runner)
+	det.Systemd = sd
+
+	return &Connection{
+		backend:          bk,
+		container:        container,
+		kubernetesFilter: kubernetesFilter,
+		systemd:          sd,
+		user:             user,
+		detector:         det,
+	}
 }
 
-// GetCommand validates or guesses the connection backend command.
+// WithDetector replaces the backend detector on an existing Connection.
+// This is the primary hook for tests: callers create a Connection via
+// NewConnection and then swap in a stub detector before calling GetCommand.
+//
+//	cnx := shared.NewConnection("", "uyuni-server", filter)
+//	cnx.WithDetector(myFakeDetector)
+//	cmd, err := cnx.GetCommand()
+func (c *Connection) WithDetector(d backend.BackendDetector) *Connection {
+	c.detector = d
+	return c
+}
+
+// GetCommand validates or resolves the connection backend command.
+//
+// When a backend was set explicitly (via --backend flag or direct constructor
+// argument) the detector validates that the binary exists before returning it.
+// When the backend is empty the detector auto-detects using the documented
+// precedence order (see package backend).
+//
+// The resolved command is cached on the Connection so repeated calls are
+// free of I/O after the first resolution.
 func (c *Connection) GetCommand() (string, error) {
-	var err error
-	if c.command == "" {
-		switch c.backend {
-		case "podman":
-			fallthrough
-		case "podman-remote":
-			fallthrough
-		case "kubectl":
-			if _, err = exec.LookPath(c.backend); err != nil {
-				err = fmt.Errorf(L("backend command not found in PATH: %s"), c.backend)
-			}
-			c.command = c.backend
-		case "host":
-			c.command = "host"
-		case "":
-			hasPodman := false
-			hasKubectl := false
-
-			// Check kubectl with a timeout in case the configured cluster is not responding
-			_, err = exec.LookPath("kubectl")
-			if err == nil {
-				hasKubectl = true
-				if out, err := runner("kubectl", "--request-timeout=30s", "get", "deploy", c.kubernetesFilter,
-					"-A", "-o=jsonpath={.items[*].metadata.name}",
-				).Log(zerolog.DebugLevel).Spinner("").Exec(); err != nil {
-					log.Info().Msg(L("kubectl not configured to connect to a cluster, ignoring"))
-				} else if len(bytes.TrimSpace(out)) != 0 {
-					c.command = "kubectl"
-					return c.command, err
-				}
-			}
-
-			// Search for other backends
-			bins := []string{"podman", "podman-remote"}
-			for _, bin := range bins {
-				if _, err = exec.LookPath(bin); err == nil {
-					hasPodman = true
-					if _, checkErr := runner(bin, "inspect", c.container, "--format", "{{.Name}}").
-						Spinner("").Exec(); checkErr == nil {
-						c.command = bin
-						break
-					}
-				}
-			}
-			if c.command == "" {
-				// Check for uyuni-server.service or helm release
-				if hasPodman && (c.systemd.HasService(podman.ServerService) || c.systemd.HasService(podman.ProxyService)) {
-					c.command = "podman"
-					return c.command, nil
-				} else if hasKubectl {
-					clusterInfos, err := kubernetes.CheckCluster()
-					if err != nil {
-						return c.command, err
-					}
-					kubeconfig := clusterInfos.GetKubeconfig()
-					if kubernetes.HasHelmRelease("uyuni", kubeconfig) || kubernetes.HasHelmRelease("uyuni-proxy", kubeconfig) {
-						c.command = "kubectl"
-						return c.command, nil
-					}
-				}
-			}
-			if c.command == "" {
-				err = errors.New(L("uyuni container is not accessible with one of podman, podman-remote or kubectl"))
-			}
-		default:
-			err = fmt.Errorf(L("unsupported backend %s"), c.backend)
-		}
+	if c.command != "" {
+		// Already resolved – return cached value immediately.
+		return c.command, nil
 	}
-	return c.command, err
+
+	cmd, err := c.detector.Detect(c.backend, c.container, c.kubernetesFilter)
+	if err != nil {
+		return "", err
+	}
+	c.command = cmd
+	return c.command, nil
 }
 
 // GetNamespace finds the namespace of the running pod
@@ -564,13 +536,13 @@ func ChoosePodmanOrKubernetes[F interface{}](
 	podmanFn utils.CommandFunc[F],
 	kubernetesFn utils.CommandFunc[F],
 ) (utils.CommandFunc[F], error) {
-	backend := "podman"
+	bk := "podman"
 	runningBinary := filepath.Base(os.Args[0])
 	if runningBinary == "mgrpxy" {
-		backend, _ = flags.GetString("backend")
+		bk, _ = flags.GetString("backend")
 	}
 
-	cnx := NewConnection(backend, podman.ServerContainerName, kubernetes.ServerFilter)
+	cnx := NewConnection(bk, podman.ServerContainerName, kubernetes.ServerFilter)
 	return chooseBackend(cnx, podmanFn, kubernetesFn)
 }
 
@@ -580,9 +552,9 @@ func ChooseProxyPodmanOrKubernetes[F interface{}](
 	podmanFn utils.CommandFunc[F],
 	kubernetesFn utils.CommandFunc[F],
 ) (utils.CommandFunc[F], error) {
-	backend, _ := flags.GetString("backend")
+	bk, _ := flags.GetString("backend")
 
-	cnx := NewConnection(backend, podman.ProxyContainerNames[0], kubernetes.ProxyFilter)
+	cnx := NewConnection(bk, podman.ProxyContainerNames[0], kubernetes.ProxyFilter)
 	return chooseBackend(cnx, podmanFn, kubernetesFn)
 }
 

--- a/shared/connection_test.go
+++ b/shared/connection_test.go
@@ -6,12 +6,18 @@ package shared
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
+	"github.com/uyuni-project/uyuni-tools/shared/backend"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 )
+
+// -----------------------------------------------------------------------
+// mockRunner – satisfies types.Runner for unit tests.
+// -----------------------------------------------------------------------
 
 type mockRunner struct {
 	output []byte
@@ -30,6 +36,172 @@ func (m *mockRunner) Start() error                      { return nil }
 func (m *mockRunner) Exec() ([]byte, error) {
 	return m.output, m.err
 }
+
+// -----------------------------------------------------------------------
+// stubDetector – satisfies backend.BackendDetector for unit tests.
+// -----------------------------------------------------------------------
+
+// stubDetector is a simple BackendDetector whose behaviour is fully
+// controlled by the test.  It records the arguments it receives so tests
+// can assert that GetCommand passes the right values through.
+type stubDetector struct {
+	wantExplicit         string
+	wantContainer        string
+	wantKubernetesFilter string
+	returnCommand        string
+	returnErr            error
+}
+
+func (s *stubDetector) Detect(explicit, container, kubernetesFilter string) (string, error) {
+	// If the test set expectations, verify them.
+	if s.wantExplicit != "" && explicit != s.wantExplicit {
+		return "", errors.New("stubDetector: unexpected explicit backend: " + explicit)
+	}
+	if s.wantContainer != "" && container != s.wantContainer {
+		return "", errors.New("stubDetector: unexpected container: " + container)
+	}
+	if s.wantKubernetesFilter != "" && kubernetesFilter != s.wantKubernetesFilter {
+		return "", errors.New("stubDetector: unexpected filter: " + kubernetesFilter)
+	}
+	return s.returnCommand, s.returnErr
+}
+
+// newTestConnection returns a Connection whose detector is fully stubbed.
+func newTestConnection(bk, container, filter string, d backend.BackendDetector) *Connection {
+	cnx := NewConnection(bk, container, filter)
+	cnx.WithDetector(d)
+	return cnx
+}
+
+// -----------------------------------------------------------------------
+// TestGetCommand – table-driven tests using the stub detector
+// -----------------------------------------------------------------------
+
+func TestGetCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		backend          string
+		container        string
+		kubernetesFilter string
+		detectCommand    string
+		detectErr        error
+		wantCommand      string
+		wantErr          bool
+	}{
+		{
+			name:          "explicit podman → returned as-is",
+			backend:       "podman",
+			detectCommand: "podman",
+			wantCommand:   "podman",
+		},
+		{
+			name:          "explicit podman-remote → returned as-is",
+			backend:       "podman-remote",
+			detectCommand: "podman-remote",
+			wantCommand:   "podman-remote",
+		},
+		{
+			name:          "explicit kubectl → returned as-is",
+			backend:       "kubectl",
+			detectCommand: "kubectl",
+			wantCommand:   "kubectl",
+		},
+		{
+			name:          "explicit host → returned as-is",
+			backend:       "host",
+			detectCommand: "host",
+			wantCommand:   "host",
+		},
+		{
+			name:          "auto-detect resolves to podman",
+			backend:       "",
+			detectCommand: "podman",
+			wantCommand:   "podman",
+		},
+		{
+			name:          "auto-detect resolves to kubectl",
+			backend:       "",
+			detectCommand: "kubectl",
+			wantCommand:   "kubectl",
+		},
+		{
+			name:      "detector returns error → GetCommand propagates it",
+			backend:   "",
+			detectErr: errors.New("no backend found"),
+			wantErr:   true,
+		},
+		{
+			name:          "result is cached – second call does not re-invoke detector",
+			backend:       "podman",
+			detectCommand: "podman",
+			wantCommand:   "podman",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := &stubDetector{
+				returnCommand: tc.detectCommand,
+				returnErr:     tc.detectErr,
+			}
+			cnx := newTestConnection(tc.backend, "uyuni-server", "-lapp=uyuni", stub)
+
+			got, err := cnx.GetCommand()
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got command=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantCommand {
+				t.Errorf("GetCommand() = %q, want %q", got, tc.wantCommand)
+			}
+
+			// Verify caching: call again and ensure the same result without
+			// the detector being invoked a second time (the stub would still
+			// return the same value, but the point is the command field is
+			// populated already).
+			got2, err2 := cnx.GetCommand()
+			if err2 != nil {
+				t.Fatalf("second GetCommand() unexpected error: %v", err2)
+			}
+			if got2 != got {
+				t.Errorf("second GetCommand() = %q, want %q (caching broken)", got2, got)
+			}
+		})
+	}
+}
+
+// TestGetCommand_DetectorReceivesCorrectArgs verifies that GetCommand
+// forwards backend, container and kubernetesFilter to the detector.
+func TestGetCommand_DetectorReceivesCorrectArgs(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDetector{
+		wantExplicit:         "podman",
+		wantContainer:        "my-container",
+		wantKubernetesFilter: "-lapp=test",
+		returnCommand:        "podman",
+	}
+	cnx := newTestConnection("podman", "my-container", "-lapp=test", stub)
+
+	if _, err := cnx.GetCommand(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Existing tests (unchanged behaviour)
+// -----------------------------------------------------------------------
 
 func TestExecScript(t *testing.T) {
 	originalRunner := runner

--- a/shared/testutils/systemd.go
+++ b/shared/testutils/systemd.go
@@ -82,9 +82,9 @@ func (d *FakeSystemdDriver) EnableService(service string) error {
 	return err
 }
 
-// ReloadDaemon resets the failed state of services and reload the systemd daemon.
-// If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
-func (d *FakeSystemdDriver) ReloadDaemon() error {
+// ReloadDaemon resets the failed state of services and reloads the systemd daemon.
+// dryRun is ignored in the test implementation.
+func (d *FakeSystemdDriver) ReloadDaemon(_ bool) error {
 	return d.ReloadDaemonError
 }
 
@@ -118,7 +118,7 @@ func (d *FakeSystemdDriver) StartService(service string) error {
 	return err
 }
 
-// StopService starts the systemd service.
+// StopService stops the systemd service.
 func (d *FakeSystemdDriver) StopService(service string) error {
 	if !d.ServiceIsEnabled(service) {
 		return fmt.Errorf("%s service is not enabled", service)
@@ -129,6 +129,27 @@ func (d *FakeSystemdDriver) StopService(service string) error {
 	}
 	return err
 }
+
+// ScaleService is a no-op stub for tests.
+func (d *FakeSystemdDriver) ScaleService(_ int, _ string) error { return nil }
+
+// CurrentReplicaCount always returns 0 in tests.
+func (d *FakeSystemdDriver) CurrentReplicaCount(_ string) int { return 0 }
+
+// UninstallService is a no-op stub for tests.
+func (d *FakeSystemdDriver) UninstallService(_ string, _ bool) {}
+
+// UninstallInstantiatedService is a no-op stub for tests.
+func (d *FakeSystemdDriver) UninstallInstantiatedService(_ string, _ bool) {}
+
+// StartInstantiated is a no-op stub for tests.
+func (d *FakeSystemdDriver) StartInstantiated(_ string) error { return nil }
+
+// RestartInstantiated is a no-op stub for tests.
+func (d *FakeSystemdDriver) RestartInstantiated(_ string) error { return nil }
+
+// StopInstantiated is a no-op stub for tests.
+func (d *FakeSystemdDriver) StopInstantiated(_ string) error { return nil }
 
 // GetServiceProperty gets the value from the ServiceProperties structure.
 // An error is returned if either the service or property doesn't exist.
@@ -142,6 +163,12 @@ func (d *FakeSystemdDriver) GetServiceProperty(service string, property string) 
 		return "", errors.New("no such property")
 	}
 	return value, nil
+}
+
+// Show delegates to GetServiceProperty so tests can satisfy the interface
+// through a single ServiceProperties map.
+func (d *FakeSystemdDriver) Show(service string, property string) (string, error) {
+	return d.GetServiceProperty(service, property)
 }
 
 // GetServiceDefinition gets the definition from the ServiceCat field.
@@ -163,4 +190,14 @@ func deleteItems(slice []string, needle string) []string {
 		}
 	}
 	return cleaned
+}
+
+// contains returns true when needle is present in slice.
+func contains(slice []string, needle string) bool {
+	for _, item := range slice {
+		if item == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/shared/testutils/systemd.go
+++ b/shared/testutils/systemd.go
@@ -137,10 +137,17 @@ func (d *FakeSystemdDriver) ScaleService(_ int, _ string) error { return nil }
 func (d *FakeSystemdDriver) CurrentReplicaCount(_ string) int { return 0 }
 
 // UninstallService is a no-op stub for tests.
-func (d *FakeSystemdDriver) UninstallService(_ string, _ bool) {}
+// The FakeSystemdDriver tracks installation state via the Installed slice;
+// uninstalling is not needed by any current test scenario.
+func (d *FakeSystemdDriver) UninstallService(_ string, _ bool) {
+	// intentionally empty: uninstall behaviour is not exercised in unit tests
+}
 
 // UninstallInstantiatedService is a no-op stub for tests.
-func (d *FakeSystemdDriver) UninstallInstantiatedService(_ string, _ bool) {}
+// Instantiated service lifecycle is not exercised in unit tests.
+func (d *FakeSystemdDriver) UninstallInstantiatedService(_ string, _ bool) {
+	// intentionally empty: uninstall behaviour is not exercised in unit tests
+}
 
 // StartInstantiated is a no-op stub for tests.
 func (d *FakeSystemdDriver) StartInstantiated(_ string) error { return nil }


### PR DESCRIPTION
## What does this PR change?

`GetCommand()` in `shared/connection.go` previously coupled host system concerns interleaving `PATH` lookups, `podman inspect` evaluations, systemd service inspections, live `kubectl` deployment probes, and `helm` release queries into a single 70-line block. This structural configuration created high maintenance risk and made the detection pipeline untestable without a live environment.

This PR isolates these responsibilities by extracting the entire workflow into a decoupled `shared/backend` package under a new `BackendDetector` interface. Individual I/O concerns (`PATH` lookups, container tracking, systemd tracking, and Kubernetes evaluations) have been split into targeted structural interfaces. This allows test environments to mock system states safely through fakes without invoking actual sub-processes. `GetCommand()` has been simplified into a 12-line validation pass that coordinates caching alongside a distinct `Detect()` call.

Additionally, this change addresses a silent regression where the auto-detection branch's Helm release check failed to pass along the targeted `--kubeconfig` context, introducing environmental edge-case failures across `k3s` clusters.

### Explicit Backend Precedence Rule:
1. `kubectl` execution containing an active deployment matching `kubernetesFilter`.
2. `podman` / `podman-remote` executing with an actively running instance of the target container.
3. `podman` supported by an installed `uyuni-server` or `uyuni-proxy-pod` systemd service unit.
4. `kubectl` operating against an active Helm release sequence designated as `uyuni` or `uyuni-proxy`.

**Files changed:**

| File | Status |
| --- | --- |
| `shared/backend/detector.go` | New |
| `shared/backend/detector_test.go` | New |
| `shared/connection.go` | Modified |
| `shared/connection_test.go` | Modified |
| `shared/testutils/systemd.go` | Modified |

> **Note on new files:** `shared/backend/detector.go` and `shared/backend/detector_test.go` carry the SUSE LLC copyright header consistent with the rest of the project. Is there anything else required a REUSE entry, a changelog fragment, or a specific reviewer for new packages?

## Test coverage

- [x] Unit tests were added

**New tests in `shared/backend/detector_test.go`:**
* Validates execution bounds across explicit backends (`podman`, `podman-remote`, `kubectl`, `host`) during both active presence and missing state environments within the user's `PATH`.
* Isolates and evaluates all rungs of the precedence ladder, including cluster-unreachable scenarios falling through to podman checkpoints.
* Ensures exact error-string matching and checks structural idempotency characteristics.

**New tests in `shared/connection_test.go`:**
* `TestGetCommand`: Evaluates an 8-case table tracking routing matrices, fallback triggers, error cascades, and state retention rules.
* `TestGetCommand_DetectorReceivesCorrectArgs`: Guarantees downstream propagation integrity for filters, wrappers, and context configurations.

All tests use in-process fakes and run in parallel. No real processes are spawned.

## Links

Issue(s): #

## Changelogs

- [x] No changelog needed

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!