### PR TITLE
Check all supported locations for CA file in rotation check script

### DIFF
--- a/mgradm/shared/podman/clients.go
+++ b/mgradm/shared/podman/clients.go
@@ -132,22 +132,28 @@ func parseClientTrustResults(saltOutput []byte, unreachable map[string]bool) (
 // CA file holds a certificate matching a given SHA-256 fingerprint.
 // It prints "OK" on a match and "MISSING" otherwise.
 const clientTrustCheckScript = `
-caFile="/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"
-
-# Without the managed CA file the minion cannot trust the new CA yet.
-[ -f "$caFile" ] || { echo MISSING; exit 0; }
-
-# Split the (possibly multi-cert) CA file into one file per certificate.
-d=$(mktemp -d)
-trap 'rm -rf "$d"' EXIT
-csplit -z -s -f "$d/cert-" "$caFile" '/-----BEGIN CERTIFICATE-----/' '{*}' 2>/dev/null
-
-# Report OK as soon as one of the certificates matches the expected fingerprint.
 found=MISSING
-for cert in "$d"/cert-*; do
-	fp=$(openssl x509 -in "$cert" -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2)
-	[ "$fp" = "%[1]s" ] && found=OK
+
+for caFile in \
+	/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT \
+	/etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT \
+	/usr/local/share/ca-certificates/RHN-ORG-TRUSTED-SSL-CERT.crt; do
+	# Skip the locations that do not apply to this minion's OS.
+	[ -f "$caFile" ] || continue
+
+	# Split the (possibly multi-cert) CA file into one file per certificate.
+	d=$(mktemp -d)
+	csplit -z -s -f "$d/cert-" "$caFile" '/-----BEGIN CERTIFICATE-----/' '{*}' 2>/dev/null
+
+	# Report OK as soon as one of the certificates matches the expected fingerprint.
+	for cert in "$d"/cert-*; do
+		fp=$(openssl x509 -in "$cert" -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2)
+		[ "$fp" = "%[1]s" ] && found=OK
+	done
+
+	rm -rf "$d"
 done
+
 echo "$found"
 `
 

--- a/uyuni-tools.changes.mfriedrich.fix-ca-rotation-nonsuse
+++ b/uyuni-tools.changes.mfriedrich.fix-ca-rotation-nonsuse
@@ -1,0 +1,1 @@
+- Check all supported locations for CA file in rotation check script


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Previously `mgradm ssl rotate` didn't check the for other locations of the CA file, so the rotation check only succeeds on SUSE systems. This PR adds checks for multiple locations used in RHEL and Debian variants.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
