### PR TITLE
Remove the direct dependency on x/net

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/spf13/cobra v1.8.0
-	golang.org/x/net v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,6 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/shared/testutils/runner.go
+++ b/shared/testutils/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,9 +7,10 @@ package testutils
 import (
 	"bytes"
 
+	"context"
+
 	"github.com/rs/zerolog"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
-	"golang.org/x/net/context"
 )
 
 type fakeRunner struct {

--- a/update-copyright-year.sh
+++ b/update-copyright-year.sh
@@ -9,6 +9,9 @@ changed="n"
 current_year=$(date +%Y)
 for changed_file in $@; do
     case "$changed_file" in
+        go.mod|go.sum)
+            continue
+            ;;
         # Changelogs
         uyuni-tools.changes*)
             continue

--- a/uyuni-tools.changes.cbosdo.bsc1266481-mini
+++ b/uyuni-tools.changes.cbosdo.bsc1266481-mini
@@ -1,0 +1,1 @@
+- CVE-2026-39821: Drop the direct dependency on golang.org/x/net (bsc#1266481)


### PR DESCRIPTION
## What does this PR change?

Since x/net is affected by a CVE and we only use it for its deprecated context module, switch to the built in `context` module. (bsc1266481) CVE-2026-39821.


## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31256
Ports:
* 5.2: https://github.com/SUSE/uyuni-tools/pull/255
* 5.1: https://github.com/SUSE/uyuni-tools/pull/256

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
