### PR TITLE
Add mgradm commands to enable or disable services at boot

### DIFF
--- a/mgradm/cmd/cmd.go
+++ b/mgradm/cmd/cmd.go
@@ -12,7 +12,9 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/backup"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/disable"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/distro"
+	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/enable"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/gpg"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/inspect"
 	"github.com/uyuni-project/uyuni-tools/mgradm/cmd/install"
@@ -84,6 +86,8 @@ func NewUyuniadmCommand() (*cobra.Command, error) {
 	rootCmd.AddCommand(completion.NewCommand(globalFlags))
 	rootCmd.AddCommand(support.NewCommand(globalFlags))
 	rootCmd.AddCommand(start.NewCommand(globalFlags))
+	rootCmd.AddCommand(enable.NewCommand(globalFlags))
+	rootCmd.AddCommand(disable.NewCommand(globalFlags))
 	rootCmd.AddCommand(scale.NewCommand(globalFlags))
 	rootCmd.AddCommand(restart.NewCommand(globalFlags))
 	rootCmd.AddCommand(stop.NewCommand(globalFlags))

--- a/mgradm/cmd/disable/disable.go
+++ b/mgradm/cmd/disable/disable.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package disable
+
+import (
+	"github.com/spf13/cobra"
+	admPodman "github.com/uyuni-project/uyuni-tools/mgradm/shared/podman"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+var systemd podman.Systemd = podman.NewSystemd()
+
+func podmanDisable(
+	_ *types.GlobalFlags,
+	_ *disableFlags,
+	_ *cobra.Command,
+	_ []string,
+) error {
+	return admPodman.DisableServices(systemd)
+}
+
+type disableFlags struct {
+}
+
+func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[disableFlags]) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "disable",
+		GroupID: "management",
+		Short:   L("Disable server services at boot"),
+		Long:    L("Disable server services at boot without stopping them"),
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags disableFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
+		},
+	}
+	cmd.SetUsageTemplate(cmd.UsageTemplate())
+	return cmd
+}
+
+// NewCommand disables automatic startup of the server services.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	return newCmd(globalFlags, podmanDisable)
+}

--- a/mgradm/cmd/disable/disable_test.go
+++ b/mgradm/cmd/disable/disable_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package disable
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+func TestParamsParsing(t *testing.T) {
+	tester := func(_ *types.GlobalFlags, _ *disableFlags, _ *cobra.Command, _ []string) error {
+		return nil
+	}
+	cmd := newCmd(&types.GlobalFlags{}, tester)
+	testutils.AssertHasAllFlags(t, cmd, []string{})
+	cmd.SetArgs([]string{})
+	testutils.AssertNoError(t, "command failed: ", cmd.Execute())
+}
+
+func TestRejectsArguments(t *testing.T) {
+	cmd := newCmd(&types.GlobalFlags{}, func(_ *types.GlobalFlags, _ *disableFlags, _ *cobra.Command, _ []string) error {
+		return nil
+	})
+	cmd.SetArgs([]string{"unexpected"})
+	testutils.AssertError(t, "accepts 0 arg(s)", cmd.Execute())
+}

--- a/mgradm/cmd/enable/enable.go
+++ b/mgradm/cmd/enable/enable.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package enable
+
+import (
+	"github.com/spf13/cobra"
+	admPodman "github.com/uyuni-project/uyuni-tools/mgradm/shared/podman"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+var systemd podman.Systemd = podman.NewSystemd()
+
+func podmanEnable(
+	_ *types.GlobalFlags,
+	_ *enableFlags,
+	_ *cobra.Command,
+	_ []string,
+) error {
+	return admPodman.EnableServices(systemd)
+}
+
+type enableFlags struct {
+}
+
+func newCmd(globalFlags *types.GlobalFlags, run utils.CommandFunc[enableFlags]) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "enable",
+		GroupID: "management",
+		Short:   L("Enable server services at boot"),
+		Long:    L("Enable server services at boot without starting them"),
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags enableFlags
+			return utils.CommandHelper(globalFlags, cmd, args, &flags, nil, run)
+		},
+	}
+	cmd.SetUsageTemplate(cmd.UsageTemplate())
+	return cmd
+}
+
+// NewCommand enables automatic startup of the server services.
+func NewCommand(globalFlags *types.GlobalFlags) *cobra.Command {
+	return newCmd(globalFlags, podmanEnable)
+}

--- a/mgradm/cmd/enable/enable_test.go
+++ b/mgradm/cmd/enable/enable_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package enable
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+	"github.com/uyuni-project/uyuni-tools/shared/types"
+)
+
+func TestParamsParsing(t *testing.T) {
+	tester := func(_ *types.GlobalFlags, _ *enableFlags, _ *cobra.Command, _ []string) error {
+		return nil
+	}
+	cmd := newCmd(&types.GlobalFlags{}, tester)
+	testutils.AssertHasAllFlags(t, cmd, []string{})
+	cmd.SetArgs([]string{})
+	testutils.AssertNoError(t, "command failed: ", cmd.Execute())
+}
+
+func TestRejectsArguments(t *testing.T) {
+	cmd := newCmd(&types.GlobalFlags{}, func(_ *types.GlobalFlags, _ *enableFlags, _ *cobra.Command, _ []string) error {
+		return nil
+	})
+	cmd.SetArgs([]string{"unexpected"})
+	testutils.AssertError(t, "accepts 0 arg(s)", cmd.Execute())
+}

--- a/mgradm/cmd/status/podman.go
+++ b/mgradm/cmd/status/podman.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	admPodman "github.com/uyuni-project/uyuni-tools/mgradm/shared/podman"
 	adm_utils "github.com/uyuni-project/uyuni-tools/mgradm/shared/utils"
 	"github.com/uyuni-project/uyuni-tools/shared"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
 	"github.com/uyuni-project/uyuni-tools/shared/utils"
@@ -18,12 +21,22 @@ import (
 
 var systemd podman.Systemd = podman.NewSystemd()
 
+func logServerServicesState(systemd podman.Systemd) {
+	if admPodman.ServerServicesEnabled(systemd) {
+		log.Info().Msg(L("Server services are enabled"))
+	} else {
+		log.Info().Msg(L("Server services are disabled"))
+	}
+}
+
 func podmanStatus(
 	_ *types.GlobalFlags,
 	_ *statusFlags,
 	_ *cobra.Command,
 	_ []string,
 ) error {
+	logServerServicesState(systemd)
+
 	if systemd.HasService(podman.DBService) {
 		_ = utils.RunCmdStdMapping(zerolog.DebugLevel, "systemctl", "status", "--no-pager", podman.DBService)
 	}

--- a/mgradm/cmd/status/podman_test.go
+++ b/mgradm/cmd/status/podman_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+func TestLogServerServicesState(t *testing.T) {
+	cases := []struct {
+		name     string
+		enabled  []string
+		expected string
+	}{
+		{name: "enabled", enabled: []string{podman.ServerService}, expected: "Server services are enabled"},
+		{name: "disabled", enabled: []string{}, expected: "Server services are disabled"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			driver := &testutils.FakeSystemdDriver{
+				Installed: []string{podman.ServerService},
+				Enabled:   testCase.enabled,
+			}
+			var output bytes.Buffer
+			oldLogger := log.Logger
+			log.Logger = zerolog.New(&output)
+			t.Cleanup(func() {
+				log.Logger = oldLogger
+			})
+
+			logServerServicesState(podman.NewSystemdWithDriver(driver))
+			testutils.AssertStringContains(t, "service state missing: ", output.String(), testCase.expected)
+		})
+	}
+}

--- a/mgradm/cmd/upgrade/utils.go
+++ b/mgradm/cmd/upgrade/utils.go
@@ -33,6 +33,7 @@ func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.C
 	if _, err := exec.LookPath("podman"); err != nil {
 		return errors.New(L("install podman before running this command"))
 	}
+	podman.WarnIfServicesDisabled(systemd)
 
 	return podman.Upgrade(
 		systemd, authFile,

--- a/mgradm/shared/podman/services.go
+++ b/mgradm/shared/podman/services.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
+	sharedPodman "github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
+)
+
+var replicatedServerServices = []string{
+	sharedPodman.ServerAttestationService,
+	sharedPodman.HubXmlrpcService,
+	sharedPodman.SalineService,
+}
+
+var coreServerServices = []string{
+	sharedPodman.ServerService,
+	sharedPodman.DBService,
+}
+
+func enabledOptionalServices(systemd sharedPodman.Systemd) []string {
+	services := []string{}
+	if systemd.ServiceIsEnabled(sharedPodman.TFTPService) {
+		services = append(services, sharedPodman.TFTPService)
+	}
+	for _, service := range replicatedServerServices {
+		for i := 0; i < systemd.CurrentReplicaCount(service); i++ {
+			services = append(services, fmt.Sprintf("%s@%d", service, i))
+		}
+	}
+	return services
+}
+
+// ServerServicesEnabled reports whether the server is configured to start automatically at boot.
+func ServerServicesEnabled(systemd sharedPodman.Systemd) bool {
+	return systemd.ServiceIsEnabled(sharedPodman.ServerService)
+}
+
+// EnableServices enables automatic startup of the core server services without starting them.
+// Optional services and replicas disabled by DisableServices need to be configured again explicitly.
+func EnableServices(systemd sharedPodman.Systemd) error {
+	if !systemd.HasService(sharedPodman.ServerService) {
+		return errors.New(L("no installed server detected"))
+	}
+
+	errs := []error{}
+	for _, service := range coreServerServices {
+		if systemd.HasService(service) {
+			errs = append(errs, systemd.EnableServiceAtBoot(service))
+		}
+	}
+	return utils.JoinErrors(errs...)
+}
+
+// DisableServices disables automatic startup of all currently enabled server services without stopping them.
+func DisableServices(systemd sharedPodman.Systemd) error {
+	if !systemd.HasService(sharedPodman.ServerService) {
+		return errors.New(L("no installed server detected"))
+	}
+
+	services := enabledOptionalServices(systemd)
+	for _, service := range coreServerServices {
+		if systemd.HasService(service) {
+			services = append(services, service)
+		}
+	}
+
+	errs := []error{}
+	for _, service := range services {
+		errs = append(errs, systemd.DisableServiceAtBoot(service))
+	}
+	return utils.JoinErrors(errs...)
+}
+
+// WarnIfServicesDisabled warns that the server stack will not start automatically at boot.
+func WarnIfServicesDisabled(systemd sharedPodman.Systemd) {
+	if !ServerServicesEnabled(systemd) {
+		log.Warn().Msg(L("Server services are disabled and will not start automatically at boot"))
+	}
+}

--- a/mgradm/shared/podman/services_test.go
+++ b/mgradm/shared/podman/services_test.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package podman
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	sharedPodman "github.com/uyuni-project/uyuni-tools/shared/podman"
+	"github.com/uyuni-project/uyuni-tools/shared/testutils"
+)
+
+func TestDisableServicesDisablesAllEnabledServicesWithoutStopping(t *testing.T) {
+	driver := &testutils.FakeSystemdDriver{
+		Installed: []string{
+			sharedPodman.ServerService,
+			sharedPodman.DBService,
+			sharedPodman.TFTPService,
+			sharedPodman.ServerAttestationService + "@",
+			sharedPodman.HubXmlrpcService + "@",
+			sharedPodman.SalineService + "@",
+		},
+		Enabled: []string{
+			sharedPodman.ServerService,
+			sharedPodman.DBService,
+			sharedPodman.TFTPService,
+			sharedPodman.ServerAttestationService + "@0",
+			sharedPodman.ServerAttestationService + "@1",
+			sharedPodman.HubXmlrpcService + "@0",
+			sharedPodman.SalineService + "@0",
+		},
+		Running: []string{
+			sharedPodman.ServerService,
+			sharedPodman.DBService,
+			sharedPodman.TFTPService,
+			sharedPodman.ServerAttestationService + "@0",
+			sharedPodman.ServerAttestationService + "@1",
+			sharedPodman.HubXmlrpcService + "@0",
+			sharedPodman.SalineService + "@0",
+		},
+	}
+	originalRunning := append([]string{}, driver.Running...)
+
+	err := DisableServices(sharedPodman.NewSystemdWithDriver(driver))
+	testutils.AssertNoError(t, "disable failed: ", err)
+	testutils.AssertEquals(t, "services remain enabled", []string{}, driver.Enabled)
+	testutils.AssertEquals(t, "disable changed the running services", originalRunning, driver.Running)
+}
+
+func TestEnableServicesEnablesOnlyCoreServicesWithoutStarting(t *testing.T) {
+	driver := &testutils.FakeSystemdDriver{
+		Installed: []string{
+			sharedPodman.ServerService,
+			sharedPodman.DBService,
+			sharedPodman.TFTPService,
+			sharedPodman.ServerAttestationService + "@",
+		},
+	}
+	systemd := sharedPodman.NewSystemdWithDriver(driver)
+
+	testutils.AssertNoError(t, "enable failed: ", EnableServices(systemd))
+	testutils.AssertContains(t, "server was not enabled", driver.Enabled, sharedPodman.ServerService)
+	testutils.AssertContains(t, "database was not enabled", driver.Enabled, sharedPodman.DBService)
+	testutils.AssertNotContains(t, "TFTP was unexpectedly enabled", driver.Enabled, sharedPodman.TFTPService)
+	testutils.AssertNotContains(t, "replica was unexpectedly enabled", driver.Enabled,
+		sharedPodman.ServerAttestationService+"@0")
+	testutils.AssertEquals(t, "enable started services", 0, len(driver.Running))
+	testutils.AssertNoError(t, "second enable failed: ", EnableServices(systemd))
+}
+
+func TestEnableDisableServicesRequireInstalledServer(t *testing.T) {
+	systemd := sharedPodman.NewSystemdWithDriver(&testutils.FakeSystemdDriver{})
+	testutils.AssertError(t, "no installed server detected", EnableServices(systemd))
+	testutils.AssertError(t, "no installed server detected", DisableServices(systemd))
+}
+
+func TestDisableServicesReturnsErrors(t *testing.T) {
+	disableErr := errors.New("cannot disable database")
+	driver := &testutils.FakeSystemdDriver{
+		Installed:            []string{sharedPodman.ServerService, sharedPodman.DBService},
+		Enabled:              []string{sharedPodman.ServerService, sharedPodman.DBService},
+		DisableServiceErrors: map[string]error{sharedPodman.DBService: disableErr},
+	}
+
+	err := DisableServices(sharedPodman.NewSystemdWithDriver(driver))
+	testutils.AssertError(t, disableErr.Error(), err)
+	testutils.AssertNotContains(t, "server was not disabled", driver.Enabled, sharedPodman.ServerService)
+	testutils.AssertContains(t, "database should remain enabled after its error", driver.Enabled, sharedPodman.DBService)
+}
+
+func TestWarnIfServicesDisabled(t *testing.T) {
+	driver := &testutils.FakeSystemdDriver{
+		Installed: []string{sharedPodman.ServerService},
+	}
+	var output bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&output)
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+	})
+
+	WarnIfServicesDisabled(sharedPodman.NewSystemdWithDriver(driver))
+	testutils.AssertStringContains(t, "disabled warning missing: ", output.String(),
+		"Server services are disabled and will not start automatically at boot")
+}

--- a/mgradm/shared/podman/startstop.go
+++ b/mgradm/shared/podman/startstop.go
@@ -10,6 +10,8 @@ import (
 )
 
 func StartServices() error {
+	WarnIfServicesDisabled(systemd)
+
 	var dbErr error
 	if systemd.HasService(podman.DBService) {
 		dbErr = systemd.StartService(podman.DBService)
@@ -34,6 +36,8 @@ func StartServices() error {
 }
 
 func StopServices() error {
+	WarnIfServicesDisabled(systemd)
+
 	errs := utils.JoinErrors(
 		systemd.StopInstantiated(podman.ServerAttestationService),
 		systemd.StopInstantiated(podman.HubXmlrpcService),

--- a/mgradm/shared/podman/startstop_test.go
+++ b/mgradm/shared/podman/startstop_test.go
@@ -5,10 +5,14 @@
 package podman
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/testutils"
 )
@@ -19,6 +23,27 @@ var allServices = []string{
 	podman.SalineService + "@",
 	podman.ServerAttestationService + "@",
 	podman.HubXmlrpcService + "@",
+}
+
+func TestStartStopWarnWhenServicesDisabled(t *testing.T) {
+	driver := testutils.FakeSystemdDriver{
+		Installed: []string{podman.ServerService, podman.DBService},
+	}
+	systemd = podman.NewSystemdWithDriver(&driver)
+	var output bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&output)
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+	})
+
+	testutils.AssertNoError(t, "start failed: ", StartServices())
+	testutils.AssertNoError(t, "stop failed: ", StopServices())
+	if count := strings.Count(output.String(),
+		"Server services are disabled and will not start automatically at boot"); count != 2 {
+		t.Errorf("expected start and stop warnings, got %d", count)
+	}
+	testutils.AssertEquals(t, "start or stop changed boot enablement", 0, len(driver.Enabled))
 }
 
 func TestStartServices(t *testing.T) {

--- a/shared/podman/interfaces.go
+++ b/shared/podman/interfaces.go
@@ -26,9 +26,15 @@ type Systemd interface {
 	// EnableService enables and starts a systemd service.
 	EnableService(name string) error
 
+	// EnableServiceAtBoot enables a systemd unit without starting it.
+	EnableServiceAtBoot(name string) error
+
 	// DisableService disables a service.
 	// name is the name of the service without the '.service' part.
 	DisableService(name string) error
+
+	// DisableServiceAtBoot disables a systemd unit without stopping it.
+	DisableServiceAtBoot(name string) error
 
 	// UninstallService stops and remove a systemd service.
 	// If dryRun is set to true, nothing happens but messages are logged to explain what would be done.

--- a/shared/podman/systemd.go
+++ b/shared/podman/systemd.go
@@ -81,6 +81,12 @@ type SystemdDriver interface {
 	// EnableService enables and starts a systemd service.
 	EnableService(service string) error
 
+	// EnableServiceAtBoot enables a systemd unit without starting it.
+	EnableServiceAtBoot(service string) error
+
+	// DisableServiceAtBoot disables a systemd unit without stopping it.
+	DisableServiceAtBoot(service string) error
+
 	// GetServiceProperty returns the value of a systemd service property.
 	GetServiceProperty(service string, property string) (string, error)
 
@@ -173,6 +179,30 @@ func (d *systemdDriverImpl) EnableService(service string) error {
 	}
 	if err := utils.RunCmd("systemctl", "enable", "--now", service); err != nil {
 		return utils.Errorf(err, L("failed to enable %s systemd service"), service)
+	}
+	return nil
+}
+
+// EnableServiceAtBoot enables a systemd unit without starting it.
+func (d *systemdDriverImpl) EnableServiceAtBoot(service string) error {
+	if d.ServiceIsEnabled(service) {
+		log.Debug().Msgf("%s is already enabled.", service)
+		return nil
+	}
+	if err := utils.RunCmd("systemctl", "enable", service); err != nil {
+		return utils.Errorf(err, L("failed to enable %s systemd unit"), service)
+	}
+	return nil
+}
+
+// DisableServiceAtBoot disables a systemd unit without stopping it.
+func (d *systemdDriverImpl) DisableServiceAtBoot(service string) error {
+	if !d.ServiceIsEnabled(service) {
+		log.Debug().Msgf("%s is already disabled.", service)
+		return nil
+	}
+	if err := utils.RunCmd("systemctl", "disable", service); err != nil {
+		return utils.Errorf(err, L("failed to disable %s systemd unit"), service)
 	}
 	return nil
 }
@@ -380,6 +410,16 @@ func (s SystemdImpl) StopService(service string) error {
 // EnableService enables and starts a systemd service.
 func (s SystemdImpl) EnableService(service string) error {
 	return s.driver.EnableService(service)
+}
+
+// EnableServiceAtBoot enables a systemd unit without starting it.
+func (s SystemdImpl) EnableServiceAtBoot(service string) error {
+	return s.driver.EnableServiceAtBoot(service)
+}
+
+// DisableServiceAtBoot disables a systemd unit without stopping it.
+func (s SystemdImpl) DisableServiceAtBoot(service string) error {
+	return s.driver.DisableServiceAtBoot(service)
 }
 
 // StartInstantiated starts all replicas.

--- a/shared/testutils/systemd.go
+++ b/shared/testutils/systemd.go
@@ -82,6 +82,20 @@ func (d *FakeSystemdDriver) EnableService(service string) error {
 	return err
 }
 
+// EnableServiceAtBoot enables a systemd unit without starting it.
+func (d *FakeSystemdDriver) EnableServiceAtBoot(service string) error {
+	return d.EnableService(service)
+}
+
+// DisableServiceAtBoot disables a systemd unit without stopping it.
+func (d *FakeSystemdDriver) DisableServiceAtBoot(service string) error {
+	err := d.DisableServiceErrors[service]
+	if err == nil {
+		d.Enabled = deleteItems(d.Enabled, service)
+	}
+	return err
+}
+
 // ReloadDaemon resets the failed state of services and reload the systemd daemon.
 // If dryRun is set to true, nothing happens but messages are logged to explain what would be done.
 func (d *FakeSystemdDriver) ReloadDaemon() error {
@@ -108,9 +122,6 @@ func (d *FakeSystemdDriver) RestartService(service string) error {
 
 // StartService starts the systemd service.
 func (d *FakeSystemdDriver) StartService(service string) error {
-	if !d.ServiceIsEnabled(service) {
-		return fmt.Errorf("%s service is not enabled", service)
-	}
 	err := d.StartServiceErrors[service]
 	if err == nil && !contains(d.Running, service) {
 		d.Running = append(d.Running, service)
@@ -120,9 +131,6 @@ func (d *FakeSystemdDriver) StartService(service string) error {
 
 // StopService starts the systemd service.
 func (d *FakeSystemdDriver) StopService(service string) error {
-	if !d.ServiceIsEnabled(service) {
-		return fmt.Errorf("%s service is not enabled", service)
-	}
 	err := d.StopServiceErrors[service]
 	if err == nil {
 		d.Running = deleteItems(d.Running, service)

--- a/uyuni-tools.changes.mfriedrich.mgradm-enable-disable
+++ b/uyuni-tools.changes.mfriedrich.mgradm-enable-disable
@@ -1,0 +1,1 @@
+- Add mgradm commands to enable or disable services at boot


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Adds two verbs `enable` and `disable` to the `mgradm` command.
Changes the `enabled` systemd service status and reports it in `mgradm status`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31547

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
