### PR TITLE
Fix typos in shared utility comments

### DIFF
--- a/shared/api/api.go
+++ b/shared/api/api.go
@@ -97,7 +97,7 @@ func (c *APIClient) sendRequest(req *http.Request) (*http.Response, error) {
 // Provided connectionDetails must have Server specified with FQDN to the
 // target host.
 //
-// Optionaly connectionDetails can have user name and password set and Init
+// Optionally connectionDetails can have user name and password set and Init
 // will try to login to the host.
 // caCert can be set to use custom CA certificate to validate target host.
 func Init(conn *ConnectionDetails) (*APIClient, error) {
@@ -211,7 +211,7 @@ func (c *APIClient) sessionValidity() error {
 	return err
 }
 
-// Logout from the server and remove localy stored session key.
+// Logout from the server and remove locally stored session key.
 func (c *APIClient) Logout() error {
 	if _, err := c.Post("auth/logout", nil); err != nil {
 		return utils.Errorf(err, L("failed to logout from the server"))

--- a/shared/utils/exec.go
+++ b/shared/utils/exec.go
@@ -49,7 +49,7 @@ func NewRunner(command string, args ...string) types.Runner {
 }
 
 // NewRunnerWithContext creates a new runner instance for the command,
-// interuptable based on provided context.
+// interruptible based on provided context.
 func NewRunnerWithContext(ctx context.Context, command string, args ...string) types.Runner {
 	runner := runnerImpl{logger: log.Logger}
 	runner.cmd = exec.CommandContext(ctx, command, args...)

--- a/shared/utils/flaggroups.go
+++ b/shared/utils/flaggroups.go
@@ -70,7 +70,7 @@ func usageFunc(cmd *cobra.Command) error {
 	return origUsageFunc(cmd)
 }
 
-// ContainsGroup checks if the command alrady has a group with the same ID.
+// ContainsGroup checks if the command already has a group with the same ID.
 func ContainsGroup(cmd *cobra.Command, groupID string) bool {
 	for _, grp := range commandGroups[cmd] {
 		if grp.ID == groupID {


### PR DESCRIPTION
Fix four spelling mistakes in shared utility comments and API doc comments.

This is a comment only cleanup with no functional change.

Tested with `go test ./shared/api ./shared/utils`.

- [x] No changelog needed