### PR TITLE
Fix typos in shared SSL comments

### DIFF
--- a/shared/podman/utils.go
+++ b/shared/podman/utils.go
@@ -225,7 +225,7 @@ func DeleteVolume(name string, dryRun bool) error {
 	return nil
 }
 
-// ExportVolume exports a podman volume based on its name to the specified targed directory.
+// ExportVolume exports a podman volume based on its name to the specified target directory.
 // outputDir option expects already existing directory.
 // If dryRun is set to true, only messages will be logged to explain what would happen.
 func ExportVolume(name string, outputDir string, dryRun bool) error {

--- a/shared/ssl/ssl.go
+++ b/shared/ssl/ssl.go
@@ -35,7 +35,7 @@ const (
 	ServerCertKeyPath = "/etc/pki/tls/private/spacewalk.key"
 	// DBCertPath is the path to the database certificate in the database container.
 	DBCertPath = "/etc/pki/tls/certs/spacewalk.crt"
-	// DBCertKeyPaht is the path to the database certificate in the database container.
+	// DBCertKeyPath is the path to the database certificate in the database container.
 	DBCertKeyPath = "/etc/pki/tls/private/pg-spacewalk.key"
 )
 

--- a/shared/types/ssl.go
+++ b/shared/types/ssl.go
@@ -4,7 +4,7 @@
 
 package types
 
-// SSLCertGenerationFlags stores informations to generate an SSL Certificate.
+// SSLCertGenerationFlags stores information to generate an SSL Certificate.
 type SSLCertGenerationFlags struct {
 	Cnames   []string `mapstructure:"cname"`
 	Country  string


### PR DESCRIPTION
Fix three spelling mistakes in shared SSL and podman comments.

This is a comment only cleanup with no functional change.

Tested with `go test ./shared/podman ./shared/ssl ./shared/types`.

- [x] No changelog needed