### PR TITLE
Fix typo in proxy flags test comment

### DIFF
--- a/mgrpxy/shared/utils/flags_test.go
+++ b/mgrpxy/shared/utils/flags_test.go
@@ -19,7 +19,7 @@ func TestGetContainerImage(t *testing.T) {
 		expectedResult string
 		description    string
 	}{
-		// Defaults and overiding values
+		// Defaults and overriding values
 		{
 			name: "no image details",
 			proxyFlags: ProxyImageFlags{


### PR DESCRIPTION
Fix a spelling mistake in a proxy flags test comment.

This is a comment only cleanup with no functional change.

Tested with `go test ./mgrpxy/shared/...`.

- [x] No changelog needed