### PR TITLE
Detect and fix legacy service file (bsc#1268755)

### DIFF
--- a/mgradm/cmd/upgrade/utils.go
+++ b/mgradm/cmd/upgrade/utils.go
@@ -6,18 +6,58 @@ package upgrade
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"github.com/uyuni-project/uyuni-tools/mgradm/shared/podman"
 	. "github.com/uyuni-project/uyuni-tools/shared/l10n"
 	shared_podman "github.com/uyuni-project/uyuni-tools/shared/podman"
 	"github.com/uyuni-project/uyuni-tools/shared/types"
+	"github.com/uyuni-project/uyuni-tools/shared/utils"
 )
 
 var systemd shared_podman.Systemd = shared_podman.NewSystemd()
 
+func checkAndCleanIPv6PortBindings() error {
+	// Workaround for IPv6 options that do not work with nftables - bsc#1268755
+	servicePath := shared_podman.GetServicePath(shared_podman.ServerService)
+	if !utils.FileExists(servicePath) {
+		return nil
+	}
+
+	content, err := os.ReadFile(servicePath)
+	if err != nil {
+		return utils.Errorf(err, L("failed to read %s"), servicePath)
+	}
+
+	// For example "-p [::]:443:443 \"
+	re := regexp.MustCompile(`(?m)^[ \t]*-p[ \t]+["']?\[::\]:\d+:\d+(?:/\w+)?["']?[ \t]*\\?[ \t]*(?:\r?\n|$)`)
+
+	if !re.Match(content) {
+		return nil
+	}
+
+	cleaned := re.ReplaceAllString(string(content), "")
+
+	if err := os.Chmod(servicePath, 0640); err != nil {
+		return utils.Errorf(err, L("failed to change permissions for %s"), servicePath)
+	}
+
+	if err := os.WriteFile(servicePath, []byte(cleaned), 0640); err != nil {
+		return utils.Errorf(err, L("failed to write %s"), servicePath)
+	}
+
+	return errors.New(L("Legacy dual-stack IPv6 port bindings have been removed from uyuni-server.service. " +
+		"Please reboot the host and then run the upgrade command again"))
+}
+
 func upgradePodman(_ *types.GlobalFlags, flags *podmanUpgradeFlags, cmd *cobra.Command, _ []string) error {
+	if err := checkAndCleanIPv6PortBindings(); err != nil {
+		return err
+	}
+
 	hostData, err := shared_podman.InspectHost()
 	if err != nil {
 		return err

--- a/uyuni-tools.changes.nadvornik.cleanup_ipv6
+++ b/uyuni-tools.changes.nadvornik.cleanup_ipv6
@@ -1,0 +1,1 @@
+- Detect and fix legacy service file (bsc#1268755)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

uyuni-server.service created on 5.0 use podman options for ipv6 ports. This is incompatible with new podman and nftables. It causes error messages and inaccessible services after upgrade.

This PR detects and fixes the old service file and asks user to reboot.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue(s): #

https://github.com/SUSE/spacewalk/issues/31037
https://bugzilla.suse.com/show_bug.cgi?id=1268755
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
