### PR TITLE
Ignored tito packages files in copyright year update

### DIFF
--- a/update-copyright-year.sh
+++ b/update-copyright-year.sh
@@ -9,6 +9,9 @@ changed="n"
 current_year=$(date +%Y)
 for changed_file in $@; do
     case "$changed_file" in
+        .tito/packages/*)
+            continue
+            ;;
         go.mod|go.sum)
             continue
             ;;


### PR DESCRIPTION
## What does this PR change?

The tito packages files have a special format and cannot have a copyright comment, ignoring them.

## Test coverage
- No tests: commit check

- [x] **DONE**

## Links

Issue(s): #
Ports:
- 5.1: https://github.com/SUSE/uyuni-tools/pull/275
- 5.2: https://github.com/SUSE/uyuni-tools/pull/274

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
