### PR TITLE
Fix the wording of the password length error message

### DIFF
--- a/shared/utils/utils.go
+++ b/shared/utils/utils.go
@@ -55,12 +55,9 @@ func checkValueSize(value string, minValue int, maxValue int) bool {
 		return true
 	}
 
-	if len(value) < minValue {
-		fmt.Printf(NL("Has to be more than %d character long", "Has to be more than %d characters long", minValue), minValue)
-		return false
-	}
-	if len(value) > maxValue {
-		fmt.Printf(NL("Has to be less than %d character long", "Has to be less than %d characters long", maxValue), maxValue)
+	length := len(value)
+	if length < minValue || length > maxValue {
+		fmt.Printf(L("Has to be between %[1]d and %[2]d characters long"), minValue, maxValue)
 		return false
 	}
 	return true

--- a/shared/utils/utils_test.go
+++ b/shared/utils/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SUSE LLC
+// SPDX-FileCopyrightText: 2026 SUSE LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -69,8 +69,8 @@ func TestAskIfMissing(t *testing.T) {
 
 	data := []askTestData{
 		{value: "\n", expectedMessage: "A value is required", min: 1, max: 5},
-		{value: "superlong\n", expectedMessage: "Has to be less than 5 characters long", min: 1, max: 5},
-		{value: "a\n", expectedMessage: "Has to be more than 2 characters long", min: 2, max: 5},
+		{value: "superlong\n", expectedMessage: "Has to be between 1 and 5 characters long", min: 1, max: 5},
+		{value: "a\n", expectedMessage: "Has to be between 2 and 5 characters long", min: 2, max: 5},
 		{value: "booh\n", expectedMessage: "Has to contain an 'f'", min: 0, max: 0, checker: fChecker},
 	}
 
@@ -95,8 +95,8 @@ func TestCheckValidPassword(t *testing.T) {
 
 	data := []askTestData{
 		{value: "\n", expectedMessage: "A value is required", min: 1, max: 5},
-		{value: "superlong\n", expectedMessage: "Has to be less than 5 characters long", min: 1, max: 5},
-		{value: "a\n", expectedMessage: "Has to be more than 2 characters long", min: 2, max: 5},
+		{value: "superlong\n", expectedMessage: "Has to be between 1 and 5 characters long", min: 1, max: 5},
+		{value: "a\n", expectedMessage: "Has to be between 2 and 5 characters long", min: 2, max: 5},
 	}
 
 	for i, testCase := range data {

--- a/uyuni-tools.changes.mfriedrich.fix_password_wording
+++ b/uyuni-tools.changes.mfriedrich.fix_password_wording
@@ -1,0 +1,1 @@
+- Fix the wording of the password length error message


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

Fixes incorrect wording which previously declined 5-letter passwords, even though they are allowed. Also gives a clearer indication of what the limits of the password are.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
