### PR TITLE
Fix --tuning-httpd being shadowed by spacewalk-proxy.conf

### DIFF
--- a/mgrpxy/shared/podman/podman.go
+++ b/mgrpxy/shared/podman/podman.go
@@ -106,7 +106,7 @@ func GenerateSystemdService(
 
 		if additionHTTPConfPath != "" {
 			additionHttpdTuningSettings = fmt.Sprintf(
-				`Environment=HTTPD_EXTRA_CONF=-v%s:/etc/apache2/conf.d/apache_tuning.conf:ro`,
+				`Environment=HTTPD_EXTRA_CONF=-v%s:/etc/apache2/conf.d/zz_apache_tuning.conf:ro`,
 				additionHTTPConfPath,
 			)
 		}

--- a/mgrpxy/shared/podman/podman_test.go
+++ b/mgrpxy/shared/podman/podman_test.go
@@ -101,7 +101,7 @@ func TestGenerateSystemdService(t *testing.T) {
 		case "httpd":
 			testutils.AssertEquals(t, "Wrong httpd image", "fake/httpd:latest", image)
 			testutils.AssertStringContains(t, "Missing httpd tuning configuration", config,
-				"Environment=HTTPD_EXTRA_CONF=-v/my/apache.conf:/etc/apache2/conf.d/apache_tuning.conf:ro",
+				"Environment=HTTPD_EXTRA_CONF=-v/my/apache.conf:/etc/apache2/conf.d/zz_apache_tuning.conf:ro",
 			)
 			httpTemplate, ok := template.(templates.HttpdTemplateData)
 			testutils.AssertTrue(t, "httpd template of unexpected type", ok)

--- a/uyuni-tools.changes.mbussolotto.fix-httpd-tuning-override
+++ b/uyuni-tools.changes.mbussolotto.fix-httpd-tuning-override
@@ -1,0 +1,3 @@
+- Mount --tuning-httpd file as zz_apache_tuning conf so it
+  overrides the vendor spacewalk-proxy conf MPM settings
+  (bsc#1277719)


### PR DESCRIPTION
## What does this PR change?

The proxy httpd container ships /etc/apache2/conf.d/spacewalk-proxy.conf which hard-sets MaxRequestWorkers 150 and MaxRequestsPerChild 200 inside an <IfModule prefork.c> block.

Files under /etc/apache2/conf.d/ are included alphabetically and Apache applies "last wins" semantics for scalar server-scope directives. The tuning file was mounted as apache_tuning.conf, which sorts before spacewalk-proxy.conf, so any MPM directive set via --tuning-httpd was silently overwritten by the vendor defaults. This made large-scale proxy tuning impossible without a manual bind-mount workaround.

Mount the user file as zz_apache_tuning.conf so it is parsed after spacewalk-proxy.conf and its directives become the effective configuration.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni-tools)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31911
5.1 : https://github.com/SUSE/uyuni-tools/pull/279
5.2: https://github.com/SUSE/uyuni-tools/pull/280

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
